### PR TITLE
Fixes segmentation fault when sending null as name or password.

### DIFF
--- a/stub/CouchbaseCluster.class.php
+++ b/stub/CouchbaseCluster.class.php
@@ -58,7 +58,7 @@ class CouchbaseCluster {
         $bucketDsn = cbdsn_normalize($this->_dsn);
         $bucketDsn['bucket'] = $name;
         $dsnStr = cbdsn_stringify($bucketDsn);
-        return new CouchbaseBucket($dsnStr, $name, $password);
+        return new CouchbaseBucket($dsnStr, (string) $name, (string) $password);
     }
 
     /**


### PR DESCRIPTION
If i enter the bucket password as null then i get a segmentation fault:
This fix forces the password to be a string.

``` php
<?php

$cluster = new CouchbaseCluster('localhost');

$bucketPassword = null;
$bucket = $cluster->openBucket('bucket_name', $bucketPassword);

$bucket->get('key');
```

```
Segmentation fault (core dumped)
```
