### PR TITLE
fix allowed PHP versions

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -145,7 +145,6 @@
         <required>
             <php>
                 <min>7.2.0</min>
-                <max>7.4.99</max>
             </php>
             <pearinstaller>
                 <min>1.10.1</min>

--- a/package.xml
+++ b/package.xml
@@ -144,7 +144,8 @@
     <dependencies>
         <required>
             <php>
-                <min>7.1.0</min>
+                <min>7.2.0</min>
+                <max>7.4.99</max>
             </php>
             <pearinstaller>
                 <min>1.10.1</min>


### PR DESCRIPTION
PHP 7.1 is no more supported, lot of changes in type hinting, especially in

* ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX
* ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX

Seems a huge change to fix for a dead version.

PHP 8.0 is not yet supported