### PR TITLE
Fix N1ql Classname Typo in fromString Call

### DIFF
--- a/stub/CouchbaseN1qlQuery.class.php
+++ b/stub/CouchbaseN1qlQuery.class.php
@@ -18,10 +18,10 @@ class CouchbaseN1qlQuery {
     /**
      * Creates a new N1qlQuery instance directly from a N1QL DML.
      * @param $str
-     * @return CouchbaseNq1lQuery
+     * @return CouchbaseN1qlQuery
      */
     static public function fromString($str) {
-        $res = new CouchbaseNq1lQuery();
+        $res = new CouchbaseN1qlQuery();
         $res->querystr = $str;
         return $res;
     }


### PR DESCRIPTION
Noticed that when trying to use the `fromString()` method, as documented on the [Couchbase Site](http://docs.couchbase.com/developer/php-2.0/n1ql-queries.html), that it tries to insantiate the wrong type of class. This should fix that.

Side note: N1ql is pretty annoying to type.
