### PR TITLE
PHP Running as Module Sporadic Errors Fix

### DIFF
--- a/cluster.c
+++ b/cluster.c
@@ -17,6 +17,11 @@ void cluster_free_storage(void *object TSRMLS_DC)
     zend_hash_destroy(obj->std.properties);
     FREE_HASHTABLE(obj->std.properties);
 
+    if(obj->lcb)
+    {
+        lcb_destroy(obj->lcb);    
+    }
+
     efree(obj);
 }
 


### PR DESCRIPTION
When running php-couchbase in Apache or as PHP-FPM (NGINX) sporadic memory issues would occur.  This was happening because the libcouchbase lcb_t struct was not being cleaned up properly.  In the free storage call a call to lcb_destory was added to correct the issue.
