### PR TITLE
add --with-system-fastlz configure option

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,5 +1,9 @@
 PHP_ARG_ENABLE(couchbase, whether to enable Couchbase support,
-[ --with-couchbase   Include Couchbase support])
+[  --with-couchbase        Include Couchbase support])
+
+PHP_ARG_WITH(system-fastlz, wheter to use system FastLZ bibrary,
+[  --with-system-fastlz    Use system FastLZ bibrary], no, no)
+
 if test "$PHP_COUCHBASE" = "yes"; then
   AC_DEFINE(HAVE_COUCHBASE, 1, [Whether you have Couchbase])
 
@@ -9,6 +13,16 @@ if test "$PHP_COUCHBASE" = "yes"; then
 
   PHP_ADD_LIBRARY(couchbase, 1, COUCHBASE_SHARED_LIBADD)
   
+  if test "$PHP_SYSTEM_FASTLZ" != "no"; then
+    FASTLZ=""
+    AC_CHECK_HEADERS([fastlz.h])
+    PHP_CHECK_LIBRARY(fastlz, fastlz_compress,
+      [PHP_ADD_LIBRARY(fastlz, 1, COUCHBASE_SHARED_LIBADD)],
+      [AC_MSG_ERROR(FastLZ library not found)])
+  else
+    FASTLZ="fastlz/fastlz.c"
+  fi
+
   ifdef([PHP_ADD_EXTENDION_DEP], [
 	PHP_ADD_EXTENSION_DEP(couchbase, json)
   ]) 
@@ -22,6 +36,11 @@ if test "$PHP_COUCHBASE" = "yes"; then
 	exception.c \
 	metadoc.c \
 	transcoding.c \
-	fastlz/fastlz.c \
+	$FASTLZ \
   , $ext_shared)
+
+  if test -n "$FASTLZ" ; then
+    PHP_ADD_BUILD_DIR($ext_builddir/fastlz, 1)
+    PHP_ADD_INCLUDE([$ext_srcdir/fastlz])
+  fi
 fi

--- a/couchbase.c
+++ b/couchbase.c
@@ -2,7 +2,7 @@
 #include "cas.h"
 #include "metadoc.h"
 #include "phpstubstr.h"
-#include "fastlz/fastlz.h"
+#include <fastlz.h>
 
 #if HAVE_ZLIB
 #include <zlib.h>


### PR DESCRIPTION
Most distribution forbid the use of bundled libraries.

This patch allow to build with system fastlz library when available.

FYI fastlz is available in Fedora and EPEL (RHEL / CentOS) and already used by pecl/yac and pecl/memcached.

Build with default options is unchanged.