### PR TITLE
Fixed getAndTouch and getAndLock in stub code

### DIFF
--- a/phpstubstr.h
+++ b/phpstubstr.h
@@ -1195,7 +1195,7 @@ char *PCBC_PHP_CODESTR = \
 "     */\n" \
 "    public function getAndTouch($id, $expiry, $options = array()) {\n" \
 "        $options['expiry'] = $expiry;\n" \
-"        return $this->me->getAndTouch($id, $expiry, $options);\n" \
+"        return $this->me->get($id, $options);\n" \
 "    }\n" \
 "\n" \
 "    /**\n" \
@@ -1205,7 +1205,8 @@ char *PCBC_PHP_CODESTR = \
 "     * @param array $options\n" \
 "     * @return mixed\n" \
 "     */\n" \
-"    public function getAndLock($id, $options = array()) {\n" \
+"    public function getAndLock($id, $lockTime, $options = array()) {\n" \
+"		  $options['lockTime'] = $lockTime;\n"\
 "        return $this->me->get($id, $options);\n" \
 "    }\n" \
 "\n" \

--- a/stub/CouchbaseBucket.class.php
+++ b/stub/CouchbaseBucket.class.php
@@ -206,17 +206,19 @@ class CouchbaseBucket {
      */
     public function getAndTouch($id, $expiry, $options = array()) {
         $options['expiry'] = $expiry;
-        return $this->me->getAndTouch($id, $expiry, $options);
+        return $this->me->get($id, $options);
     }
 
     /**
      * Retrieves a document and locks it.
      *
      * @param string $id
+     * @param integer $lockTime
      * @param array $options
      * @return mixed
      */
-    public function getAndLock($id, $options = array()) {
+    public function getAndLock($id, $lockTime, $options = array()) {
+        $options['lockTime'] = $lockTime;
         return $this->me->get($id, $options);
     }
 


### PR DESCRIPTION
The stub code was calling and undefined function "getAndTouch" from the base _CouchbaseBucket class.  This should call the get method with the 'expiry' option defined.  Also adjusted "getAndLock" to take in a parameter for the 'lockTime' and set the 'lockTime' option to the value passed in.
