### PR TITLE
typo in _niql function

### DIFF
--- a/phpstubstr.h
+++ b/phpstubstr.h
@@ -1373,7 +1373,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "        $data = $queryObj->options;\n" \
 "        if (is_array($params)) {\n" \
 "            foreach ($params as $key => $value) {\n" \
-"                $data['$' + $key] = $value;\n" \
+"                $data['$' . $key] = $value;\n" \
 "            }\n" \
 "        }\n" \
 "        $dataStr = json_encode($data, true);\n" \

--- a/stub/CouchbaseBucket.class.php
+++ b/stub/CouchbaseBucket.class.php
@@ -300,7 +300,7 @@ class CouchbaseBucket {
         $data = $queryObj->options;
         if (is_array($params)) {
             foreach ($params as $key => $value) {
-                $data['$' + $key] = $value;
+                $data['$' . $key] = $value;
             }
         }
         $dataStr = json_encode($data, true);


### PR DESCRIPTION
just a '+' used for string concat instead of '.'  that broke parameter niql queries.