### PR TITLE
Added getName() to return name of the bucket

### DIFF
--- a/stub/CouchbaseBucket.class.php
+++ b/stub/CouchbaseBucket.class.php
@@ -468,6 +468,15 @@ class CouchbaseBucket {
     }
 
     /**
+     * returns bucket name
+     * @return string name of the bucket
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
      * Magic function to handle the retrieval of various properties.
      *
      * @internal


### PR DESCRIPTION
As N1ql query requires a bucket name, it would be nice to have getName() to return the bucket name from bucket object. Otherwise, you need to either hard code or get the value from a config.

