### PR TITLE
Increase refcount of arg in ViewOptions::keys()

### DIFF
--- a/src/couchbase/bucket/view.c
+++ b/src/couchbase/bucket/view.c
@@ -475,6 +475,7 @@ PHP_METHOD(ViewOptions, keys)
         Z_DELREF_P(data);
     }
     add_assoc_zval_ex(data, ZEND_STRL("keys"), arg);
+    Z_ADDREF_P(arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 


### PR DESCRIPTION
I was getting segfaults in my Symfony application when using `ViewOptions->keys()` and `Bucket->viewQuery()`, but at first only when from inside a controller action.

When I tried narrowing it down and tried only the view query in a single procedural script, it did not segfault. But when running this script with `USE_ZEND_ALLOC=0` did give a weird result.

The php script looks like this:

```php
$cOpt = new \Couchbase\ClusterOptions();
$cOpt->credentials('admin', '****');
$cluster = new \Couchbase\Cluster('couchbase://couchbase', $cOpt);
$bucket = $cluster->bucket('data');

$opt = new \Couchbase\ViewOptions();
$opt->keys([1, 2, 3]);

$result = $bucket->viewQuery('item_collection_dag_node', 'item_collection_id', $opt);
```

When run with `USE_ZEND_ALLOC=0`, this results in:

```
$ USE_ZEND_ALLOC=0 php tests/e.php 
[cb,WARN] (cccp L:383 I:1564131154) <couchbase:11210> (CTX=0x562c6e835d30,bc_cccp) CCCP Packet responded with 0x8; nkey=0, nbytes=42, cmd=0xb5, seq=0xf00d
[cb,EROR] (cccp L:171 I:1564131154) <couchbase:11210> (CTX=0x562c6e835d30,bc_cccp) Could not get configuration: LCB_ERR_PROTOCOL_ERROR (1050)
[cb,WARN] (cccp L:176 I:1564131154) <NOHOST:NOPORT> (CTX=(nil),) Failed to bootstrap using CCCP
Aborted (core dumped)
```

When run with `valgrind` it reports:

```
$ USE_ZEND_ALLOC=0 valgrind php test/e.php
.... [SNIP!]
==12019== Invalid read of size 4
==12019==    at 0x60FE6C: zend_array_destroy (in /usr/local/bin/php)
==12019==    by 0x63086C: zend_object_std_dtor (in /usr/local/bin/php)
==12019==    by 0x635834: zend_objects_store_del (in /usr/local/bin/php)
…. [SNIP!]
```

Commenting out the `$opt->keys([1, 2, 3]);` line removed the errors.

This PR fixes this and according to `valgrind` does not seem to leak memory.