### PR TITLE
For PHP 8 support

### DIFF
--- a/couchbase.c
+++ b/couchbase.c
@@ -362,7 +362,7 @@ PHP_MINIT_FUNCTION(couchbase)
     {                                                                                                                  \
         ap_php_snprintf(buf, sizeof(buf), "COUCHBASE_%s", #name + 4);                                                  \
         zend_register_long_constant(buf, PCBC_CONST_LENGTH(buf), value, CONST_CS | CONST_PERSISTENT,                   \
-                                    module_number TSRMLS_CC);                                                          \
+                                    module_number);                                                          \
     }
 
         LCB_XERROR(X)
@@ -439,7 +439,7 @@ PHP_RINIT_FUNCTION(couchbase)
 }
 
 static void basic_encoder_v1(zval *value, int sertype, int cmprtype, long cmprthresh, double cmprfactor,
-                             zval *return_value TSRMLS_DC)
+                             zval *return_value)
 {
     zval res;
     zval flg;
@@ -515,7 +515,7 @@ static void basic_encoder_v1(zval *value, int sertype, int cmprtype, long cmprth
                 smart_str buf = {0};
 
                 PHP_VAR_SERIALIZE_INIT(var_hash);
-                php_var_serialize(&buf, value, &var_hash TSRMLS_CC);
+                php_var_serialize(&buf, value, &var_hash);
                 PHP_VAR_SERIALIZE_DESTROY(var_hash);
 
                 if (EG(exception)) {
@@ -625,7 +625,7 @@ static void basic_encoder_v1(zval *value, int sertype, int cmprtype, long cmprth
 }
 
 static void basic_decoder_v1(char *bytes, size_t bytes_len, unsigned long flags, unsigned long datatype,
-                             zend_bool jsonassoc, zval *return_value TSRMLS_DC)
+                             zend_bool jsonassoc, zval *return_value)
 {
     zval res;
     int rv;
@@ -731,7 +731,7 @@ static void basic_decoder_v1(char *bytes, size_t bytes_len, unsigned long flags,
             php_unserialize_data_t var_hash;
             const unsigned char *p = (const unsigned char *)bytes;
             PHP_VAR_UNSERIALIZE_INIT(var_hash);
-            rv = php_var_unserialize(&res, &p, p + bytes_len, &var_hash TSRMLS_CC);
+            rv = php_var_unserialize(&res, &p, p + bytes_len, &var_hash);
             if (!rv) {
                 if (!EG(exception)) {
                     pcbc_log(LOGARGS(WARN), "Failed to unserialize value at offset %ld of %d bytes",
@@ -784,7 +784,7 @@ PHP_FUNCTION(basicEncoderV1)
     long cmprthresh = DEFAULT_COUCHBASE_CMPRTHRESH;
     double cmprfactor = DEFAULT_COUCHBASE_CMPRFACTOR;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z|a", &value, &options);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "z|a", &value, &options);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -818,7 +818,7 @@ PHP_FUNCTION(basicEncoderV1)
         }
     }
 
-    basic_encoder_v1(value, sertype, cmprtype, cmprthresh, cmprfactor, return_value TSRMLS_CC);
+    basic_encoder_v1(value, sertype, cmprtype, cmprthresh, cmprfactor, return_value);
 }
 
 /* {{{ proto \Couchbase\couchbase_basic_decoder_v1(string $bytes, int $flags, int $datatype, array $options =
@@ -834,7 +834,7 @@ PHP_FUNCTION(basicDecoderV1)
     zend_bool json_array = 0;
     int rv;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sll|a", &bytes, &bytes_len, &flags, &datatype, &options);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "sll|a", &bytes, &bytes_len, &flags, &datatype, &options);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -847,13 +847,13 @@ PHP_FUNCTION(basicDecoderV1)
         json_array = tmp && Z_TYPE_P(tmp) == IS_TRUE;
     }
 
-    basic_decoder_v1(bytes, (int)bytes_len, flags, datatype, json_array, return_value TSRMLS_CC);
+    basic_decoder_v1(bytes, (int)bytes_len, flags, datatype, json_array, return_value);
 }
 
 PHP_FUNCTION(passthruEncoder)
 {
     zval *value;
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &value) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &value) == FAILURE) {
         RETURN_NULL();
     }
 
@@ -867,7 +867,7 @@ PHP_FUNCTION(passthruEncoder)
 PHP_FUNCTION(passthruDecoder)
 {
     zval *value, *flags, *datatype;
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zzz", &value, &flags, &datatype) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "zzz", &value, &flags, &datatype) == FAILURE) {
         RETURN_NULL();
     }
 
@@ -885,13 +885,13 @@ PHP_FUNCTION(defaultEncoder)
     zval *value = NULL;
     int rv;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z|a", &value);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "z|a", &value);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
     basic_encoder_v1(value, PCBCG(enc_format_i), PCBCG(enc_cmpr_i), PCBCG(enc_cmpr_threshold), PCBCG(enc_cmpr_factor),
-                     return_value TSRMLS_CC);
+                     return_value);
 }
 
 /**
@@ -907,12 +907,12 @@ PHP_FUNCTION(defaultDecoder)
     unsigned long flags = 0, datatype = 0;
     int rv;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sll|a", &bytes, &bytes_len, &flags, &datatype);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "sll|a", &bytes, &bytes_len, &flags, &datatype);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    basic_decoder_v1(bytes, (int)bytes_len, flags, datatype, PCBCG(dec_json_array), return_value TSRMLS_CC);
+    basic_decoder_v1(bytes, (int)bytes_len, flags, datatype, PCBCG(dec_json_array), return_value);
 }
 
 PHP_FUNCTION(zlibCompress)
@@ -922,7 +922,7 @@ PHP_FUNCTION(zlibCompress)
     void *dataIn, *dataOut;
     unsigned long dataSize, dataOutSize;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &zdata) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &zdata) == FAILURE) {
         RETURN_NULL();
     }
 
@@ -937,7 +937,7 @@ PHP_FUNCTION(zlibCompress)
     efree(dataOut);
 #else
     zend_throw_exception(NULL, "The zlib library was not available when the couchbase extension was built.",
-                         0 TSRMLS_CC);
+                         0);
 #endif
 }
 
@@ -948,7 +948,7 @@ PHP_FUNCTION(zlibDecompress)
     void *dataIn, *dataOut;
     unsigned long dataSize, dataOutSize;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &zdata) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &zdata) == FAILURE) {
         RETURN_NULL();
     }
 
@@ -962,7 +962,7 @@ PHP_FUNCTION(zlibDecompress)
     efree(dataOut);
 #else
     zend_throw_exception(NULL, "The zlib library was not available when the couchbase extension was built.",
-                         0 TSRMLS_CC);
+                         0);
 #endif
 }
 
@@ -972,7 +972,7 @@ PHP_FUNCTION(fastlzCompress)
     void *dataIn, *dataOut;
     unsigned long dataSize, dataOutSize;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &zdata) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &zdata) == FAILURE) {
         RETURN_NULL();
     }
 
@@ -994,7 +994,7 @@ PHP_FUNCTION(fastlzDecompress)
     void *dataIn, *dataOut;
     unsigned long dataSize, dataOutSize;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &zdata) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &zdata) == FAILURE) {
         RETURN_NULL();
     }
 

--- a/couchbase.h
+++ b/couchbase.h
@@ -65,9 +65,9 @@ struct pcbc_connection {
 };
 typedef struct pcbc_connection pcbc_connection_t;
 lcb_STATUS pcbc_connection_get(pcbc_connection_t **result, lcb_INSTANCE_TYPE type, const char *connstr,
-                               const char *bucketname, const char *username, const char *password TSRMLS_DC);
-void pcbc_connection_addref(pcbc_connection_t *conn TSRMLS_DC);
-void pcbc_connection_delref(pcbc_connection_t *conn TSRMLS_DC);
+                               const char *bucketname, const char *username, const char *password);
+void pcbc_connection_addref(pcbc_connection_t *conn);
+void pcbc_connection_delref(pcbc_connection_t *conn);
 void pcbc_connection_cleanup();
 
 ZEND_BEGIN_MODULE_GLOBALS(couchbase)
@@ -137,15 +137,15 @@ extern zend_class_entry *pcbc_binary_collection_ce;
 #define PCBC_OPCODE_UNLOCK (3)
 
 void pcbc_create_lcb_exception(zval *return_value, long code, zend_string *context, zend_string *ref, int http_code,
-                               const char *http_msg, int opcode TSRMLS_DC);
+                               const char *http_msg, int opcode);
 
-void pcbc_exception_init(zval *return_value, long code, const char *message TSRMLS_DC);
+void pcbc_exception_init(zval *return_value, long code, const char *message);
 #define throw_pcbc_exception(__pcbc_message, __pcbc_code)                                                              \
     do {                                                                                                               \
         zval __pcbc_error;                                                                                             \
         ZVAL_UNDEF(&__pcbc_error);                                                                                     \
-        pcbc_exception_init(&__pcbc_error, __pcbc_code, __pcbc_message TSRMLS_CC);                                     \
-        zend_throw_exception_object(&__pcbc_error TSRMLS_CC);                                                          \
+        pcbc_exception_init(&__pcbc_error, __pcbc_code, __pcbc_message);                                     \
+        zend_throw_exception_object(&__pcbc_error);                                                          \
     } while (0)
 
 #define throw_lcb_exception_ex(code, opcode, result_ce)                                                                \
@@ -164,8 +164,8 @@ void pcbc_exception_init(zval *return_value, long code, const char *message TSRM
         }                                                                                                              \
         zval __pcbc_error;                                                                                             \
         ZVAL_UNDEF(&__pcbc_error);                                                                                     \
-        pcbc_create_lcb_exception(&__pcbc_error, code, ctx, ref, 0, NULL, opcode TSRMLS_CC);                           \
-        zend_throw_exception_object(&__pcbc_error TSRMLS_CC);                                                          \
+        pcbc_create_lcb_exception(&__pcbc_error, code, ctx, ref, 0, NULL, opcode);                           \
+        zend_throw_exception_object(&__pcbc_error);                                                          \
     } while (0)
 
 #define throw_lcb_exception(code, result_ce) throw_lcb_exception_ex((code), PCBC_OPCODE_UNSPEC, (result_ce))
@@ -175,8 +175,8 @@ void pcbc_exception_init(zval *return_value, long code, const char *message TSRM
         zval __pcbc_error;                                                                                             \
         ZVAL_UNDEF(&__pcbc_error);                                                                                     \
         pcbc_create_lcb_exception(&__pcbc_error, code, NULL, NULL, query_code, query_msg,                              \
-                                  PCBC_OPCODE_UNSPEC TSRMLS_CC);                                                       \
-        zend_throw_exception_object(&__pcbc_error TSRMLS_CC);                                                          \
+                                  PCBC_OPCODE_UNSPEC);                                                       \
+        zend_throw_exception_object(&__pcbc_error);                                                          \
     } while (0)
 
 #define PCBC_CONTENT_TYPE_FORM "application/x-www-form-urlencoded"
@@ -215,7 +215,7 @@ void pcbc_exception_init(zval *return_value, long code, const char *message TSRM
 #define PCBC_JSON_ENCODE(__pcbc_buf, __pcbc_value, __pcbc_flags, __pcbc_error_code)                                    \
     do {                                                                                                               \
         PCBC_JSON_RESET_STATE;                                                                                         \
-        php_json_encode((__pcbc_buf), (__pcbc_value), (__pcbc_flags)TSRMLS_CC);                                        \
+        php_json_encode((__pcbc_buf), (__pcbc_value), (__pcbc_flags));                                        \
         (__pcbc_error_code) = JSON_G(error_code);                                                                      \
     } while (0)
 
@@ -224,7 +224,7 @@ void pcbc_exception_init(zval *return_value, long code, const char *message TSRM
         char *__copy = estrndup((__pcbc_src), (__pcbc_len));                                                           \
         PCBC_JSON_RESET_STATE;                                                                                         \
         php_json_decode_ex((__pcbc_zval), (__copy), (__pcbc_len), (__options),                                         \
-                           PHP_JSON_PARSER_DEFAULT_DEPTH TSRMLS_CC);                                                   \
+                           PHP_JSON_PARSER_DEFAULT_DEPTH);                                                   \
         efree(__copy);                                                                                                 \
         (__pcbc_error_code) = JSON_G(error_code);                                                                      \
     } while (0)
@@ -289,22 +289,22 @@ typedef struct {
 } opcookie_res;
 
 int pcbc_decode_value(zval *return_value, pcbc_bucket_t *bucket, const char *bytes, int bytes_len, uint32_t flags,
-                      uint8_t datatype TSRMLS_DC);
+                      uint8_t datatype);
 int pcbc_encode_value(pcbc_bucket_t *bucket, zval *value, void **bytes, lcb_size_t *nbytes, lcb_uint32_t *flags,
-                      uint8_t *datatype TSRMLS_DC);
+                      uint8_t *datatype);
 
 void pcbc_http_request(zval *return_value, lcb_INSTANCE *conn, lcb_CMDHTTP *cmd, int json_response, void *cbctx,
-                       void(httpcb)(void *, zval *, zval *), int(errorcb)(void *, zval *) TSRMLS_DC);
+                       void(httpcb)(void *, zval *, zval *), int(errorcb)(void *, zval *));
 
-void pcbc_mutation_state_export_for_n1ql(zval *obj, zval *scan_vectors TSRMLS_DC);
-void pcbc_mutation_state_export_for_search(zval *mutation_state, zval *scan_vectors TSRMLS_DC);
+void pcbc_mutation_state_export_for_n1ql(zval *obj, zval *scan_vectors);
+void pcbc_mutation_state_export_for_search(zval *mutation_state, zval *scan_vectors);
 
-void pcbc_crypto_register(pcbc_bucket_t *obj, const char *name, int name_len, zval *provider TSRMLS_DC);
-void pcbc_crypto_unregister(pcbc_bucket_t *obj, const char *name, int name_len TSRMLS_DC);
+void pcbc_crypto_register(pcbc_bucket_t *obj, const char *name, int name_len, zval *provider);
+void pcbc_crypto_unregister(pcbc_bucket_t *obj, const char *name, int name_len);
 void pcbc_crypto_encrypt_fields(pcbc_bucket_t *obj, zval *document, zval *options, const char *prefix,
-                                zval *return_value TSRMLS_DC);
+                                zval *return_value);
 void pcbc_crypto_decrypt_fields(pcbc_bucket_t *obj, zval *document, zval *options, const char *prefix,
-                                zval *return_value TSRMLS_DC);
+                                zval *return_value);
 
 static inline pcbc_cluster_t *pcbc_cluster_fetch_object(zend_object *obj)
 {
@@ -355,7 +355,7 @@ opcookie_res *opcookie_next_res(opcookie *cookie, opcookie_res *cur);
         size_t ndata = 0;                                                                                              \
         getter(target, &data, &ndata);                                                                                 \
         if (ndata && data) {                                                                                           \
-            zend_update_property_stringl(class_entry, return_value, ZEND_STRL(prop), data, ndata TSRMLS_CC);           \
+            zend_update_property_stringl(class_entry, return_value, ZEND_STRL(prop), data, ndata);           \
         }                                                                                                              \
     } while (0);
 
@@ -363,7 +363,7 @@ opcookie_res *opcookie_next_res(opcookie *cookie, opcookie_res *cur);
     do {                                                                                                               \
         type data = 0;                                                                                                 \
         getter(resp, &data);                                                                                           \
-        zend_update_property_long(class_entry, return_value, ZEND_STRL(prop), data TSRMLS_CC);                         \
+        zend_update_property_long(class_entry, return_value, ZEND_STRL(prop), data);                         \
     } while (0);
 
 #endif /* COUCHBASE_H_ */

--- a/couchbase.h
+++ b/couchbase.h
@@ -44,6 +44,66 @@
 #define PCBC_ARG_VARIADIC_INFO(__pcbc_pass_by_ref, __pcbc_name)                                                        \
     ZEND_ARG_VARIADIC_INFO((__pcbc_pass_by_ref), (__pcbc_name))
 
+#if PHP_VERSION_ID < 80000
+
+#define pcbc_read_property(scope, object, name, silent, rv) \
+        zend_read_property((scope), (object), ZEND_STRL(name), (silent), (rv))
+
+#define pcbc_update_property(scope, object, name, value) \
+        zend_update_property((scope), (object), ZEND_STRL(name), (value))
+
+#define pcbc_update_property_null(scope, object, name) \
+        zend_update_property_null((scope), (object), ZEND_STRL(name))
+
+#define pcbc_update_property_bool(scope, object, name, value) \
+        zend_update_property_bool((scope), (object), ZEND_STRL(name), (value))
+
+#define pcbc_update_property_long(scope, object, name, value) \
+        zend_update_property_long((scope), (object), ZEND_STRL(name), (value))
+
+#define pcbc_update_property_double(scope, object, name, value) \
+        zend_update_property_double((scope), (object), ZEND_STRL(name), (value))
+
+#define pcbc_update_property_stringl(scope, object, name, value, value_len) \
+        zend_update_property_stringl((scope), (object), ZEND_STRL(name), (value), (value_len))
+
+#define pcbc_update_property_string(scope, object, name, value) \
+        zend_update_property_string((scope), (object), ZEND_STRL(name), (value))
+
+#define pcbc_update_property_str(scope, object, name, value) \
+        zend_update_property_str((scope), (object), ZEND_STRL(name), (value))
+
+#else
+
+#define pcbc_read_property(scope, object, name, silent, rv) \
+        zend_read_property((scope), Z_OBJ_P(object), ZEND_STRL(name), (silent), (rv))
+
+#define pcbc_update_property(scope, object, name, value) \
+        zend_update_property((scope), Z_OBJ_P(object), ZEND_STRL(name), (value))
+
+#define pcbc_update_property_null(scope, object, name) \
+        zend_update_property_null((scope), Z_OBJ_P(object), ZEND_STRL(name))
+
+#define pcbc_update_property_bool(scope, object, name, value) \
+        zend_update_property_bool((scope), Z_OBJ_P(object), ZEND_STRL(name), (value))
+
+#define pcbc_update_property_long(scope, object, name, value) \
+        zend_update_property_long((scope), Z_OBJ_P(object), ZEND_STRL(name), (value))
+
+#define pcbc_update_property_double(scope, object, name, value) \
+        zend_update_property_double((scope), Z_OBJ_P(object), ZEND_STRL(name), (value))
+
+#define pcbc_update_property_stringl(scope, object, name, value, value_len) \
+        zend_update_property_stringl((scope), Z_OBJ_P(object), ZEND_STRL(name), (value), (value_len))
+
+#define pcbc_update_property_string(scope, object, name, value) \
+        zend_update_property_string((scope), Z_OBJ_P(object), ZEND_STRL(name), (value))
+
+#define pcbc_update_property_str(scope, object, name, value) \
+        zend_update_property_str((scope), Z_OBJ_P(object), ZEND_STRL(name), (value))
+
+#endif
+
 enum pcbc_constants {
     PERSISTTO_ONE = 1,
     PERSISTTO_TWO = 2,
@@ -114,14 +174,14 @@ extern zend_class_entry *pcbc_binary_collection_ce;
     {                                                                                                                  \
         zval *prop, rv__;                                                                                              \
         zval *self = getThis();                                                                                        \
-        prop = zend_read_property((class_entry), self, ZEND_STRL("bucket"), 0, &rv__);                                 \
+        prop = pcbc_read_property((class_entry), self, ("bucket"), 0, &rv__);                                 \
         bucket = Z_BUCKET_OBJ_P(prop);                                                                                 \
-        prop = zend_read_property((class_entry), self, ZEND_STRL("scope"), 0, &rv__);                                  \
+        prop = pcbc_read_property((class_entry), self, ("scope"), 0, &rv__);                                  \
         if (Z_TYPE_P(prop) == IS_STRING) {                                                                             \
             scope_str = Z_STRVAL_P(prop);                                                                              \
             scope_len = Z_STRLEN_P(prop);                                                                              \
         }                                                                                                              \
-        prop = zend_read_property((class_entry), self, ZEND_STRL("name"), 0, &rv__);                                   \
+        prop = pcbc_read_property((class_entry), self, ("name"), 0, &rv__);                                   \
         if (Z_TYPE_P(prop) == IS_STRING) {                                                                             \
             collection_str = Z_STRVAL_P(prop);                                                                         \
             collection_len = Z_STRLEN_P(prop);                                                                         \
@@ -153,11 +213,11 @@ void pcbc_exception_init(zval *return_value, long code, const char *message);
         zend_string *ctx = NULL, *ref = NULL;                                                                          \
         zval *zref, __rv1, *zctx, __rv2;                                                                               \
         if (result_ce) {                                                                                               \
-            zref = zend_read_property(result_ce, return_value, ZEND_STRL("err_ref"), 0, &__rv1);                       \
+            zref = pcbc_read_property(result_ce, return_value, ("err_ref"), 0, &__rv1);                       \
             if (Z_TYPE_P(zref) == IS_STRING) {                                                                         \
                 ref = Z_STR_P(zref);                                                                                   \
             }                                                                                                          \
-            zctx = zend_read_property(result_ce, return_value, ZEND_STRL("err_ctx"), 0, &__rv2);                       \
+            zctx = pcbc_read_property(result_ce, return_value, ("err_ctx"), 0, &__rv2);                       \
             if (Z_TYPE_P(zctx) == IS_STRING) {                                                                         \
                 ctx = Z_STR_P(zctx);                                                                                   \
             }                                                                                                          \
@@ -355,7 +415,7 @@ opcookie_res *opcookie_next_res(opcookie *cookie, opcookie_res *cur);
         size_t ndata = 0;                                                                                              \
         getter(target, &data, &ndata);                                                                                 \
         if (ndata && data) {                                                                                           \
-            zend_update_property_stringl(class_entry, return_value, ZEND_STRL(prop), data, ndata);           \
+            pcbc_update_property_stringl(class_entry, return_value, (prop), data, ndata);           \
         }                                                                                                              \
     } while (0);
 
@@ -363,7 +423,7 @@ opcookie_res *opcookie_next_res(opcookie *cookie, opcookie_res *cur);
     do {                                                                                                               \
         type data = 0;                                                                                                 \
         getter(resp, &data);                                                                                           \
-        zend_update_property_long(class_entry, return_value, ZEND_STRL(prop), data);                         \
+        pcbc_update_property_long(class_entry, return_value, (prop), data);                         \
     } while (0);
 
 #endif /* COUCHBASE_H_ */

--- a/exception.c
+++ b/exception.c
@@ -26,10 +26,10 @@ static void pcbc_exception_make(zval *return_value, zend_class_entry *exception_
     object_init_ex(return_value, pcbc_base_exception_ce);
 
     if (message) {
-        zend_update_property_string(pcbc_base_exception_ce, return_value, ZEND_STRL("message"), message);
+        pcbc_update_property_string(pcbc_base_exception_ce, return_value, ("message"), message);
     }
     if (code) {
-        zend_update_property_long(pcbc_base_exception_ce, return_value, ZEND_STRL("code"), code);
+        pcbc_update_property_long(pcbc_base_exception_ce, return_value, ("code"), code);
     }
 }
 
@@ -373,16 +373,16 @@ void pcbc_create_lcb_exception(zval *return_value, long code, zend_string *conte
         break;
     }
     object_init_ex(return_value, exc_ce);
-    zend_update_property_long(pcbc_default_exception_ce, return_value, ZEND_STRL("code"),
+    pcbc_update_property_long(pcbc_default_exception_ce, return_value, ("code"),
                               http_code ? http_code : code);
-    zend_update_property_string(pcbc_default_exception_ce, return_value, ZEND_STRL("message"),
+    pcbc_update_property_string(pcbc_default_exception_ce, return_value, ("message"),
                                 http_msg ? http_msg : lcb_strerror_short(code));
 
     if (ref) {
-        zend_update_property_str(pcbc_base_exception_ce, return_value, ZEND_STRL("ref"), ref);
+        pcbc_update_property_str(pcbc_base_exception_ce, return_value, ("ref"), ref);
     }
     if (context) {
-        zend_update_property_str(pcbc_base_exception_ce, return_value, ZEND_STRL("context"), context);
+        pcbc_update_property_str(pcbc_base_exception_ce, return_value, ("context"), context);
     }
 }
 
@@ -393,7 +393,7 @@ PHP_METHOD(BaseException, context)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_base_exception_ce, getThis(), ZEND_STRL("context"), 0, &rv);
+    prop = pcbc_read_property(pcbc_base_exception_ce, getThis(), ("context"), 0, &rv);
     ZVAL_DEREF(prop);
     ZVAL_COPY(return_value, prop);
 }
@@ -405,7 +405,7 @@ PHP_METHOD(BaseException, code)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_base_exception_ce, getThis(), ZEND_STRL("code"), 0, &rv);
+    prop = pcbc_read_property(pcbc_base_exception_ce, getThis(), ("code"), 0, &rv);
     ZVAL_DEREF(prop);
     ZVAL_COPY(return_value, prop);
 }
@@ -417,7 +417,7 @@ PHP_METHOD(BaseException, message)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_base_exception_ce, getThis(), ZEND_STRL("message"), 0, &rv);
+    prop = pcbc_read_property(pcbc_base_exception_ce, getThis(), ("message"), 0, &rv);
     ZVAL_DEREF(prop);
     ZVAL_COPY(return_value, prop);
 }
@@ -429,7 +429,7 @@ PHP_METHOD(BaseException, ref)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_base_exception_ce, getThis(), ZEND_STRL("ref"), 0, &rv);
+    prop = pcbc_read_property(pcbc_base_exception_ce, getThis(), ("ref"), 0, &rv);
     ZVAL_DEREF(prop);
     ZVAL_COPY(return_value, prop);
 }

--- a/exception.c
+++ b/exception.c
@@ -21,21 +21,21 @@ zend_class_entry *pcbc_default_exception_ce;
 zend_class_entry *pcbc_base_exception_ce;
 
 static void pcbc_exception_make(zval *return_value, zend_class_entry *exception_ce, long code,
-                                const char *message TSRMLS_DC)
+                                const char *message)
 {
     object_init_ex(return_value, pcbc_base_exception_ce);
 
     if (message) {
-        zend_update_property_string(pcbc_base_exception_ce, return_value, ZEND_STRL("message"), message TSRMLS_CC);
+        zend_update_property_string(pcbc_base_exception_ce, return_value, ZEND_STRL("message"), message);
     }
     if (code) {
-        zend_update_property_long(pcbc_base_exception_ce, return_value, ZEND_STRL("code"), code TSRMLS_CC);
+        zend_update_property_long(pcbc_base_exception_ce, return_value, ZEND_STRL("code"), code);
     }
 }
 
-void pcbc_exception_init(zval *return_value, long code, const char *message TSRMLS_DC)
+void pcbc_exception_init(zval *return_value, long code, const char *message)
 {
-    pcbc_exception_make(return_value, pcbc_base_exception_ce, code, message TSRMLS_CC);
+    pcbc_exception_make(return_value, pcbc_base_exception_ce, code, message);
 }
 
 zend_class_entry *pcbc_http_exception_ce;
@@ -91,113 +91,113 @@ static const zend_function_entry pcbc_base_exception_methods[] = {
 PHP_MINIT_FUNCTION(CouchbaseException)
 {
     zend_class_entry ce;
-    pcbc_default_exception_ce = (zend_class_entry *)zend_exception_get_default(TSRMLS_C);
+    pcbc_default_exception_ce = (zend_class_entry *)zend_exception_get_default();
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "BaseException", pcbc_base_exception_methods);
-    pcbc_base_exception_ce = zend_register_internal_class_ex(&ce, pcbc_default_exception_ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("ref"), ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("context"), ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_input"), ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_network"), ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_fatal"), ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_transient"), ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_data_operation"), ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_internal"), ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_plugin"), ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_server_under_load"), ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_server_generated"), ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_subdoc"), ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_durability"), ZEND_ACC_PROTECTED TSRMLS_CC);
+    pcbc_base_exception_ce = zend_register_internal_class_ex(&ce, pcbc_default_exception_ce);
+    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("ref"), ZEND_ACC_PROTECTED);
+    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("context"), ZEND_ACC_PROTECTED);
+    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_input"), ZEND_ACC_PROTECTED);
+    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_network"), ZEND_ACC_PROTECTED);
+    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_fatal"), ZEND_ACC_PROTECTED);
+    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_transient"), ZEND_ACC_PROTECTED);
+    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_data_operation"), ZEND_ACC_PROTECTED);
+    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_internal"), ZEND_ACC_PROTECTED);
+    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_plugin"), ZEND_ACC_PROTECTED);
+    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_server_under_load"), ZEND_ACC_PROTECTED);
+    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_server_generated"), ZEND_ACC_PROTECTED);
+    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_subdoc"), ZEND_ACC_PROTECTED);
+    zend_declare_property_null(pcbc_base_exception_ce, ZEND_STRL("is_durability"), ZEND_ACC_PROTECTED);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "HttpException", NULL);
-    pcbc_http_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_http_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "QueryException", NULL);
-    pcbc_query_exception_ce = zend_register_internal_class_ex(&ce, pcbc_http_exception_ce TSRMLS_CC);
+    pcbc_query_exception_ce = zend_register_internal_class_ex(&ce, pcbc_http_exception_ce);
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "QueryErrorException", NULL);
-    pcbc_query_error_exception_ce = zend_register_internal_class_ex(&ce, pcbc_query_exception_ce TSRMLS_CC);
+    pcbc_query_error_exception_ce = zend_register_internal_class_ex(&ce, pcbc_query_exception_ce);
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "QueryServiceException", NULL);
-    pcbc_query_service_exception_ce = zend_register_internal_class_ex(&ce, pcbc_query_exception_ce TSRMLS_CC);
+    pcbc_query_service_exception_ce = zend_register_internal_class_ex(&ce, pcbc_query_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchException", NULL);
-    pcbc_search_exception_ce = zend_register_internal_class_ex(&ce, pcbc_http_exception_ce TSRMLS_CC);
+    pcbc_search_exception_ce = zend_register_internal_class_ex(&ce, pcbc_http_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "AnalyticsException", NULL);
-    pcbc_analytics_exception_ce = zend_register_internal_class_ex(&ce, pcbc_http_exception_ce TSRMLS_CC);
+    pcbc_analytics_exception_ce = zend_register_internal_class_ex(&ce, pcbc_http_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ViewException", NULL);
-    pcbc_view_exception_ce = zend_register_internal_class_ex(&ce, pcbc_http_exception_ce TSRMLS_CC);
+    pcbc_view_exception_ce = zend_register_internal_class_ex(&ce, pcbc_http_exception_ce);
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "PartialViewException", NULL);
-    pcbc_partial_view_exception_ce = zend_register_internal_class_ex(&ce, pcbc_view_exception_ce TSRMLS_CC);
+    pcbc_partial_view_exception_ce = zend_register_internal_class_ex(&ce, pcbc_view_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "BindingsException", NULL);
-    pcbc_bindings_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_bindings_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "InvalidStateException", NULL);
-    pcbc_invalid_state_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_invalid_state_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "KeyValueException", NULL);
-    pcbc_key_value_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_key_value_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "DocumentNotFoundException", NULL);
-    pcbc_key_not_found_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce TSRMLS_CC);
+    pcbc_key_not_found_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce);
     zend_register_class_alias("Couchbase\\KeyNotFoundException", pcbc_key_not_found_exception_ce);
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "KeyExistsException", NULL);
-    pcbc_key_exists_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce TSRMLS_CC);
+    pcbc_key_exists_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce);
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ValueTooBigException", NULL);
-    pcbc_value_too_big_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce TSRMLS_CC);
+    pcbc_value_too_big_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce);
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "KeyLockedException", NULL);
-    pcbc_key_locked_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce TSRMLS_CC);
+    pcbc_key_locked_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce);
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "TempFailException", NULL);
-    pcbc_temp_fail_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce TSRMLS_CC);
+    pcbc_temp_fail_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce);
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "PathNotFoundException", NULL);
-    pcbc_path_not_found_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce TSRMLS_CC);
+    pcbc_path_not_found_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce);
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "PathExistsException", NULL);
-    pcbc_path_exists_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce TSRMLS_CC);
+    pcbc_path_exists_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce);
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "InvalidRangeException", NULL);
-    pcbc_invalid_range_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce TSRMLS_CC);
+    pcbc_invalid_range_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce);
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "KeyDeletedException", NULL);
-    pcbc_key_deleted_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce TSRMLS_CC);
+    pcbc_key_deleted_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce);
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "CasMismatchException", NULL);
-    pcbc_cas_mismatch_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce TSRMLS_CC);
+    pcbc_cas_mismatch_exception_ce = zend_register_internal_class_ex(&ce, pcbc_key_value_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "InvalidConfigurationException", NULL);
-    pcbc_invalid_configuration_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_invalid_configuration_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ServiceMissingException", NULL);
-    pcbc_service_missing_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_service_missing_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "NetworkException", NULL);
-    pcbc_network_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_network_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "TimeoutException", NULL);
-    pcbc_timeout_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_timeout_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "BucketMissingException", NULL);
-    pcbc_bucket_missing_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_bucket_missing_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ScopeMissingException", NULL);
-    pcbc_scope_missing_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_scope_missing_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "CollectionMissingException", NULL);
-    pcbc_collection_missing_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_collection_missing_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "AuthenticationException", NULL);
-    pcbc_authentication_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_authentication_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "BadInputException", NULL);
-    pcbc_bad_input_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_bad_input_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "DurabilityException", NULL);
-    pcbc_durability_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_durability_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SubdocumentException", NULL);
-    pcbc_subdocument_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce TSRMLS_CC);
+    pcbc_subdocument_exception_ce = zend_register_internal_class_ex(&ce, pcbc_base_exception_ce);
 
     return SUCCESS;
 }
 
 void pcbc_create_lcb_exception(zval *return_value, long code, zend_string *context, zend_string *ref, int http_code,
-                               const char *http_msg, int opcode TSRMLS_DC)
+                               const char *http_msg, int opcode)
 {
     zend_class_entry *exc_ce = NULL;
 
@@ -374,15 +374,15 @@ void pcbc_create_lcb_exception(zval *return_value, long code, zend_string *conte
     }
     object_init_ex(return_value, exc_ce);
     zend_update_property_long(pcbc_default_exception_ce, return_value, ZEND_STRL("code"),
-                              http_code ? http_code : code TSRMLS_CC);
+                              http_code ? http_code : code);
     zend_update_property_string(pcbc_default_exception_ce, return_value, ZEND_STRL("message"),
-                                http_msg ? http_msg : lcb_strerror_short(code) TSRMLS_CC);
+                                http_msg ? http_msg : lcb_strerror_short(code));
 
     if (ref) {
-        zend_update_property_str(pcbc_base_exception_ce, return_value, ZEND_STRL("ref"), ref TSRMLS_CC);
+        zend_update_property_str(pcbc_base_exception_ce, return_value, ZEND_STRL("ref"), ref);
     }
     if (context) {
-        zend_update_property_str(pcbc_base_exception_ce, return_value, ZEND_STRL("context"), context TSRMLS_CC);
+        zend_update_property_str(pcbc_base_exception_ce, return_value, ZEND_STRL("context"), context);
     }
 }
 

--- a/log.c
+++ b/log.c
@@ -52,10 +52,9 @@ static void log_handler(const lcb_LOGGER *logger, uint64_t iid, const char *subs
     }
 
     char buf[PCBC_LOG_MSG_SIZE] = {0};
-    TSRMLS_FETCH();
 
     pcbc_log_formatter(buf, PCBC_LOG_MSG_SIZE, level_to_string(severity), subsys, srcline, iid, NULL, 1, fmt, ap);
-    php_log_err(buf TSRMLS_CC);
+    php_log_err(buf);
 }
 
 struct pcbc_logger_st pcbc_logger = {LCB_LOG_INFO, log_handler};
@@ -65,7 +64,6 @@ void pcbc_log(int severity, lcb_INSTANCE *instance, const char *subsys, const ch
 {
     va_list ap;
     char buf[PCBC_LOG_MSG_SIZE] = {0};
-    TSRMLS_FETCH();
 
     if (severity < pcbc_logger.minlevel) {
         return;
@@ -76,5 +74,5 @@ void pcbc_log(int severity, lcb_INSTANCE *instance, const char *subsys, const ch
                        ap);
     va_end(ap);
 
-    php_log_err(buf TSRMLS_CC);
+    php_log_err(buf);
 }

--- a/src/couchbase/authenticator.c
+++ b/src/couchbase/authenticator.c
@@ -24,7 +24,7 @@ PHP_MINIT_FUNCTION(Authenticator)
 {
     zend_class_entry ce;
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "Authenticator", authenticator_interface);
-    pcbc_authenticator_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_authenticator_ce = zend_register_internal_interface(&ce);
 
     return SUCCESS;
 }

--- a/src/couchbase/bucket.c
+++ b/src/couchbase/bucket.c
@@ -39,7 +39,7 @@ PHP_METHOD(Bucket, setTranscoder)
     zval *encoder, *decoder;
     int rv;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zz", &encoder, &decoder);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "zz", &encoder, &decoder);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -68,7 +68,7 @@ PHP_METHOD(Bucket, __set)
     long val;
     lcb_uint32_t lcbval;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl", &name, &name_len, &val);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "sl", &name, &name_len, &val);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -114,7 +114,7 @@ PHP_METHOD(Bucket, __get)
     int rv, cmd;
     lcb_uint32_t lcbval;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &name, &name_len);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name, &name_len);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -172,7 +172,7 @@ PHP_METHOD(Bucket, collections)
     }
 
     object_init_ex(return_value, pcbc_collection_manager_ce);
-    zend_update_property(pcbc_collection_manager_ce, return_value, ZEND_STRL("bucket"), getThis() TSRMLS_CC);
+    zend_update_property(pcbc_collection_manager_ce, return_value, ZEND_STRL("bucket"), getThis());
 }
 
 PHP_METHOD(Bucket, viewIndexes)
@@ -182,7 +182,7 @@ PHP_METHOD(Bucket, viewIndexes)
     }
 
     object_init_ex(return_value, pcbc_view_index_manager_ce);
-    zend_update_property(pcbc_view_index_manager_ce, return_value, ZEND_STRL("bucket"), getThis() TSRMLS_CC);
+    zend_update_property(pcbc_view_index_manager_ce, return_value, ZEND_STRL("bucket"), getThis());
 }
 
 PHP_METHOD(Bucket, defaultCollection)
@@ -195,7 +195,7 @@ PHP_METHOD(Bucket, defaultCollection)
     }
 
     object_init_ex(return_value, pcbc_collection_ce);
-    zend_update_property(pcbc_collection_ce, return_value, ZEND_STRL("bucket"), getThis() TSRMLS_CC);
+    zend_update_property(pcbc_collection_ce, return_value, ZEND_STRL("bucket"), getThis());
 }
 
 PHP_METHOD(Bucket, defaultScope)
@@ -208,7 +208,7 @@ PHP_METHOD(Bucket, defaultScope)
     }
 
     object_init_ex(return_value, pcbc_scope_ce);
-    zend_update_property(pcbc_scope_ce, return_value, ZEND_STRL("bucket"), getThis() TSRMLS_CC);
+    zend_update_property(pcbc_scope_ce, return_value, ZEND_STRL("bucket"), getThis());
 }
 
 PHP_METHOD(Bucket, scope)
@@ -216,14 +216,14 @@ PHP_METHOD(Bucket, scope)
     int rv;
     zend_string *name;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
     object_init_ex(return_value, pcbc_scope_ce);
-    zend_update_property(pcbc_scope_ce, return_value, ZEND_STRL("bucket"), getThis() TSRMLS_CC);
-    zend_update_property_str(pcbc_scope_ce, return_value, ZEND_STRL("name"), name TSRMLS_CC);
+    zend_update_property(pcbc_scope_ce, return_value, ZEND_STRL("bucket"), getThis());
+    zend_update_property_str(pcbc_scope_ce, return_value, ZEND_STRL("name"), name);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_Bucket_none, 0, 0, 0)
@@ -301,7 +301,7 @@ zend_function_entry bucket_methods[] = {
 
 zend_object_handlers pcbc_bucket_handlers;
 
-static void pcbc_bucket_free_object(zend_object *object TSRMLS_DC)
+static void pcbc_bucket_free_object(zend_object *object)
 {
     pcbc_bucket_t *obj = Z_BUCKET_OBJ(object);
 
@@ -311,7 +311,7 @@ static void pcbc_bucket_free_object(zend_object *object TSRMLS_DC)
         for (ptr = obj->crypto_head; ptr;) {
             cur = ptr;
             if (cur->name) {
-                pcbc_crypto_unregister(obj, cur->name, cur->name_len TSRMLS_CC);
+                pcbc_crypto_unregister(obj, cur->name, cur->name_len);
                 efree(cur->name);
             }
             ptr = ptr->next;
@@ -319,7 +319,7 @@ static void pcbc_bucket_free_object(zend_object *object TSRMLS_DC)
         }
     }
     */
-    pcbc_connection_delref(obj->conn TSRMLS_CC);
+    pcbc_connection_delref(obj->conn);
     if (!Z_ISUNDEF(obj->encoder)) {
         zval_ptr_dtor(&obj->encoder);
         ZVAL_UNDEF(&obj->encoder);
@@ -329,23 +329,23 @@ static void pcbc_bucket_free_object(zend_object *object TSRMLS_DC)
         ZVAL_UNDEF(&obj->decoder);
     }
 
-    zend_object_std_dtor(&obj->std TSRMLS_CC);
+    zend_object_std_dtor(&obj->std);
 }
 
-static zend_object *pcbc_bucket_create_object(zend_class_entry *class_type TSRMLS_DC)
+static zend_object *pcbc_bucket_create_object(zend_class_entry *class_type)
 {
     pcbc_bucket_t *obj = NULL;
 
     obj = PCBC_ALLOC_OBJECT_T(pcbc_bucket_t, class_type);
 
-    zend_object_std_init(&obj->std, class_type TSRMLS_CC);
+    zend_object_std_init(&obj->std, class_type);
     object_properties_init(&obj->std, class_type);
 
     obj->std.handlers = &pcbc_bucket_handlers;
     return &obj->std;
 }
 
-static HashTable *pcbc_bucket_get_debug_info(zval *object, int *is_temp TSRMLS_DC)
+static HashTable *pcbc_bucket_get_debug_info(zval *object, int *is_temp)
 {
     pcbc_bucket_t *obj = NULL;
     zval retval;
@@ -393,7 +393,7 @@ PHP_MINIT_FUNCTION(Bucket)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "Bucket", bucket_methods);
-    pcbc_bucket_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_bucket_ce = zend_register_internal_class(&ce);
     pcbc_bucket_ce->create_object = pcbc_bucket_create_object;
     PCBC_CE_DISABLE_SERIALIZATION(pcbc_bucket_ce);
 

--- a/src/couchbase/bucket.c
+++ b/src/couchbase/bucket.c
@@ -283,8 +283,8 @@ ZEND_END_ARG_INFO()
 // clang-format off
 zend_function_entry bucket_methods[] = {
     PHP_ME(Bucket, __construct, ai_Bucket_none, ZEND_ACC_PRIVATE | ZEND_ACC_FINAL | ZEND_ACC_CTOR)
-    PHP_ME(Bucket, __get, ai_Bucket___get, ZEND_ACC_PRIVATE)
-    PHP_ME(Bucket, __set, ai_Bucket___set, ZEND_ACC_PRIVATE)
+    PHP_ME(Bucket, __get, ai_Bucket___get, ZEND_ACC_PUBLIC)
+    PHP_ME(Bucket, __set, ai_Bucket___set, ZEND_ACC_PUBLIC)
     PHP_ME(Bucket, setTranscoder, ai_Bucket_setTranscoder, ZEND_ACC_PUBLIC)
     PHP_ME(Bucket, name, ai_Bucket_name, ZEND_ACC_PUBLIC)
     PHP_ME(Bucket, viewQuery, ai_Bucket_viewQuery, ZEND_ACC_PUBLIC)

--- a/src/couchbase/bucket.c
+++ b/src/couchbase/bucket.c
@@ -172,7 +172,7 @@ PHP_METHOD(Bucket, collections)
     }
 
     object_init_ex(return_value, pcbc_collection_manager_ce);
-    zend_update_property(pcbc_collection_manager_ce, return_value, ZEND_STRL("bucket"), getThis());
+    pcbc_update_property(pcbc_collection_manager_ce, return_value, ("bucket"), getThis());
 }
 
 PHP_METHOD(Bucket, viewIndexes)
@@ -182,7 +182,7 @@ PHP_METHOD(Bucket, viewIndexes)
     }
 
     object_init_ex(return_value, pcbc_view_index_manager_ce);
-    zend_update_property(pcbc_view_index_manager_ce, return_value, ZEND_STRL("bucket"), getThis());
+    pcbc_update_property(pcbc_view_index_manager_ce, return_value, ("bucket"), getThis());
 }
 
 PHP_METHOD(Bucket, defaultCollection)
@@ -195,7 +195,7 @@ PHP_METHOD(Bucket, defaultCollection)
     }
 
     object_init_ex(return_value, pcbc_collection_ce);
-    zend_update_property(pcbc_collection_ce, return_value, ZEND_STRL("bucket"), getThis());
+    pcbc_update_property(pcbc_collection_ce, return_value, ("bucket"), getThis());
 }
 
 PHP_METHOD(Bucket, defaultScope)
@@ -208,7 +208,7 @@ PHP_METHOD(Bucket, defaultScope)
     }
 
     object_init_ex(return_value, pcbc_scope_ce);
-    zend_update_property(pcbc_scope_ce, return_value, ZEND_STRL("bucket"), getThis());
+    pcbc_update_property(pcbc_scope_ce, return_value, ("bucket"), getThis());
 }
 
 PHP_METHOD(Bucket, scope)
@@ -222,8 +222,8 @@ PHP_METHOD(Bucket, scope)
     }
 
     object_init_ex(return_value, pcbc_scope_ce);
-    zend_update_property(pcbc_scope_ce, return_value, ZEND_STRL("bucket"), getThis());
-    zend_update_property_str(pcbc_scope_ce, return_value, ZEND_STRL("name"), name);
+    pcbc_update_property(pcbc_scope_ce, return_value, ("bucket"), getThis());
+    pcbc_update_property_str(pcbc_scope_ce, return_value, ("name"), name);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_Bucket_none, 0, 0, 0)
@@ -345,13 +345,18 @@ static zend_object *pcbc_bucket_create_object(zend_class_entry *class_type)
     return &obj->std;
 }
 
+#if PHP_VERSION_ID < 80000
 static HashTable *pcbc_bucket_get_debug_info(zval *object, int *is_temp)
 {
-    pcbc_bucket_t *obj = NULL;
+    pcbc_bucket_t *obj = Z_BUCKET_OBJ_P(object);;
+#else
+static HashTable *pcbc_bucket_get_debug_info(zend_object *object, int *is_temp)
+{
+    pcbc_bucket_t *obj = pcbc_bucket_fetch_object(object);;
+#endif
     zval retval;
 
     *is_temp = 1;
-    obj = Z_BUCKET_OBJ_P(object);
 
     array_init(&retval);
     switch (obj->type) {

--- a/src/couchbase/bucket/cbas.c
+++ b/src/couchbase/bucket/cbas.c
@@ -34,7 +34,7 @@ static void analytics_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_R
     cookie->rc = lcb_respanalytics_status(resp);
     zval *return_value = cookie->return_value;
 
-    zend_update_property_long(pcbc_analytics_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_analytics_result_impl_ce, return_value, ("status"), cookie->rc);
 
     const char *row = NULL;
     size_t nrow = 0;
@@ -57,39 +57,39 @@ static void analytics_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_R
 
             mval = zend_symtable_str_find(marr, ZEND_STRL("status"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("status"), mval);
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("status"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("requestID"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("request_id"), mval);
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("request_id"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("clientContextID"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("client_context_id"),
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("client_context_id"),
                                      mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("signature"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("signature"), mval);
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("signature"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("errors"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("errors"), mval);
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("errors"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("warnings"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("warnings"), mval);
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("warnings"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("metrics"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("metrics"), mval);
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("metrics"), mval);
             }
-            zend_update_property(pcbc_analytics_result_impl_ce, return_value, ZEND_STRL("meta"), &meta);
+            pcbc_update_property(pcbc_analytics_result_impl_ce, return_value, ("meta"), &meta);
             zval_ptr_dtor(&meta);
             zval_dtor(&value);
         } else {
             zval *rows, rv;
-            rows = zend_read_property(pcbc_analytics_result_impl_ce, return_value, ZEND_STRL("rows"), 0, &rv);
+            rows = pcbc_read_property(pcbc_analytics_result_impl_ce, return_value, ("rows"), 0, &rv);
             add_next_index_zval(rows, &value);
         }
     }
@@ -102,7 +102,7 @@ PHP_METHOD(AnalyticsOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_analytics_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_analytics_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -135,7 +135,7 @@ PHP_METHOD(AnalyticsOptions, namedParameters)
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_analytics_options_ce, getThis(), ZEND_STRL("named_params"), &params);
+    pcbc_update_property(pcbc_analytics_options_ce, getThis(), ("named_params"), &params);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -166,7 +166,7 @@ PHP_METHOD(AnalyticsOptions, positionalParameters)
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_analytics_options_ce, getThis(), ZEND_STRL("positional_params"), &params);
+    pcbc_update_property(pcbc_analytics_options_ce, getThis(), ("positional_params"), &params);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -180,11 +180,11 @@ PHP_METHOD(AnalyticsOptions, raw)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_analytics_options_ce, getThis(), ZEND_STRL("raw_params"), 0, &rv1);
+    data = pcbc_read_property(pcbc_analytics_options_ce, getThis(), ("raw_params"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_analytics_options_ce, getThis(), ZEND_STRL("raw_params"), data);
+        pcbc_update_property(pcbc_analytics_options_ce, getThis(), ("raw_params"), data);
     }
     smart_str buf = {0};
     int last_error;
@@ -208,7 +208,7 @@ PHP_METHOD(AnalyticsOptions, clientContextId)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_analytics_options_ce, getThis(), ZEND_STRL("client_context_id"), arg);
+    pcbc_update_property_str(pcbc_analytics_options_ce, getThis(), ("client_context_id"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -219,7 +219,7 @@ PHP_METHOD(AnalyticsOptions, scanConsistency)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_analytics_options_ce, getThis(), ZEND_STRL("scan_consistency"), arg);
+    pcbc_update_property_str(pcbc_analytics_options_ce, getThis(), ("scan_consistency"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -230,7 +230,7 @@ PHP_METHOD(AnalyticsOptions, priority)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_analytics_options_ce, getThis(), ZEND_STRL("priority"), arg);
+    pcbc_update_property_bool(pcbc_analytics_options_ce, getThis(), ("priority"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -241,7 +241,7 @@ PHP_METHOD(AnalyticsOptions, readonly)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_analytics_options_ce, getThis(), ZEND_STRL("readonly"), arg);
+    pcbc_update_property_bool(pcbc_analytics_options_ce, getThis(), ("readonly"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -312,11 +312,11 @@ PHP_METHOD(Cluster, analyticsQuery)
     lcb_cmdanalytics_statement(cmd, ZSTR_VAL(statement), ZSTR_LEN(statement));
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_analytics_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_analytics_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdanalytics_timeout(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_analytics_options_ce, options, ZEND_STRL("named_params"), 0, &ret);
+        prop = pcbc_read_property(pcbc_analytics_options_ce, options, ("named_params"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_ARRAY) {
             HashTable *ht = HASH_OF(prop);
             zend_string *string_key = NULL;
@@ -330,7 +330,7 @@ PHP_METHOD(Cluster, analyticsQuery)
             }
             ZEND_HASH_FOREACH_END();
         }
-        prop = zend_read_property(pcbc_analytics_options_ce, options, ZEND_STRL("positional_params"), 0, &ret);
+        prop = pcbc_read_property(pcbc_analytics_options_ce, options, ("positional_params"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_ARRAY) {
             HashTable *ht = HASH_OF(prop);
             zval *entry;
@@ -342,7 +342,7 @@ PHP_METHOD(Cluster, analyticsQuery)
             }
             ZEND_HASH_FOREACH_END();
         }
-        prop = zend_read_property(pcbc_analytics_options_ce, options, ZEND_STRL("raw_params"), 0, &ret);
+        prop = pcbc_read_property(pcbc_analytics_options_ce, options, ("raw_params"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_ARRAY) {
             HashTable *ht = HASH_OF(prop);
             zend_string *string_key = NULL;
@@ -375,7 +375,7 @@ PHP_METHOD(Cluster, analyticsQuery)
     }
     zval rows;
     array_init(&rows);
-    zend_update_property(pcbc_analytics_result_impl_ce, return_value, ZEND_STRL("rows"), &rows);
+    pcbc_update_property(pcbc_analytics_result_impl_ce, return_value, ("rows"), &rows);
     struct query_cookie cookie = {LCB_SUCCESS, return_value};
     err = lcb_analytics(cluster->conn->lcb, &cookie, cmd);
     lcb_cmdanalytics_destroy(cmd);

--- a/src/couchbase/bucket/cbas.c
+++ b/src/couchbase/bucket/cbas.c
@@ -29,14 +29,12 @@ struct query_cookie {
 
 static void analytics_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RESPANALYTICS *resp)
 {
-    TSRMLS_FETCH();
-
     struct query_cookie *cookie;
     lcb_respanalytics_cookie(resp, (void **)&cookie);
     cookie->rc = lcb_respanalytics_status(resp);
     zval *return_value = cookie->return_value;
 
-    zend_update_property_long(pcbc_analytics_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
+    zend_update_property_long(pcbc_analytics_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
 
     const char *row = NULL;
     size_t nrow = 0;
@@ -59,34 +57,34 @@ static void analytics_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_R
 
             mval = zend_symtable_str_find(marr, ZEND_STRL("status"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("status"), mval TSRMLS_CC);
+                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("status"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("requestID"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("request_id"), mval TSRMLS_CC);
+                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("request_id"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("clientContextID"));
             if (mval) {
                 zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("client_context_id"),
-                                     mval TSRMLS_CC);
+                                     mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("signature"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("signature"), mval TSRMLS_CC);
+                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("signature"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("errors"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("errors"), mval TSRMLS_CC);
+                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("errors"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("warnings"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("warnings"), mval TSRMLS_CC);
+                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("warnings"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("metrics"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("metrics"), mval TSRMLS_CC);
+                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("metrics"), mval);
             }
-            zend_update_property(pcbc_analytics_result_impl_ce, return_value, ZEND_STRL("meta"), &meta TSRMLS_CC);
+            zend_update_property(pcbc_analytics_result_impl_ce, return_value, ZEND_STRL("meta"), &meta);
             zval_ptr_dtor(&meta);
             zval_dtor(&value);
         } else {
@@ -100,18 +98,18 @@ static void analytics_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_R
 PHP_METHOD(AnalyticsOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_analytics_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_analytics_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(AnalyticsOptions, namedParameters)
 {
     zval *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "a", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -133,18 +131,18 @@ PHP_METHOD(AnalyticsOptions, namedParameters)
                 continue;
             }
             smart_str_0(&buf);
-            add_assoc_str_ex(&params, ZSTR_VAL(string_key), ZSTR_LEN(string_key), buf.s TSRMLS_CC);
+            add_assoc_str_ex(&params, ZSTR_VAL(string_key), ZSTR_LEN(string_key), buf.s);
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_analytics_options_ce, getThis(), ZEND_STRL("named_params"), &params TSRMLS_CC);
+    zend_update_property(pcbc_analytics_options_ce, getThis(), ZEND_STRL("named_params"), &params);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(AnalyticsOptions, positionalParameters)
 {
     zval *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "a", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -164,11 +162,11 @@ PHP_METHOD(AnalyticsOptions, positionalParameters)
             RETURN_NULL();
         } else {
             smart_str_0(&buf);
-            add_next_index_str(&params, buf.s TSRMLS_CC);
+            add_next_index_str(&params, buf.s);
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_analytics_options_ce, getThis(), ZEND_STRL("positional_params"), &params TSRMLS_CC);
+    zend_update_property(pcbc_analytics_options_ce, getThis(), ZEND_STRL("positional_params"), &params);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -177,7 +175,7 @@ PHP_METHOD(AnalyticsOptions, raw)
 {
     zend_string *key;
     zval *value = NULL;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Sz!", &key, &value);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "Sz!", &key, &value);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -186,7 +184,7 @@ PHP_METHOD(AnalyticsOptions, raw)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_analytics_options_ce, getThis(), ZEND_STRL("raw_params"), data TSRMLS_CC);
+        zend_update_property(pcbc_analytics_options_ce, getThis(), ZEND_STRL("raw_params"), data);
     }
     smart_str buf = {0};
     int last_error;
@@ -198,7 +196,7 @@ PHP_METHOD(AnalyticsOptions, raw)
         RETURN_NULL();
     }
     smart_str_0(&buf);
-    add_assoc_str_ex(data, ZSTR_VAL(key), ZSTR_LEN(key), buf.s TSRMLS_CC);
+    add_assoc_str_ex(data, ZSTR_VAL(key), ZSTR_LEN(key), buf.s);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -206,44 +204,44 @@ PHP_METHOD(AnalyticsOptions, raw)
 PHP_METHOD(AnalyticsOptions, clientContextId)
 {
     zend_string *arg;
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &arg);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_analytics_options_ce, getThis(), ZEND_STRL("client_context_id"), arg TSRMLS_CC);
+    zend_update_property_str(pcbc_analytics_options_ce, getThis(), ZEND_STRL("client_context_id"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(AnalyticsOptions, scanConsistency)
 {
     zend_string *arg;
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &arg);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_analytics_options_ce, getThis(), ZEND_STRL("scan_consistency"), arg TSRMLS_CC);
+    zend_update_property_str(pcbc_analytics_options_ce, getThis(), ZEND_STRL("scan_consistency"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(AnalyticsOptions, priority)
 {
     zend_bool arg;
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &arg);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_analytics_options_ce, getThis(), ZEND_STRL("priority"), arg TSRMLS_CC);
+    zend_update_property_bool(pcbc_analytics_options_ce, getThis(), ZEND_STRL("priority"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(AnalyticsOptions, readonly)
 {
     zend_bool arg;
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &arg);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_analytics_options_ce, getThis(), ZEND_STRL("readonly"), arg TSRMLS_CC);
+    zend_update_property_bool(pcbc_analytics_options_ce, getThis(), ZEND_STRL("readonly"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -301,7 +299,7 @@ PHP_METHOD(Cluster, analyticsQuery)
     zval *options = NULL;
 
     int rv =
-        zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|O!", &statement, &options, pcbc_analytics_options_ce);
+        zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|O!", &statement, &options, pcbc_analytics_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -377,7 +375,7 @@ PHP_METHOD(Cluster, analyticsQuery)
     }
     zval rows;
     array_init(&rows);
-    zend_update_property(pcbc_analytics_result_impl_ce, return_value, ZEND_STRL("rows"), &rows TSRMLS_CC);
+    zend_update_property(pcbc_analytics_result_impl_ce, return_value, ZEND_STRL("rows"), &rows);
     struct query_cookie cookie = {LCB_SUCCESS, return_value};
     err = lcb_analytics(cluster->conn->lcb, &cookie, cmd);
     lcb_cmdanalytics_destroy(cmd);
@@ -398,16 +396,16 @@ PHP_MINIT_FUNCTION(AnalyticsQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "AnalyticsOptions", pcbc_analytics_options_methods);
-    pcbc_analytics_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_analytics_options_ce = zend_register_internal_class(&ce);
 
-    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("positional_params"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("named_params"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("raw_params"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("scan_consistency"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("priority"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("readonly"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("client_context_id"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("positional_params"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("named_params"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("raw_params"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("scan_consistency"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("priority"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("readonly"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_analytics_options_ce, ZEND_STRL("client_context_id"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/bucket/cbft.c
+++ b/src/couchbase/bucket/cbft.c
@@ -133,7 +133,7 @@ PHP_METHOD(Cluster, searchQuery)
         zval values;
         PCBC_STRING(fname, "jsonSerialize");
         ZVAL_UNDEF(&values);
-        rv = call_user_function_ex(EG(function_table), options, &fname, &values, 0, NULL, 1, NULL);
+        rv = call_user_function(EG(function_table), options, &fname, &values, 0, NULL);
         if (rv != FAILURE && !EG(exception) && !Z_ISUNDEF(values)) {
             zend_hash_merge(HASH_OF(&payload), HASH_OF(&values), NULL, 0);
         }

--- a/src/couchbase/bucket/cbft.c
+++ b/src/couchbase/bucket/cbft.c
@@ -28,14 +28,12 @@ struct search_cookie {
 
 static void ftsrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RESPSEARCH *resp)
 {
-    TSRMLS_FETCH();
-
     struct search_cookie *cookie;
     lcb_respsearch_cookie(resp, (void **)&cookie);
     cookie->rc = lcb_respsearch_status(resp);
     zval *return_value = cookie->return_value;
 
-    zend_update_property_long(pcbc_search_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
+    zend_update_property_long(pcbc_search_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
 
     const char *row = NULL;
     size_t nrow = 0;
@@ -57,19 +55,19 @@ static void ftsrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RESP
 
             mval = zend_symtable_str_find(marr, ZEND_STRL("took"));
             if (mval) {
-                zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("took"), mval TSRMLS_CC);
+                zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("took"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("total_hits"));
             if (mval) {
-                zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("total_hits"), mval TSRMLS_CC);
+                zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("total_hits"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("max_score"));
             if (mval) {
-                zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("max_score"), mval TSRMLS_CC);
+                zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("max_score"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("metrics"));
             if (mval) {
-                zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("metrics"), mval TSRMLS_CC);
+                zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("metrics"), mval);
             }
 
             mstatus = zend_symtable_str_find(marr, ZEND_STRL("status"));
@@ -78,28 +76,28 @@ static void ftsrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RESP
                 case IS_STRING:
                     // TODO: read and expose value in "error" key
                     zend_update_property_stringl(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("status"),
-                                                 Z_STRVAL_P(mstatus), Z_STRLEN_P(mstatus) TSRMLS_CC);
+                                                 Z_STRVAL_P(mstatus), Z_STRLEN_P(mstatus));
                     break;
                 case IS_ARRAY:
                     zend_update_property_string(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("status"),
-                                                "success" TSRMLS_CC);
+                                                "success");
                     mval = zend_symtable_str_find(Z_ARRVAL_P(mstatus), ZEND_STRL("successful"));
                     if (mval) {
                         zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("success_count"),
-                                             mval TSRMLS_CC);
+                                             mval);
                     }
                     mval = zend_symtable_str_find(Z_ARRVAL_P(mstatus), ZEND_STRL("failed"));
                     if (mval) {
                         zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("error_count"),
-                                             mval TSRMLS_CC);
+                                             mval);
                     }
                     break;
                 }
             }
-            zend_update_property(pcbc_search_result_impl_ce, return_value, ZEND_STRL("meta"), &meta TSRMLS_CC);
+            zend_update_property(pcbc_search_result_impl_ce, return_value, ZEND_STRL("meta"), &meta);
             mval = zend_symtable_str_find(marr, ZEND_STRL("facets"));
             if (mval) {
-                zend_update_property(pcbc_search_result_impl_ce, return_value, ZEND_STRL("facets"), mval TSRMLS_CC);
+                zend_update_property(pcbc_search_result_impl_ce, return_value, ZEND_STRL("facets"), mval);
             }
             zval_ptr_dtor(&meta);
             zval_dtor(&value);
@@ -119,7 +117,7 @@ PHP_METHOD(Cluster, searchQuery)
     zval *options = NULL;
     int rv;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SO|O!", &index, &query, pcbc_search_query_ce, &options,
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "SO|O!", &index, &query, pcbc_search_query_ce, &options,
                                pcbc_search_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
@@ -135,7 +133,7 @@ PHP_METHOD(Cluster, searchQuery)
         zval values;
         PCBC_STRING(fname, "jsonSerialize");
         ZVAL_UNDEF(&values);
-        rv = call_user_function_ex(EG(function_table), options, &fname, &values, 0, NULL, 1, NULL TSRMLS_CC);
+        rv = call_user_function_ex(EG(function_table), options, &fname, &values, 0, NULL, 1, NULL);
         if (rv != FAILURE && !EG(exception) && !Z_ISUNDEF(values)) {
             zend_hash_merge(HASH_OF(&payload), HASH_OF(&values), NULL, 0);
         }
@@ -163,7 +161,7 @@ PHP_METHOD(Cluster, searchQuery)
     object_init_ex(return_value, pcbc_search_result_impl_ce);
     zval hits;
     array_init(&hits);
-    zend_update_property(pcbc_search_result_impl_ce, return_value, ZEND_STRL("rows"), &hits TSRMLS_CC);
+    zend_update_property(pcbc_search_result_impl_ce, return_value, ZEND_STRL("rows"), &hits);
     Z_DELREF(hits);
     struct search_cookie cookie = {LCB_SUCCESS, return_value};
 

--- a/src/couchbase/bucket/cbft.c
+++ b/src/couchbase/bucket/cbft.c
@@ -33,7 +33,7 @@ static void ftsrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RESP
     cookie->rc = lcb_respsearch_status(resp);
     zval *return_value = cookie->return_value;
 
-    zend_update_property_long(pcbc_search_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_search_result_impl_ce, return_value, ("status"), cookie->rc);
 
     const char *row = NULL;
     size_t nrow = 0;
@@ -55,19 +55,19 @@ static void ftsrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RESP
 
             mval = zend_symtable_str_find(marr, ZEND_STRL("took"));
             if (mval) {
-                zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("took"), mval);
+                pcbc_update_property(pcbc_search_meta_data_impl_ce, &meta, ("took"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("total_hits"));
             if (mval) {
-                zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("total_hits"), mval);
+                pcbc_update_property(pcbc_search_meta_data_impl_ce, &meta, ("total_hits"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("max_score"));
             if (mval) {
-                zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("max_score"), mval);
+                pcbc_update_property(pcbc_search_meta_data_impl_ce, &meta, ("max_score"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("metrics"));
             if (mval) {
-                zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("metrics"), mval);
+                pcbc_update_property(pcbc_search_meta_data_impl_ce, &meta, ("metrics"), mval);
             }
 
             mstatus = zend_symtable_str_find(marr, ZEND_STRL("status"));
@@ -75,35 +75,35 @@ static void ftsrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RESP
                 switch (Z_TYPE_P(mstatus)) {
                 case IS_STRING:
                     // TODO: read and expose value in "error" key
-                    zend_update_property_stringl(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("status"),
+                    pcbc_update_property_stringl(pcbc_search_meta_data_impl_ce, &meta, ("status"),
                                                  Z_STRVAL_P(mstatus), Z_STRLEN_P(mstatus));
                     break;
                 case IS_ARRAY:
-                    zend_update_property_string(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("status"),
+                    pcbc_update_property_string(pcbc_search_meta_data_impl_ce, &meta, ("status"),
                                                 "success");
                     mval = zend_symtable_str_find(Z_ARRVAL_P(mstatus), ZEND_STRL("successful"));
                     if (mval) {
-                        zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("success_count"),
+                        pcbc_update_property(pcbc_search_meta_data_impl_ce, &meta, ("success_count"),
                                              mval);
                     }
                     mval = zend_symtable_str_find(Z_ARRVAL_P(mstatus), ZEND_STRL("failed"));
                     if (mval) {
-                        zend_update_property(pcbc_search_meta_data_impl_ce, &meta, ZEND_STRL("error_count"),
+                        pcbc_update_property(pcbc_search_meta_data_impl_ce, &meta, ("error_count"),
                                              mval);
                     }
                     break;
                 }
             }
-            zend_update_property(pcbc_search_result_impl_ce, return_value, ZEND_STRL("meta"), &meta);
+            pcbc_update_property(pcbc_search_result_impl_ce, return_value, ("meta"), &meta);
             mval = zend_symtable_str_find(marr, ZEND_STRL("facets"));
             if (mval) {
-                zend_update_property(pcbc_search_result_impl_ce, return_value, ZEND_STRL("facets"), mval);
+                pcbc_update_property(pcbc_search_result_impl_ce, return_value, ("facets"), mval);
             }
             zval_ptr_dtor(&meta);
             zval_dtor(&value);
         } else {
             zval *hits, rv;
-            hits = zend_read_property(pcbc_search_result_impl_ce, return_value, ZEND_STRL("rows"), 0, &rv);
+            hits = pcbc_read_property(pcbc_search_result_impl_ce, return_value, ("rows"), 0, &rv);
             add_next_index_zval(hits, &value);
         }
     }
@@ -161,7 +161,7 @@ PHP_METHOD(Cluster, searchQuery)
     object_init_ex(return_value, pcbc_search_result_impl_ce);
     zval hits;
     array_init(&hits);
-    zend_update_property(pcbc_search_result_impl_ce, return_value, ZEND_STRL("rows"), &hits);
+    pcbc_update_property(pcbc_search_result_impl_ce, return_value, ("rows"), &hits);
     Z_DELREF(hits);
     struct search_cookie cookie = {LCB_SUCCESS, return_value};
 

--- a/src/couchbase/bucket/counter.c
+++ b/src/couchbase/bucket/counter.c
@@ -33,7 +33,7 @@ void counter_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPCOUNTER 
     lcb_respcounter_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respcounter_status(resp);
-    zend_update_property_long(pcbc_counter_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_counter_result_impl_ce, return_value, ("status"), cookie->rc);
     lcb_respcounter_error_context(resp, &ectx);
 
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_counter_result_impl_ce, "err_ctx");
@@ -43,14 +43,14 @@ void counter_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPCOUNTER 
     if (cookie->rc == LCB_SUCCESS) {
         uint64_t value = 0;
         lcb_respcounter_value(resp, &value);
-        zend_update_property_long(pcbc_counter_result_impl_ce, return_value, ZEND_STRL("content"), value);
+        pcbc_update_property_long(pcbc_counter_result_impl_ce, return_value, ("content"), value);
 
         zend_string *b64;
         {
             uint64_t data;
             lcb_respcounter_cas(resp, &data);
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_counter_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
+            pcbc_update_property_str(pcbc_counter_result_impl_ce, return_value, ("cas"), b64);
             zend_string_release(b64);
         }
         {
@@ -60,22 +60,22 @@ void counter_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPCOUNTER 
                 zval val;
                 object_init_ex(&val, pcbc_mutation_token_impl_ce);
 
-                zend_update_property_long(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_id"),
+                pcbc_update_property_long(pcbc_mutation_token_impl_ce, &val, ("partition_id"),
                                           token.vbid_);
                 b64 = php_base64_encode((unsigned char *)&token.uuid_, sizeof(token.uuid_));
-                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_uuid"), b64);
+                pcbc_update_property_str(pcbc_mutation_token_impl_ce, &val, ("partition_uuid"), b64);
                 zend_string_release(b64);
                 b64 = php_base64_encode((unsigned char *)&token.seqno_, sizeof(token.seqno_));
-                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("sequence_number"),
+                pcbc_update_property_str(pcbc_mutation_token_impl_ce, &val, ("sequence_number"),
                                          b64);
                 zend_string_release(b64);
 
                 const char *bucket;
                 lcb_cntl(instance, LCB_CNTL_GET, LCB_CNTL_BUCKETNAME, &bucket);
-                zend_update_property_string(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("bucket_name"),
+                pcbc_update_property_string(pcbc_mutation_token_impl_ce, &val, ("bucket_name"),
                                             bucket);
 
-                zend_update_property(pcbc_counter_result_impl_ce, return_value, ZEND_STRL("mutation_token"),
+                pcbc_update_property(pcbc_counter_result_impl_ce, return_value, ("mutation_token"),
                                      &val);
                 zval_ptr_dtor(&val);
             }
@@ -92,7 +92,7 @@ PHP_METHOD(IncrementOptions, expiry)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("expiry"), arg);
+    pcbc_update_property_long(pcbc_increment_options_ce, getThis(), ("expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -103,7 +103,7 @@ PHP_METHOD(IncrementOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_increment_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -114,7 +114,7 @@ PHP_METHOD(IncrementOptions, durabilityLevel)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
+    pcbc_update_property_long(pcbc_increment_options_ce, getThis(), ("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -125,7 +125,7 @@ PHP_METHOD(IncrementOptions, delta)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("delta"), arg);
+    pcbc_update_property_long(pcbc_increment_options_ce, getThis(), ("delta"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -136,7 +136,7 @@ PHP_METHOD(IncrementOptions, initial)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("initial"), arg);
+    pcbc_update_property_long(pcbc_increment_options_ce, getThis(), ("initial"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -147,7 +147,7 @@ PHP_METHOD(IncrementOptions, cas)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_increment_options_ce, getThis(), ZEND_STRL("cas"), arg);
+    pcbc_update_property_str(pcbc_increment_options_ce, getThis(), ("cas"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -206,27 +206,27 @@ PHP_METHOD(BinaryCollection, increment)
     lcb_cmdcounter_delta(cmd, +1);
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_increment_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_increment_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdcounter_timeout(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_increment_options_ce, options, ZEND_STRL("durability_level"), 0, &ret);
+        prop = pcbc_read_property(pcbc_increment_options_ce, options, ("durability_level"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdcounter_durability(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_increment_options_ce, options, ZEND_STRL("expiry"), 0, &ret);
+        prop = pcbc_read_property(pcbc_increment_options_ce, options, ("expiry"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdcounter_expiry(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_increment_options_ce, options, ZEND_STRL("delta"), 0, &ret);
+        prop = pcbc_read_property(pcbc_increment_options_ce, options, ("delta"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG && Z_LVAL_P(prop) > 0) {
             lcb_cmdcounter_delta(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_increment_options_ce, options, ZEND_STRL("initial"), 0, &ret);
+        prop = pcbc_read_property(pcbc_increment_options_ce, options, ("initial"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdcounter_initial(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_increment_options_ce, options, ZEND_STRL("cas"), 0, &ret);
+        prop = pcbc_read_property(pcbc_increment_options_ce, options, ("cas"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             zend_string *decoded = php_base64_decode_str(Z_STR_P(prop));
             if (decoded) {
@@ -274,7 +274,7 @@ PHP_METHOD(DecrementOptions, expiry)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("expiry"), arg);
+    pcbc_update_property_long(pcbc_decrement_options_ce, getThis(), ("expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -285,7 +285,7 @@ PHP_METHOD(DecrementOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_decrement_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -296,7 +296,7 @@ PHP_METHOD(DecrementOptions, durabilityLevel)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
+    pcbc_update_property_long(pcbc_decrement_options_ce, getThis(), ("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -307,7 +307,7 @@ PHP_METHOD(DecrementOptions, delta)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("delta"), arg);
+    pcbc_update_property_long(pcbc_decrement_options_ce, getThis(), ("delta"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -318,7 +318,7 @@ PHP_METHOD(DecrementOptions, initial)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("initial"), arg);
+    pcbc_update_property_long(pcbc_decrement_options_ce, getThis(), ("initial"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -329,7 +329,7 @@ PHP_METHOD(DecrementOptions, cas)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_decrement_options_ce, getThis(), ZEND_STRL("cas"), arg);
+    pcbc_update_property_str(pcbc_decrement_options_ce, getThis(), ("cas"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -388,27 +388,27 @@ PHP_METHOD(BinaryCollection, decrement)
     lcb_cmdcounter_delta(cmd, -1);
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_decrement_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_decrement_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdcounter_timeout(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_decrement_options_ce, options, ZEND_STRL("durability_level"), 0, &ret);
+        prop = pcbc_read_property(pcbc_decrement_options_ce, options, ("durability_level"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdcounter_durability(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_decrement_options_ce, options, ZEND_STRL("expiry"), 0, &ret);
+        prop = pcbc_read_property(pcbc_decrement_options_ce, options, ("expiry"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdcounter_expiry(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_decrement_options_ce, options, ZEND_STRL("delta"), 0, &ret);
+        prop = pcbc_read_property(pcbc_decrement_options_ce, options, ("delta"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG && Z_LVAL_P(prop) > 0) {
             lcb_cmdcounter_delta(cmd, -1 * Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_decrement_options_ce, options, ZEND_STRL("initial"), 0, &ret);
+        prop = pcbc_read_property(pcbc_decrement_options_ce, options, ("initial"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdcounter_initial(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_decrement_options_ce, options, ZEND_STRL("cas"), 0, &ret);
+        prop = pcbc_read_property(pcbc_decrement_options_ce, options, ("cas"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             zend_string *decoded = php_base64_decode_str(Z_STR_P(prop));
             if (decoded) {

--- a/src/couchbase/bucket/counter.c
+++ b/src/couchbase/bucket/counter.c
@@ -28,14 +28,12 @@ struct counter_cookie {
 
 void counter_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPCOUNTER *resp)
 {
-    TSRMLS_FETCH();
-
     const lcb_KEY_VALUE_ERROR_CONTEXT *ectx = NULL;
     struct counter_cookie *cookie = NULL;
     lcb_respcounter_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respcounter_status(resp);
-    zend_update_property_long(pcbc_counter_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
+    zend_update_property_long(pcbc_counter_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
     lcb_respcounter_error_context(resp, &ectx);
 
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_counter_result_impl_ce, "err_ctx");
@@ -45,14 +43,14 @@ void counter_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPCOUNTER 
     if (cookie->rc == LCB_SUCCESS) {
         uint64_t value = 0;
         lcb_respcounter_value(resp, &value);
-        zend_update_property_long(pcbc_counter_result_impl_ce, return_value, ZEND_STRL("content"), value TSRMLS_CC);
+        zend_update_property_long(pcbc_counter_result_impl_ce, return_value, ZEND_STRL("content"), value);
 
         zend_string *b64;
         {
             uint64_t data;
             lcb_respcounter_cas(resp, &data);
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_counter_result_impl_ce, return_value, ZEND_STRL("cas"), b64 TSRMLS_CC);
+            zend_update_property_str(pcbc_counter_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
             zend_string_release(b64);
         }
         {
@@ -63,22 +61,22 @@ void counter_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPCOUNTER 
                 object_init_ex(&val, pcbc_mutation_token_impl_ce);
 
                 zend_update_property_long(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_id"),
-                                          token.vbid_ TSRMLS_CC);
+                                          token.vbid_);
                 b64 = php_base64_encode((unsigned char *)&token.uuid_, sizeof(token.uuid_));
-                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_uuid"), b64 TSRMLS_CC);
+                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_uuid"), b64);
                 zend_string_release(b64);
                 b64 = php_base64_encode((unsigned char *)&token.seqno_, sizeof(token.seqno_));
                 zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("sequence_number"),
-                                         b64 TSRMLS_CC);
+                                         b64);
                 zend_string_release(b64);
 
                 const char *bucket;
                 lcb_cntl(instance, LCB_CNTL_GET, LCB_CNTL_BUCKETNAME, &bucket);
                 zend_update_property_string(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("bucket_name"),
-                                            bucket TSRMLS_CC);
+                                            bucket);
 
                 zend_update_property(pcbc_counter_result_impl_ce, return_value, ZEND_STRL("mutation_token"),
-                                     &val TSRMLS_CC);
+                                     &val);
                 zval_ptr_dtor(&val);
             }
         }
@@ -90,66 +88,66 @@ zend_class_entry *pcbc_increment_options_ce;
 PHP_METHOD(IncrementOptions, expiry)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("expiry"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(IncrementOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(IncrementOptions, durabilityLevel)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("durability_level"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(IncrementOptions, delta)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("delta"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("delta"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(IncrementOptions, initial)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("initial"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_increment_options_ce, getThis(), ZEND_STRL("initial"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(IncrementOptions, cas)
 {
     zend_string *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_increment_options_ce, getThis(), ZEND_STRL("cas"), arg TSRMLS_CC);
+    zend_update_property_str(pcbc_increment_options_ce, getThis(), ZEND_STRL("cas"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -195,7 +193,7 @@ PHP_METHOD(BinaryCollection, increment)
     zend_string *id;
     zval *options = NULL;
 
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S|O!", &id, &options, pcbc_increment_options_ce);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S|O!", &id, &options, pcbc_increment_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -272,66 +270,66 @@ zend_class_entry *pcbc_decrement_options_ce;
 PHP_METHOD(DecrementOptions, expiry)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("expiry"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(DecrementOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(DecrementOptions, durabilityLevel)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("durability_level"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(DecrementOptions, delta)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("delta"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("delta"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(DecrementOptions, initial)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("initial"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_decrement_options_ce, getThis(), ZEND_STRL("initial"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(DecrementOptions, cas)
 {
     zend_string *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_decrement_options_ce, getThis(), ZEND_STRL("cas"), arg TSRMLS_CC);
+    zend_update_property_str(pcbc_decrement_options_ce, getThis(), ZEND_STRL("cas"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -377,7 +375,7 @@ PHP_METHOD(BinaryCollection, decrement)
     zend_string *id;
     zval *options = NULL;
 
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S|O!", &id, &options, pcbc_decrement_options_ce);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S|O!", &id, &options, pcbc_decrement_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -454,22 +452,22 @@ PHP_MINIT_FUNCTION(CollectionCounter)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "IncrementOptions", pcbc_increment_options_methods);
-    pcbc_increment_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_increment_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_increment_options_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_increment_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_increment_options_ce, ZEND_STRL("delta"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_increment_options_ce, ZEND_STRL("initial"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_increment_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_increment_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_increment_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_increment_options_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_increment_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_increment_options_ce, ZEND_STRL("delta"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_increment_options_ce, ZEND_STRL("initial"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_increment_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "DecrementOptions", pcbc_decrement_options_methods);
-    pcbc_decrement_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_decrement_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_decrement_options_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_decrement_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_decrement_options_ce, ZEND_STRL("delta"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_decrement_options_ce, ZEND_STRL("initial"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_decrement_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_decrement_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_decrement_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_decrement_options_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_decrement_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_decrement_options_ce, ZEND_STRL("delta"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_decrement_options_ce, ZEND_STRL("initial"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_decrement_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/bucket/exists.c
+++ b/src/couchbase/bucket/exists.c
@@ -27,27 +27,25 @@ struct exists_cookie {
 
 void exists_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPEXISTS *resp)
 {
-    TSRMLS_FETCH();
-
     const lcb_KEY_VALUE_ERROR_CONTEXT *ectx = NULL;
     struct exists_cookie *cookie = NULL;
     lcb_respexists_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respexists_status(resp);
-    zend_update_property_long(pcbc_exists_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
+    zend_update_property_long(pcbc_exists_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
     lcb_respexists_error_context(resp, &ectx);
 
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_exists_result_impl_ce, "err_ctx");
     set_property_str(ectx, lcb_errctx_kv_ref, pcbc_exists_result_impl_ce, "err_ref");
     set_property_str(ectx, lcb_errctx_kv_key, pcbc_exists_result_impl_ce, "key");
     zend_update_property_bool(pcbc_exists_result_impl_ce, return_value, ZEND_STRL("is_found"),
-                              lcb_respexists_is_found(resp) TSRMLS_CC);
+                              lcb_respexists_is_found(resp));
     if (cookie->rc == LCB_SUCCESS) {
         uint64_t data;
         lcb_respexists_cas(resp, &data);
         zend_string *b64;
         b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-        zend_update_property_str(pcbc_exists_result_impl_ce, return_value, ZEND_STRL("cas"), b64 TSRMLS_CC);
+        zend_update_property_str(pcbc_exists_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
         zend_string_release(b64);
     }
 }
@@ -57,11 +55,11 @@ zend_class_entry *pcbc_exists_options_ce;
 PHP_METHOD(ExistsOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_exists_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_exists_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -131,8 +129,8 @@ PHP_MINIT_FUNCTION(CollectionExists)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ExistsOptions", pcbc_exists_options_methods);
-    pcbc_exists_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_exists_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_exists_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_exists_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/bucket/exists.c
+++ b/src/couchbase/bucket/exists.c
@@ -32,20 +32,20 @@ void exists_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPEXISTS *r
     lcb_respexists_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respexists_status(resp);
-    zend_update_property_long(pcbc_exists_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_exists_result_impl_ce, return_value, ("status"), cookie->rc);
     lcb_respexists_error_context(resp, &ectx);
 
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_exists_result_impl_ce, "err_ctx");
     set_property_str(ectx, lcb_errctx_kv_ref, pcbc_exists_result_impl_ce, "err_ref");
     set_property_str(ectx, lcb_errctx_kv_key, pcbc_exists_result_impl_ce, "key");
-    zend_update_property_bool(pcbc_exists_result_impl_ce, return_value, ZEND_STRL("is_found"),
+    pcbc_update_property_bool(pcbc_exists_result_impl_ce, return_value, ("is_found"),
                               lcb_respexists_is_found(resp));
     if (cookie->rc == LCB_SUCCESS) {
         uint64_t data;
         lcb_respexists_cas(resp, &data);
         zend_string *b64;
         b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-        zend_update_property_str(pcbc_exists_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
+        pcbc_update_property_str(pcbc_exists_result_impl_ce, return_value, ("cas"), b64);
         zend_string_release(b64);
     }
 }
@@ -59,7 +59,7 @@ PHP_METHOD(ExistsOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_exists_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_exists_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -92,7 +92,7 @@ PHP_METHOD(Collection, exists)
     lcb_cmdexists_key(cmd, ZSTR_VAL(id), ZSTR_LEN(id));
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_exists_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_exists_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdexists_timeout(cmd, Z_LVAL_P(prop));
         }

--- a/src/couchbase/bucket/get.c
+++ b/src/couchbase/bucket/get.c
@@ -32,7 +32,7 @@ void get_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPGET *resp)
     lcb_respget_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respget_status(resp);
-    zend_update_property_long(pcbc_get_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_get_result_impl_ce, return_value, ("status"), cookie->rc);
     lcb_respget_error_context(resp, &ectx);
 
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_get_result_impl_ce, "err_ctx");
@@ -47,7 +47,7 @@ void get_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPGET *resp)
             lcb_respget_cas(resp, &data);
             zend_string *b64;
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_get_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
+            pcbc_update_property_str(pcbc_get_result_impl_ce, return_value, ("cas"), b64);
             zend_string_release(b64);
         }
     }
@@ -62,7 +62,7 @@ PHP_METHOD(GetOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_get_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_get_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -73,7 +73,7 @@ PHP_METHOD(GetOptions, withExpiry)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_get_options_ce, getThis(), ZEND_STRL("with_expiry"), arg);
+    pcbc_update_property_bool(pcbc_get_options_ce, getThis(), ("with_expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -84,7 +84,7 @@ PHP_METHOD(GetOptions, project)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property(pcbc_get_options_ce, getThis(), ZEND_STRL("project"), arg);
+    pcbc_update_property(pcbc_get_options_ce, getThis(), ("project"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -127,7 +127,7 @@ PHP_METHOD(Collection, get)
     lcb_cmdget_key(cmd, ZSTR_VAL(id), ZSTR_LEN(id));
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_get_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_get_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdget_timeout(cmd, Z_LVAL_P(prop));
         }
@@ -168,7 +168,7 @@ PHP_METHOD(GetAndLockOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_get_and_lock_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_get_and_lock_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -203,7 +203,7 @@ PHP_METHOD(Collection, getAndLock)
 
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_get_and_lock_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_get_and_lock_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdget_timeout(cmd, Z_LVAL_P(prop));
         }
@@ -242,7 +242,7 @@ PHP_METHOD(GetAndTouchOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_get_and_touch_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_get_and_touch_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -279,7 +279,7 @@ PHP_METHOD(Collection, getAndTouch)
 
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_get_and_touch_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_get_and_touch_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdget_timeout(cmd, Z_LVAL_P(prop));
         }

--- a/src/couchbase/bucket/get.c
+++ b/src/couchbase/bucket/get.c
@@ -27,14 +27,12 @@ struct get_cookie {
 
 void get_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPGET *resp)
 {
-    TSRMLS_FETCH();
-
     struct get_cookie *cookie = NULL;
     const lcb_KEY_VALUE_ERROR_CONTEXT *ectx = NULL;
     lcb_respget_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respget_status(resp);
-    zend_update_property_long(pcbc_get_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
+    zend_update_property_long(pcbc_get_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
     lcb_respget_error_context(resp, &ectx);
 
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_get_result_impl_ce, "err_ctx");
@@ -49,7 +47,7 @@ void get_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPGET *resp)
             lcb_respget_cas(resp, &data);
             zend_string *b64;
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_get_result_impl_ce, return_value, ZEND_STRL("cas"), b64 TSRMLS_CC);
+            zend_update_property_str(pcbc_get_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
             zend_string_release(b64);
         }
     }
@@ -60,33 +58,33 @@ zend_class_entry *pcbc_get_options_ce;
 PHP_METHOD(GetOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_get_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_get_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(GetOptions, withExpiry)
 {
     zend_bool arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "b", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_get_options_ce, getThis(), ZEND_STRL("with_expiry"), arg TSRMLS_CC);
+    zend_update_property_bool(pcbc_get_options_ce, getThis(), ZEND_STRL("with_expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(GetOptions, project)
 {
     zval *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "a", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property(pcbc_get_options_ce, getThis(), ZEND_STRL("project"), arg TSRMLS_CC);
+    zend_update_property(pcbc_get_options_ce, getThis(), ZEND_STRL("project"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -166,11 +164,11 @@ zend_class_entry *pcbc_get_and_lock_options_ce;
 PHP_METHOD(GetAndLockOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_get_and_lock_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_get_and_lock_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -190,7 +188,7 @@ PHP_METHOD(Collection, getAndLock)
     zend_long expiry;
     lcb_STATUS err;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sl|O!", &id, &expiry, &options,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sl|O!", &id, &expiry, &options,
                                          pcbc_get_and_lock_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
@@ -240,11 +238,11 @@ zend_class_entry *pcbc_get_and_touch_options_ce;
 PHP_METHOD(GetAndTouchOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_get_and_touch_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_get_and_touch_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -266,7 +264,7 @@ PHP_METHOD(Collection, getAndTouch)
     zend_long expiry;
     lcb_STATUS err;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sl|O!", &id, &expiry, &options,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sl|O!", &id, &expiry, &options,
                                          pcbc_get_and_touch_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
@@ -316,18 +314,18 @@ PHP_MINIT_FUNCTION(CollectionGet)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GetOptions", pcbc_get_options_methods);
-    pcbc_get_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_options_ce, ZEND_STRL("with_expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_options_ce, ZEND_STRL("project"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_get_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_get_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_options_ce, ZEND_STRL("with_expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_options_ce, ZEND_STRL("project"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GetAndTouchOptions", pcbc_get_and_touch_options_methods);
-    pcbc_get_and_touch_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_and_touch_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_get_and_touch_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_get_and_touch_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GetAndLockOptions", pcbc_get_and_lock_options_methods);
-    pcbc_get_and_lock_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_and_lock_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_get_and_lock_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_get_and_lock_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/bucket/get_replica.c
+++ b/src/couchbase/bucket/get_replica.c
@@ -41,14 +41,14 @@ void getreplica_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPGETRE
     }
 
     cookie->rc = lcb_respgetreplica_status(resp);
-    zend_update_property_long(pcbc_get_replica_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_get_replica_result_impl_ce, return_value, ("status"), cookie->rc);
     lcb_respgetreplica_error_context(resp, &ectx);
 
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_get_replica_result_impl_ce, "err_ctx");
     set_property_str(ectx, lcb_errctx_kv_ref, pcbc_get_replica_result_impl_ce, "err_ref");
     set_property_str(ectx, lcb_errctx_kv_key, pcbc_get_replica_result_impl_ce, "key");
     /* TODO: shall libcouchbase query master for replica? */
-    zend_update_property_bool(pcbc_get_replica_result_impl_ce, return_value, ZEND_STRL("is_replica"), 1);
+    pcbc_update_property_bool(pcbc_get_replica_result_impl_ce, return_value, ("is_replica"), 1);
     if (cookie->rc == LCB_SUCCESS) {
         set_property_num(uint32_t, lcb_respgetreplica_flags, pcbc_get_replica_result_impl_ce, "flags");
         set_property_num(uint8_t, lcb_respgetreplica_datatype, pcbc_get_replica_result_impl_ce, "datatype");
@@ -58,7 +58,7 @@ void getreplica_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPGETRE
             lcb_respgetreplica_cas(resp, &data);
             zend_string *b64;
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_get_replica_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
+            pcbc_update_property_str(pcbc_get_replica_result_impl_ce, return_value, ("cas"), b64);
             zend_string_release(b64);
         }
     }
@@ -73,7 +73,7 @@ PHP_METHOD(GetAnyReplicaOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_get_any_replica_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_get_any_replica_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -107,7 +107,7 @@ PHP_METHOD(Collection, getAnyReplica)
     lcb_cmdgetreplica_key(cmd, ZSTR_VAL(id), ZSTR_LEN(id));
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_get_any_replica_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_get_any_replica_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdgetreplica_timeout(cmd, Z_LVAL_P(prop));
         }
@@ -146,7 +146,7 @@ PHP_METHOD(GetAllReplicasOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_get_all_replicas_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_get_all_replicas_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -180,7 +180,7 @@ PHP_METHOD(Collection, getAllReplicas)
     lcb_cmdgetreplica_key(cmd, ZSTR_VAL(id), ZSTR_LEN(id));
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_get_all_replicas_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_get_all_replicas_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdgetreplica_timeout(cmd, Z_LVAL_P(prop));
         }

--- a/src/couchbase/bucket/get_replica.c
+++ b/src/couchbase/bucket/get_replica.c
@@ -28,8 +28,6 @@ struct get_replica_cookie {
 
 void getreplica_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPGETREPLICA *resp)
 {
-    TSRMLS_FETCH();
-
     const lcb_KEY_VALUE_ERROR_CONTEXT *ectx = NULL;
     struct get_replica_cookie *cookie = NULL;
     lcb_respgetreplica_cookie(resp, (void **)&cookie);
@@ -43,14 +41,14 @@ void getreplica_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPGETRE
     }
 
     cookie->rc = lcb_respgetreplica_status(resp);
-    zend_update_property_long(pcbc_get_replica_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
+    zend_update_property_long(pcbc_get_replica_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
     lcb_respgetreplica_error_context(resp, &ectx);
 
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_get_replica_result_impl_ce, "err_ctx");
     set_property_str(ectx, lcb_errctx_kv_ref, pcbc_get_replica_result_impl_ce, "err_ref");
     set_property_str(ectx, lcb_errctx_kv_key, pcbc_get_replica_result_impl_ce, "key");
     /* TODO: shall libcouchbase query master for replica? */
-    zend_update_property_bool(pcbc_get_replica_result_impl_ce, return_value, ZEND_STRL("is_replica"), 1 TSRMLS_CC);
+    zend_update_property_bool(pcbc_get_replica_result_impl_ce, return_value, ZEND_STRL("is_replica"), 1);
     if (cookie->rc == LCB_SUCCESS) {
         set_property_num(uint32_t, lcb_respgetreplica_flags, pcbc_get_replica_result_impl_ce, "flags");
         set_property_num(uint8_t, lcb_respgetreplica_datatype, pcbc_get_replica_result_impl_ce, "datatype");
@@ -60,7 +58,7 @@ void getreplica_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPGETRE
             lcb_respgetreplica_cas(resp, &data);
             zend_string *b64;
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_get_replica_result_impl_ce, return_value, ZEND_STRL("cas"), b64 TSRMLS_CC);
+            zend_update_property_str(pcbc_get_replica_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
             zend_string_release(b64);
         }
     }
@@ -71,11 +69,11 @@ zend_class_entry *pcbc_get_any_replica_options_ce;
 PHP_METHOD(GetAnyReplicaOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_get_any_replica_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_get_any_replica_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -97,7 +95,7 @@ PHP_METHOD(Collection, getAnyReplica)
     lcb_STATUS err;
 
     int rv =
-        zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|O!", &id, &options, pcbc_get_any_replica_options_ce);
+        zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|O!", &id, &options, pcbc_get_any_replica_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -144,11 +142,11 @@ zend_class_entry *pcbc_get_all_replicas_options_ce;
 PHP_METHOD(GetAllReplicasOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_get_all_replicas_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_get_all_replicas_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -170,7 +168,7 @@ PHP_METHOD(Collection, getAllReplicas)
     lcb_STATUS err;
 
     int rv =
-        zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|O!", &id, &options, pcbc_get_all_replicas_options_ce);
+        zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|O!", &id, &options, pcbc_get_all_replicas_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -217,12 +215,12 @@ PHP_MINIT_FUNCTION(CollectionGetReplica)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GetAllReplicasOptions", pcbc_get_all_replicas_options_methods);
-    pcbc_get_all_replicas_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_all_replicas_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_get_all_replicas_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_get_all_replicas_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GetAnyReplicaOptions", pcbc_get_any_replica_options_methods);
-    pcbc_get_any_replica_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_any_replica_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_get_any_replica_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_get_any_replica_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/bucket/health.c
+++ b/src/couchbase/bucket/health.c
@@ -23,7 +23,7 @@ typedef struct {
     zval val;
 } opcookie_health_res;
 
-static lcb_STATUS proc_health_results(zval *return_value, opcookie *cookie TSRMLS_DC)
+static lcb_STATUS proc_health_results(zval *return_value, opcookie *cookie)
 {
     opcookie_health_res *res;
     lcb_STATUS err = LCB_SUCCESS;
@@ -47,7 +47,6 @@ static lcb_STATUS proc_health_results(zval *return_value, opcookie *cookie TSRML
 void ping_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPPING *resp)
 {
     opcookie_health_res *result = ecalloc(1, sizeof(opcookie_health_res));
-    TSRMLS_FETCH();
 
     result->header.err = lcb_respping_status(resp);
     if (result->header.err == LCB_SUCCESS) {
@@ -75,7 +74,7 @@ PHP_METHOD(Bucket, ping)
     int rv;
     lcb_STATUS err;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|z", &options);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "|z", &options);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -92,7 +91,7 @@ PHP_METHOD(Bucket, ping)
         throw_lcb_exception(err, NULL);
     }
     lcb_wait(obj->conn->lcb, LCB_WAIT_DEFAULT);
-    err = proc_health_results(return_value, cookie TSRMLS_CC);
+    err = proc_health_results(return_value, cookie);
     opcookie_destroy(cookie);
     if (err != LCB_SUCCESS) {
         throw_lcb_exception(err, NULL);
@@ -102,8 +101,6 @@ PHP_METHOD(Bucket, ping)
 void diag_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPDIAG *resp)
 {
     opcookie_health_res *result = ecalloc(1, sizeof(opcookie_health_res));
-
-    TSRMLS_FETCH();
 
     result->header.err = lcb_respdiag_status(resp);
     if (result->header.err == LCB_SUCCESS) {
@@ -131,7 +128,7 @@ PHP_METHOD(Bucket, diagnostics)
     int rv;
     lcb_STATUS err;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|S", &report_id);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "|S", &report_id);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -146,7 +143,7 @@ PHP_METHOD(Bucket, diagnostics)
         throw_lcb_exception(err, NULL);
     }
     lcb_wait(obj->conn->lcb, LCB_WAIT_DEFAULT);
-    err = proc_health_results(return_value, cookie TSRMLS_CC);
+    err = proc_health_results(return_value, cookie);
     opcookie_destroy(cookie);
     if (err != LCB_SUCCESS) {
         throw_lcb_exception(err, NULL);

--- a/src/couchbase/bucket/http.c
+++ b/src/couchbase/bucket/http.c
@@ -117,10 +117,10 @@ static lcb_STATUS proc_http_results(zval *return_value, opcookie *cookie, void *
                             ZSTR_VAL(buf.s)[ZSTR_LEN(buf.s)] = '\0';
                         }
                         object_init_ex(return_value, pcbc_http_exception_ce);
-                        zend_update_property_str(pcbc_default_exception_ce, return_value, ZEND_STRL("message"),
+                        pcbc_update_property_str(pcbc_default_exception_ce, return_value, ("message"),
                                                  buf.s);
                         if (first_query_code) {
-                            zend_update_property_long(pcbc_default_exception_ce, return_value, ZEND_STRL("code"),
+                            pcbc_update_property_long(pcbc_default_exception_ce, return_value, ("code"),
                                                       first_query_code);
                         }
                         smart_str_free(&buf);
@@ -132,7 +132,7 @@ static lcb_STATUS proc_http_results(zval *return_value, opcookie *cookie, void *
                                 object_init_ex(return_value, pcbc_http_exception_ce);
                                 mval = zend_symtable_str_find(marr, ZEND_STRL("error"));
                                 if (mval && Z_TYPE_P(mval) == IS_STRING) {
-                                    zend_update_property(pcbc_default_exception_ce, return_value, ZEND_STRL("message"),
+                                    pcbc_update_property(pcbc_default_exception_ce, return_value, ("message"),
                                                          mval);
                                 }
                                 err = LCB_ERR_HTTP;

--- a/src/couchbase/bucket/n1ql.c
+++ b/src/couchbase/bucket/n1ql.c
@@ -42,7 +42,7 @@ static void n1qlrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
     cookie->rc = lcb_respquery_status(resp);
     zval *return_value = cookie->return_value;
 
-    zend_update_property_long(pcbc_query_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_query_result_impl_ce, return_value, ("status"), cookie->rc);
 
     const char *row = NULL;
     size_t nrow = 0;
@@ -64,44 +64,44 @@ static void n1qlrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
 
             mval = zend_symtable_str_find(marr, ZEND_STRL("status"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("status"), mval);
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("status"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("requestID"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("request_id"), mval);
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("request_id"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("clientContextID"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("client_context_id"),
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("client_context_id"),
                                      mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("signature"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("signature"), mval);
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("signature"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("errors"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("errors"), mval);
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("errors"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("warnings"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("warnings"), mval);
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("warnings"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("metrics"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("metrics"), mval);
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("metrics"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("profile"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("profile"), mval);
+                pcbc_update_property(pcbc_query_meta_data_impl_ce, &meta, ("profile"), mval);
             }
 
-            zend_update_property(pcbc_query_result_impl_ce, return_value, ZEND_STRL("meta"), &meta);
+            pcbc_update_property(pcbc_query_result_impl_ce, return_value, ("meta"), &meta);
             zval_ptr_dtor(&meta);
             zval_dtor(&value);
         } else {
             zval *rows, rv;
-            rows = zend_read_property(pcbc_query_result_impl_ce, return_value, ZEND_STRL("rows"), 0, &rv);
+            rows = pcbc_read_property(pcbc_query_result_impl_ce, return_value, ("rows"), 0, &rv);
             add_next_index_zval(rows, &value);
         }
     }
@@ -120,7 +120,7 @@ PHP_METHOD(QueryOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_query_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -131,8 +131,8 @@ PHP_METHOD(QueryOptions, scanConsistency)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_null(pcbc_query_options_ce, getThis(), ZEND_STRL("consistent_with"));
-    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("scan_consistency"), arg);
+    pcbc_update_property_null(pcbc_query_options_ce, getThis(), ("consistent_with"));
+    pcbc_update_property_long(pcbc_query_options_ce, getThis(), ("scan_consistency"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -143,7 +143,7 @@ PHP_METHOD(QueryOptions, consistentWith)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_null(pcbc_query_options_ce, getThis(), ZEND_STRL("scan_consistency"));
+    pcbc_update_property_null(pcbc_query_options_ce, getThis(), ("scan_consistency"));
 
     zval scan_vectors;
     ZVAL_UNDEF(&scan_vectors);
@@ -158,7 +158,7 @@ PHP_METHOD(QueryOptions, consistentWith)
         RETURN_NULL();
     }
     smart_str_0(&buf);
-    zend_update_property_str(pcbc_query_options_ce, getThis(), ZEND_STRL("consistent_with"), buf.s);
+    pcbc_update_property_str(pcbc_query_options_ce, getThis(), ("consistent_with"), buf.s);
     smart_str_free(&buf);
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -170,7 +170,7 @@ PHP_METHOD(QueryOptions, scanCap)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("scan_cap"), arg);
+    pcbc_update_property_long(pcbc_query_options_ce, getThis(), ("scan_cap"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -181,7 +181,7 @@ PHP_METHOD(QueryOptions, pipelineCap)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("pipeline_cap"), arg);
+    pcbc_update_property_long(pcbc_query_options_ce, getThis(), ("pipeline_cap"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -192,7 +192,7 @@ PHP_METHOD(QueryOptions, pipelineBatch)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("pipeline_batch"), arg);
+    pcbc_update_property_long(pcbc_query_options_ce, getThis(), ("pipeline_batch"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -203,7 +203,7 @@ PHP_METHOD(QueryOptions, maxParallelism)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("max_parallelism"), arg);
+    pcbc_update_property_long(pcbc_query_options_ce, getThis(), ("max_parallelism"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -214,7 +214,7 @@ PHP_METHOD(QueryOptions, clientContextId)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_query_options_ce, getThis(), ZEND_STRL("client_context_id"), arg);
+    pcbc_update_property_str(pcbc_query_options_ce, getThis(), ("client_context_id"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -227,13 +227,13 @@ PHP_METHOD(QueryOptions, profile)
     }
     switch (arg) {
     case PCBC_QUERY_PROFILE_OFF:
-        zend_update_property_string(pcbc_query_options_ce, getThis(), ZEND_STRL("profile"), "\"off\"");
+        pcbc_update_property_string(pcbc_query_options_ce, getThis(), ("profile"), "\"off\"");
         break;
     case PCBC_QUERY_PROFILE_PHASES:
-        zend_update_property_string(pcbc_query_options_ce, getThis(), ZEND_STRL("profile"), "\"phases\"");
+        pcbc_update_property_string(pcbc_query_options_ce, getThis(), ("profile"), "\"phases\"");
         break;
     case PCBC_QUERY_PROFILE_TIMINGS:
-        zend_update_property_string(pcbc_query_options_ce, getThis(), ZEND_STRL("profile"), "\"timings\"");
+        pcbc_update_property_string(pcbc_query_options_ce, getThis(), ("profile"), "\"timings\"");
         break;
     }
 
@@ -247,7 +247,7 @@ PHP_METHOD(QueryOptions, readonly)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_query_options_ce, getThis(), ZEND_STRL("readonly"), arg);
+    pcbc_update_property_bool(pcbc_query_options_ce, getThis(), ("readonly"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -258,7 +258,7 @@ PHP_METHOD(QueryOptions, flexIndex)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_query_options_ce, getThis(), ZEND_STRL("flex_index"), arg);
+    pcbc_update_property_bool(pcbc_query_options_ce, getThis(), ("flex_index"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -269,7 +269,7 @@ PHP_METHOD(QueryOptions, adhoc)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_query_options_ce, getThis(), ZEND_STRL("adhoc"), arg);
+    pcbc_update_property_bool(pcbc_query_options_ce, getThis(), ("adhoc"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -280,7 +280,7 @@ PHP_METHOD(QueryOptions, metrics)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_query_options_ce, getThis(), ZEND_STRL("metrics"), arg);
+    pcbc_update_property_bool(pcbc_query_options_ce, getThis(), ("metrics"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -313,7 +313,7 @@ PHP_METHOD(QueryOptions, namedParameters)
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_query_options_ce, getThis(), ZEND_STRL("named_params"), &params);
+    pcbc_update_property(pcbc_query_options_ce, getThis(), ("named_params"), &params);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -344,7 +344,7 @@ PHP_METHOD(QueryOptions, positionalParameters)
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_query_options_ce, getThis(), ZEND_STRL("positional_params"), &params);
+    pcbc_update_property(pcbc_query_options_ce, getThis(), ("positional_params"), &params);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -358,11 +358,11 @@ PHP_METHOD(QueryOptions, raw)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_query_options_ce, getThis(), ZEND_STRL("raw_params"), 0, &rv1);
+    data = pcbc_read_property(pcbc_query_options_ce, getThis(), ("raw_params"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_query_options_ce, getThis(), ZEND_STRL("raw_params"), data);
+        pcbc_update_property(pcbc_query_options_ce, getThis(), ("raw_params"), data);
     }
     smart_str buf = {0};
     int last_error;
@@ -485,11 +485,11 @@ PHP_METHOD(Cluster, query)
     lcb_cmdquery_statement(cmd, ZSTR_VAL(statement), ZSTR_LEN(statement));
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdquery_timeout(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("scan_consistency"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("scan_consistency"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             zend_long val = Z_LVAL_P(prop);
             switch (val) {
@@ -504,16 +504,16 @@ PHP_METHOD(Cluster, query)
                 break;
             }
         }
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("consistent_with"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("consistent_with"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             lcb_cmdquery_option(cmd, ZEND_STRL("scan_consistency"), ZEND_STRL("\"at_plus\""));
             lcb_cmdquery_option(cmd, ZEND_STRL("scan_vectors"), Z_STRVAL_P(prop), Z_STRLEN_P(prop));
         }
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("client_context_id"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("client_context_id"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             lcb_cmdquery_client_context_id(cmd, Z_STRVAL_P(prop), Z_STRLEN_P(prop));
         }
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("readonly"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("readonly"), 0, &ret);
         switch (Z_TYPE_P(prop)) {
         case IS_TRUE:
             lcb_cmdquery_readonly(cmd, 1);
@@ -522,7 +522,7 @@ PHP_METHOD(Cluster, query)
             lcb_cmdquery_readonly(cmd, 0);
             break;
         }
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("flex_index"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("flex_index"), 0, &ret);
         switch (Z_TYPE_P(prop)) {
         case IS_TRUE:
             lcb_cmdquery_flex_index(cmd, 1);
@@ -531,7 +531,7 @@ PHP_METHOD(Cluster, query)
             lcb_cmdquery_flex_index(cmd, 0);
             break;
         }
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("metrics"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("metrics"), 0, &ret);
         switch (Z_TYPE_P(prop)) {
         case IS_TRUE:
             lcb_cmdquery_metrics(cmd, 1);
@@ -540,7 +540,7 @@ PHP_METHOD(Cluster, query)
             lcb_cmdquery_metrics(cmd, 0);
             break;
         }
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("adhoc"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("adhoc"), 0, &ret);
         switch (Z_TYPE_P(prop)) {
         case IS_TRUE:
             lcb_cmdquery_adhoc(cmd, 1);
@@ -549,19 +549,19 @@ PHP_METHOD(Cluster, query)
             lcb_cmdquery_adhoc(cmd, 0);
             break;
         }
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("scan_cap"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("scan_cap"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdquery_scan_cap(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("pipeline_cap"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("pipeline_cap"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdquery_pipeline_cap(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("pipeline_batch"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("pipeline_batch"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdquery_pipeline_batch(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("named_params"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("named_params"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_ARRAY) {
             HashTable *ht = HASH_OF(prop);
             zend_string *string_key = NULL;
@@ -575,7 +575,7 @@ PHP_METHOD(Cluster, query)
             }
             ZEND_HASH_FOREACH_END();
         }
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("positional_params"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("positional_params"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_ARRAY) {
             HashTable *ht = HASH_OF(prop);
             zval *entry;
@@ -587,7 +587,7 @@ PHP_METHOD(Cluster, query)
             }
             ZEND_HASH_FOREACH_END();
         }
-        prop = zend_read_property(pcbc_query_options_ce, options, ZEND_STRL("raw_params"), 0, &ret);
+        prop = pcbc_read_property(pcbc_query_options_ce, options, ("raw_params"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_ARRAY) {
             HashTable *ht = HASH_OF(prop);
             zend_string *string_key = NULL;
@@ -620,7 +620,7 @@ PHP_METHOD(Cluster, query)
     }
     zval rows;
     array_init(&rows);
-    zend_update_property(pcbc_query_result_impl_ce, return_value, ZEND_STRL("rows"), &rows);
+    pcbc_update_property(pcbc_query_result_impl_ce, return_value, ("rows"), &rows);
     Z_DELREF(rows);
     struct query_cookie cookie = {LCB_SUCCESS, return_value};
     err = lcb_query(cluster->conn->lcb, &cookie, cmd);
@@ -636,10 +636,10 @@ PHP_METHOD(Cluster, query)
         int code = 0;
         char msg[200] = {0};
         zval *meta = NULL, mret;
-        meta = zend_read_property(pcbc_query_result_impl_ce, return_value, ZEND_STRL("meta"), 0, &mret);
+        meta = pcbc_read_property(pcbc_query_result_impl_ce, return_value, ("meta"), 0, &mret);
         if (meta && Z_TYPE_P(meta) == IS_ARRAY) {
             zval *prop, ret;
-            prop = zend_read_property(pcbc_query_meta_data_impl_ce, meta, ZEND_STRL("errors"), 0, &ret);
+            prop = pcbc_read_property(pcbc_query_meta_data_impl_ce, meta, ("errors"), 0, &ret);
             if (Z_TYPE_P(prop) == IS_ARRAY) {
                 HashTable *ht = Z_ARRVAL_P(prop);
                 zval *entry = zend_hash_index_find(ht, 0);

--- a/src/couchbase/bucket/n1ql.c
+++ b/src/couchbase/bucket/n1ql.c
@@ -37,14 +37,12 @@ struct query_cookie {
 
 static void n1qlrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RESPQUERY *resp)
 {
-    TSRMLS_FETCH();
-
     struct query_cookie *cookie;
     lcb_respquery_cookie(resp, (void **)&cookie);
     cookie->rc = lcb_respquery_status(resp);
     zval *return_value = cookie->return_value;
 
-    zend_update_property_long(pcbc_query_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
+    zend_update_property_long(pcbc_query_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
 
     const char *row = NULL;
     size_t nrow = 0;
@@ -66,39 +64,39 @@ static void n1qlrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
 
             mval = zend_symtable_str_find(marr, ZEND_STRL("status"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("status"), mval TSRMLS_CC);
+                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("status"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("requestID"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("request_id"), mval TSRMLS_CC);
+                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("request_id"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("clientContextID"));
             if (mval) {
                 zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("client_context_id"),
-                                     mval TSRMLS_CC);
+                                     mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("signature"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("signature"), mval TSRMLS_CC);
+                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("signature"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("errors"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("errors"), mval TSRMLS_CC);
+                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("errors"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("warnings"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("warnings"), mval TSRMLS_CC);
+                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("warnings"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("metrics"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("metrics"), mval TSRMLS_CC);
+                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("metrics"), mval);
             }
             mval = zend_symtable_str_find(marr, ZEND_STRL("profile"));
             if (mval) {
-                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("profile"), mval TSRMLS_CC);
+                zend_update_property(pcbc_query_meta_data_impl_ce, &meta, ZEND_STRL("profile"), mval);
             }
 
-            zend_update_property(pcbc_query_result_impl_ce, return_value, ZEND_STRL("meta"), &meta TSRMLS_CC);
+            zend_update_property(pcbc_query_result_impl_ce, return_value, ZEND_STRL("meta"), &meta);
             zval_ptr_dtor(&meta);
             zval_dtor(&value);
         } else {
@@ -118,38 +116,38 @@ static const zend_function_entry pcbc_query_profile_methods[] = {PHP_FE_END};
 PHP_METHOD(QueryOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(QueryOptions, scanConsistency)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_null(pcbc_query_options_ce, getThis(), ZEND_STRL("consistent_with") TSRMLS_CC);
-    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("scan_consistency"), arg TSRMLS_CC);
+    zend_update_property_null(pcbc_query_options_ce, getThis(), ZEND_STRL("consistent_with"));
+    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("scan_consistency"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(QueryOptions, consistentWith)
 {
     zval *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &arg, pcbc_mutation_state_ce);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "O", &arg, pcbc_mutation_state_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_null(pcbc_query_options_ce, getThis(), ZEND_STRL("scan_consistency") TSRMLS_CC);
+    zend_update_property_null(pcbc_query_options_ce, getThis(), ZEND_STRL("scan_consistency"));
 
     zval scan_vectors;
     ZVAL_UNDEF(&scan_vectors);
-    pcbc_mutation_state_export_for_n1ql(arg, &scan_vectors TSRMLS_CC);
+    pcbc_mutation_state_export_for_n1ql(arg, &scan_vectors);
     smart_str buf = {0};
     int last_error;
     PCBC_JSON_ENCODE(&buf, &scan_vectors, 0, last_error);
@@ -160,7 +158,7 @@ PHP_METHOD(QueryOptions, consistentWith)
         RETURN_NULL();
     }
     smart_str_0(&buf);
-    zend_update_property_str(pcbc_query_options_ce, getThis(), ZEND_STRL("consistent_with"), buf.s TSRMLS_CC);
+    zend_update_property_str(pcbc_query_options_ce, getThis(), ZEND_STRL("consistent_with"), buf.s);
     smart_str_free(&buf);
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -168,74 +166,74 @@ PHP_METHOD(QueryOptions, consistentWith)
 PHP_METHOD(QueryOptions, scanCap)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("scan_cap"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("scan_cap"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(QueryOptions, pipelineCap)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("pipeline_cap"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("pipeline_cap"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(QueryOptions, pipelineBatch)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("pipeline_batch"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("pipeline_batch"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(QueryOptions, maxParallelism)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("max_parallelism"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_query_options_ce, getThis(), ZEND_STRL("max_parallelism"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(QueryOptions, clientContextId)
 {
     zend_string *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_query_options_ce, getThis(), ZEND_STRL("client_context_id"), arg TSRMLS_CC);
+    zend_update_property_str(pcbc_query_options_ce, getThis(), ZEND_STRL("client_context_id"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(QueryOptions, profile)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
     switch (arg) {
     case PCBC_QUERY_PROFILE_OFF:
-        zend_update_property_string(pcbc_query_options_ce, getThis(), ZEND_STRL("profile"), "\"off\"" TSRMLS_CC);
+        zend_update_property_string(pcbc_query_options_ce, getThis(), ZEND_STRL("profile"), "\"off\"");
         break;
     case PCBC_QUERY_PROFILE_PHASES:
-        zend_update_property_string(pcbc_query_options_ce, getThis(), ZEND_STRL("profile"), "\"phases\"" TSRMLS_CC);
+        zend_update_property_string(pcbc_query_options_ce, getThis(), ZEND_STRL("profile"), "\"phases\"");
         break;
     case PCBC_QUERY_PROFILE_TIMINGS:
-        zend_update_property_string(pcbc_query_options_ce, getThis(), ZEND_STRL("profile"), "\"timings\"" TSRMLS_CC);
+        zend_update_property_string(pcbc_query_options_ce, getThis(), ZEND_STRL("profile"), "\"timings\"");
         break;
     }
 
@@ -245,51 +243,51 @@ PHP_METHOD(QueryOptions, profile)
 PHP_METHOD(QueryOptions, readonly)
 {
     zend_bool arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "b", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_query_options_ce, getThis(), ZEND_STRL("readonly"), arg TSRMLS_CC);
+    zend_update_property_bool(pcbc_query_options_ce, getThis(), ZEND_STRL("readonly"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(QueryOptions, flexIndex)
 {
     zend_bool arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "b", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_query_options_ce, getThis(), ZEND_STRL("flex_index"), arg TSRMLS_CC);
+    zend_update_property_bool(pcbc_query_options_ce, getThis(), ZEND_STRL("flex_index"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(QueryOptions, adhoc)
 {
     zend_bool arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "b", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_query_options_ce, getThis(), ZEND_STRL("adhoc"), arg TSRMLS_CC);
+    zend_update_property_bool(pcbc_query_options_ce, getThis(), ZEND_STRL("adhoc"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(QueryOptions, metrics)
 {
     zend_bool arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "b", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_query_options_ce, getThis(), ZEND_STRL("metrics"), arg TSRMLS_CC);
+    zend_update_property_bool(pcbc_query_options_ce, getThis(), ZEND_STRL("metrics"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(QueryOptions, namedParameters)
 {
     zval *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "a", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -311,18 +309,18 @@ PHP_METHOD(QueryOptions, namedParameters)
                 continue;
             }
             smart_str_0(&buf);
-            add_assoc_str_ex(&params, ZSTR_VAL(string_key), ZSTR_LEN(string_key), buf.s TSRMLS_CC);
+            add_assoc_str_ex(&params, ZSTR_VAL(string_key), ZSTR_LEN(string_key), buf.s);
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_query_options_ce, getThis(), ZEND_STRL("named_params"), &params TSRMLS_CC);
+    zend_update_property(pcbc_query_options_ce, getThis(), ZEND_STRL("named_params"), &params);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(QueryOptions, positionalParameters)
 {
     zval *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "a", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -342,11 +340,11 @@ PHP_METHOD(QueryOptions, positionalParameters)
             RETURN_NULL();
         } else {
             smart_str_0(&buf);
-            add_next_index_str(&params, buf.s TSRMLS_CC);
+            add_next_index_str(&params, buf.s);
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_query_options_ce, getThis(), ZEND_STRL("positional_params"), &params TSRMLS_CC);
+    zend_update_property(pcbc_query_options_ce, getThis(), ZEND_STRL("positional_params"), &params);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -355,7 +353,7 @@ PHP_METHOD(QueryOptions, raw)
 {
     zend_string *key;
     zval *value = NULL;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Sz!", &key, &value);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "Sz!", &key, &value);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -364,7 +362,7 @@ PHP_METHOD(QueryOptions, raw)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_query_options_ce, getThis(), ZEND_STRL("raw_params"), data TSRMLS_CC);
+        zend_update_property(pcbc_query_options_ce, getThis(), ZEND_STRL("raw_params"), data);
     }
     smart_str buf = {0};
     int last_error;
@@ -376,7 +374,7 @@ PHP_METHOD(QueryOptions, raw)
         RETURN_NULL();
     }
     smart_str_0(&buf);
-    add_assoc_str_ex(data, ZSTR_VAL(key), ZSTR_LEN(key), buf.s TSRMLS_CC);
+    add_assoc_str_ex(data, ZSTR_VAL(key), ZSTR_LEN(key), buf.s);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -474,7 +472,7 @@ PHP_METHOD(Cluster, query)
     zend_string *statement;
     zval *options = NULL;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|O!", &statement, &options, pcbc_query_options_ce);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|O!", &statement, &options, pcbc_query_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -622,7 +620,7 @@ PHP_METHOD(Cluster, query)
     }
     zval rows;
     array_init(&rows);
-    zend_update_property(pcbc_query_result_impl_ce, return_value, ZEND_STRL("rows"), &rows TSRMLS_CC);
+    zend_update_property(pcbc_query_result_impl_ce, return_value, ZEND_STRL("rows"), &rows);
     Z_DELREF(rows);
     struct query_cookie cookie = {LCB_SUCCESS, return_value};
     err = lcb_query(cluster->conn->lcb, &cookie, cmd);
@@ -665,39 +663,39 @@ PHP_MINIT_FUNCTION(N1qlQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "QueryOptions", pcbc_query_options_methods);
-    pcbc_query_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_query_options_ce = zend_register_internal_class(&ce);
 
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("adhoc"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("metrics"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("readonly"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("flex_index"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("scan_cap"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("pipeline_batch"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("pipeline_cap"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("scan_consistency"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("consistent_with"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("positional_params"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("named_params"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("raw_params"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("max_parallelism"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("profile"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("client_context_id"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("adhoc"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("metrics"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("readonly"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("flex_index"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("scan_cap"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("pipeline_batch"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("pipeline_cap"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("scan_consistency"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("consistent_with"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("positional_params"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("named_params"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("raw_params"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("max_parallelism"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("profile"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_options_ce, ZEND_STRL("client_context_id"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "QueryScanConsistency", pcbc_query_consistency_methods);
-    pcbc_query_consistency_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_query_consistency_ce = zend_register_internal_interface(&ce);
     zend_declare_class_constant_long(pcbc_query_consistency_ce, ZEND_STRL("NOT_BOUNDED"),
-                                     PCBC_QUERY_CONSISTENCY_NOT_BOUNDED TSRMLS_CC);
+                                     PCBC_QUERY_CONSISTENCY_NOT_BOUNDED);
     zend_declare_class_constant_long(pcbc_query_consistency_ce, ZEND_STRL("REQUEST_PLUS"),
-                                     PCBC_QUERY_CONSISTENCY_REQUEST_PLUS TSRMLS_CC);
+                                     PCBC_QUERY_CONSISTENCY_REQUEST_PLUS);
     zend_declare_class_constant_long(pcbc_query_consistency_ce, ZEND_STRL("STATEMENT_PLUS"),
-                                     PCBC_QUERY_CONSISTENCY_STATEMENT_PLUS TSRMLS_CC);
+                                     PCBC_QUERY_CONSISTENCY_STATEMENT_PLUS);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "QueryProfile", pcbc_query_profile_methods);
-    pcbc_query_profile_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_declare_class_constant_long(pcbc_query_profile_ce, ZEND_STRL("OFF"), PCBC_QUERY_PROFILE_OFF TSRMLS_CC);
-    zend_declare_class_constant_long(pcbc_query_profile_ce, ZEND_STRL("PHASES"), PCBC_QUERY_PROFILE_PHASES TSRMLS_CC);
-    zend_declare_class_constant_long(pcbc_query_profile_ce, ZEND_STRL("TIMINGS"), PCBC_QUERY_PROFILE_TIMINGS TSRMLS_CC);
+    pcbc_query_profile_ce = zend_register_internal_interface(&ce);
+    zend_declare_class_constant_long(pcbc_query_profile_ce, ZEND_STRL("OFF"), PCBC_QUERY_PROFILE_OFF);
+    zend_declare_class_constant_long(pcbc_query_profile_ce, ZEND_STRL("PHASES"), PCBC_QUERY_PROFILE_PHASES);
+    zend_declare_class_constant_long(pcbc_query_profile_ce, ZEND_STRL("TIMINGS"), PCBC_QUERY_PROFILE_TIMINGS);
 
     return SUCCESS;
 }

--- a/src/couchbase/bucket/remove.c
+++ b/src/couchbase/bucket/remove.c
@@ -33,7 +33,7 @@ void remove_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPREMOVE *r
     lcb_respremove_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respremove_status(resp);
-    zend_update_property_long(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_mutation_result_impl_ce, return_value, ("status"), cookie->rc);
 
     lcb_respremove_error_context(resp, &ectx);
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_mutation_result_impl_ce, "err_ctx");
@@ -46,7 +46,7 @@ void remove_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPREMOVE *r
             uint64_t data;
             lcb_respremove_cas(resp, &data);
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
+            pcbc_update_property_str(pcbc_mutation_result_impl_ce, return_value, ("cas"), b64);
             zend_string_release(b64);
         }
         {
@@ -56,22 +56,22 @@ void remove_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPREMOVE *r
                 zval val;
                 object_init_ex(&val, pcbc_mutation_token_impl_ce);
 
-                zend_update_property_long(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_id"),
+                pcbc_update_property_long(pcbc_mutation_token_impl_ce, &val, ("partition_id"),
                                           token.vbid_);
                 b64 = php_base64_encode((unsigned char *)&token.uuid_, sizeof(token.uuid_));
-                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_uuid"), b64);
+                pcbc_update_property_str(pcbc_mutation_token_impl_ce, &val, ("partition_uuid"), b64);
                 zend_string_release(b64);
                 b64 = php_base64_encode((unsigned char *)&token.seqno_, sizeof(token.seqno_));
-                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("sequence_number"),
+                pcbc_update_property_str(pcbc_mutation_token_impl_ce, &val, ("sequence_number"),
                                          b64);
                 zend_string_release(b64);
 
                 const char *bucket;
                 lcb_cntl(instance, LCB_CNTL_GET, LCB_CNTL_BUCKETNAME, &bucket);
-                zend_update_property_string(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("bucket_name"),
+                pcbc_update_property_string(pcbc_mutation_token_impl_ce, &val, ("bucket_name"),
                                             bucket);
 
-                zend_update_property(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("mutation_token"),
+                pcbc_update_property(pcbc_mutation_result_impl_ce, return_value, ("mutation_token"),
                                      &val);
                 zval_ptr_dtor(&val);
             }
@@ -91,7 +91,7 @@ PHP_METHOD(RemoveOptions, cas)
     zend_string *decoded = php_base64_decode_str(arg);
     if (decoded) {
         if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
-            zend_update_property_str(pcbc_remove_options_ce, getThis(), ZEND_STRL("cas"), arg);
+            pcbc_update_property_str(pcbc_remove_options_ce, getThis(), ("cas"), arg);
         }
         zend_string_free(decoded);
     }
@@ -105,7 +105,7 @@ PHP_METHOD(RemoveOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_remove_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_remove_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -116,7 +116,7 @@ PHP_METHOD(RemoveOptions, durabilityLevel)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_remove_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
+    pcbc_update_property_long(pcbc_remove_options_ce, getThis(), ("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -160,15 +160,15 @@ PHP_METHOD(Collection, remove)
     uint64_t cas = 0;
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_remove_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_remove_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdremove_timeout(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_remove_options_ce, options, ZEND_STRL("durability_level"), 0, &ret);
+        prop = pcbc_read_property(pcbc_remove_options_ce, options, ("durability_level"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdremove_durability(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_remove_options_ce, options, ZEND_STRL("cas"), 0, &ret);
+        prop = pcbc_read_property(pcbc_remove_options_ce, options, ("cas"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             zend_string *decoded = php_base64_decode_str(Z_STR_P(prop));
             if (decoded) {

--- a/src/couchbase/bucket/remove.c
+++ b/src/couchbase/bucket/remove.c
@@ -28,14 +28,12 @@ struct remove_cookie {
 
 void remove_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPREMOVE *resp)
 {
-    TSRMLS_FETCH();
-
     const lcb_KEY_VALUE_ERROR_CONTEXT *ectx = NULL;
     struct remove_cookie *cookie = NULL;
     lcb_respremove_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respremove_status(resp);
-    zend_update_property_long(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
+    zend_update_property_long(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
 
     lcb_respremove_error_context(resp, &ectx);
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_mutation_result_impl_ce, "err_ctx");
@@ -48,7 +46,7 @@ void remove_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPREMOVE *r
             uint64_t data;
             lcb_respremove_cas(resp, &data);
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("cas"), b64 TSRMLS_CC);
+            zend_update_property_str(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
             zend_string_release(b64);
         }
         {
@@ -59,22 +57,22 @@ void remove_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPREMOVE *r
                 object_init_ex(&val, pcbc_mutation_token_impl_ce);
 
                 zend_update_property_long(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_id"),
-                                          token.vbid_ TSRMLS_CC);
+                                          token.vbid_);
                 b64 = php_base64_encode((unsigned char *)&token.uuid_, sizeof(token.uuid_));
-                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_uuid"), b64 TSRMLS_CC);
+                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_uuid"), b64);
                 zend_string_release(b64);
                 b64 = php_base64_encode((unsigned char *)&token.seqno_, sizeof(token.seqno_));
                 zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("sequence_number"),
-                                         b64 TSRMLS_CC);
+                                         b64);
                 zend_string_release(b64);
 
                 const char *bucket;
                 lcb_cntl(instance, LCB_CNTL_GET, LCB_CNTL_BUCKETNAME, &bucket);
                 zend_update_property_string(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("bucket_name"),
-                                            bucket TSRMLS_CC);
+                                            bucket);
 
                 zend_update_property(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("mutation_token"),
-                                     &val TSRMLS_CC);
+                                     &val);
                 zval_ptr_dtor(&val);
             }
         }
@@ -86,14 +84,14 @@ zend_class_entry *pcbc_remove_options_ce;
 PHP_METHOD(RemoveOptions, cas)
 {
     zend_string *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
     zend_string *decoded = php_base64_decode_str(arg);
     if (decoded) {
         if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
-            zend_update_property_str(pcbc_remove_options_ce, getThis(), ZEND_STRL("cas"), arg TSRMLS_CC);
+            zend_update_property_str(pcbc_remove_options_ce, getThis(), ZEND_STRL("cas"), arg);
         }
         zend_string_free(decoded);
     }
@@ -103,22 +101,22 @@ PHP_METHOD(RemoveOptions, cas)
 PHP_METHOD(RemoveOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_remove_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_remove_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(RemoveOptions, durabilityLevel)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_remove_options_ce, getThis(), ZEND_STRL("durability_level"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_remove_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -149,7 +147,7 @@ PHP_METHOD(Collection, remove)
     zval *options = NULL;
     lcb_STATUS err;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|O!", &id, &options, pcbc_remove_options_ce);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|O!", &id, &options, pcbc_remove_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -211,10 +209,10 @@ PHP_MINIT_FUNCTION(CollectionRemove)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "RemoveOptions", pcbc_remove_options_methods);
-    pcbc_remove_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_remove_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_remove_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_remove_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_remove_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_remove_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_remove_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_remove_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/bucket/store.c
+++ b/src/couchbase/bucket/store.c
@@ -36,7 +36,7 @@ void store_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSTORE *res
     lcb_respstore_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respstore_status(resp);
-    zend_update_property_long(pcbc_store_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_store_result_impl_ce, return_value, ("status"), cookie->rc);
 
     lcb_respstore_error_context(resp, &ectx);
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_store_result_impl_ce, "err_ctx");
@@ -49,7 +49,7 @@ void store_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSTORE *res
             uint64_t data;
             lcb_respstore_cas(resp, &data);
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_store_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
+            pcbc_update_property_str(pcbc_store_result_impl_ce, return_value, ("cas"), b64);
             zend_string_release(b64);
         }
         {
@@ -59,22 +59,22 @@ void store_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSTORE *res
                 zval val;
                 object_init_ex(&val, pcbc_mutation_token_impl_ce);
 
-                zend_update_property_long(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_id"),
+                pcbc_update_property_long(pcbc_mutation_token_impl_ce, &val, ("partition_id"),
                                           token.vbid_);
                 b64 = php_base64_encode((unsigned char *)&token.uuid_, sizeof(token.uuid_));
-                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_uuid"), b64);
+                pcbc_update_property_str(pcbc_mutation_token_impl_ce, &val, ("partition_uuid"), b64);
                 zend_string_release(b64);
                 b64 = php_base64_encode((unsigned char *)&token.seqno_, sizeof(token.seqno_));
-                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("sequence_number"),
+                pcbc_update_property_str(pcbc_mutation_token_impl_ce, &val, ("sequence_number"),
                                          b64);
                 zend_string_release(b64);
 
                 const char *bucket;
                 lcb_cntl(instance, LCB_CNTL_GET, LCB_CNTL_BUCKETNAME, &bucket);
-                zend_update_property_string(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("bucket_name"),
+                pcbc_update_property_string(pcbc_mutation_token_impl_ce, &val, ("bucket_name"),
                                             bucket);
 
-                zend_update_property(pcbc_store_result_impl_ce, return_value, ZEND_STRL("mutation_token"),
+                pcbc_update_property(pcbc_store_result_impl_ce, return_value, ("mutation_token"),
                                      &val);
                 zval_ptr_dtor(&val);
             }
@@ -83,7 +83,7 @@ void store_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSTORE *res
     if (lcb_respstore_observe_attached(resp)) {
         int store_ok;
         lcb_respstore_observe_stored(resp, &store_ok);
-        zend_update_property_bool(pcbc_store_result_impl_ce, return_value, ZEND_STRL("is_stored"), store_ok);
+        pcbc_update_property_bool(pcbc_store_result_impl_ce, return_value, ("is_stored"), store_ok);
         if (store_ok) {
             set_property_num(uint16_t, lcb_respstore_observe_num_persisted, pcbc_store_result_impl_ce, "num_persisted");
             set_property_num(uint16_t, lcb_respstore_observe_num_replicated, pcbc_store_result_impl_ce,
@@ -101,7 +101,7 @@ PHP_METHOD(InsertOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_insert_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_insert_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -112,7 +112,7 @@ PHP_METHOD(InsertOptions, expiry)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_insert_options_ce, getThis(), ZEND_STRL("expiry"), arg);
+    pcbc_update_property_long(pcbc_insert_options_ce, getThis(), ("expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -123,7 +123,7 @@ PHP_METHOD(InsertOptions, durabilityLevel)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_insert_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
+    pcbc_update_property_long(pcbc_insert_options_ce, getThis(), ("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -165,15 +165,15 @@ PHP_METHOD(Collection, insert)
     lcb_cmdstore_collection(cmd, scope_str, scope_len, collection_str, collection_len);
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_insert_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_insert_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdstore_timeout(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_insert_options_ce, options, ZEND_STRL("expiry"), 0, &ret);
+        prop = pcbc_read_property(pcbc_insert_options_ce, options, ("expiry"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdstore_expiry(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_insert_options_ce, options, ZEND_STRL("durability_level"), 0, &ret);
+        prop = pcbc_read_property(pcbc_insert_options_ce, options, ("durability_level"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdstore_durability(cmd, Z_LVAL_P(prop));
         }
@@ -245,7 +245,7 @@ PHP_METHOD(UpsertOptions, cas)
     zend_string *decoded = php_base64_decode_str(arg);
     if (decoded) {
         if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
-            zend_update_property_str(pcbc_upsert_options_ce, getThis(), ZEND_STRL("cas"), arg);
+            pcbc_update_property_str(pcbc_upsert_options_ce, getThis(), ("cas"), arg);
         }
         zend_string_free(decoded);
     }
@@ -259,7 +259,7 @@ PHP_METHOD(UpsertOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_upsert_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_upsert_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -270,7 +270,7 @@ PHP_METHOD(UpsertOptions, expiry)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_upsert_options_ce, getThis(), ZEND_STRL("expiry"), arg);
+    pcbc_update_property_long(pcbc_upsert_options_ce, getThis(), ("expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -281,7 +281,7 @@ PHP_METHOD(UpsertOptions, durabilityLevel)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_upsert_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
+    pcbc_update_property_long(pcbc_upsert_options_ce, getThis(), ("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -328,19 +328,19 @@ PHP_METHOD(Collection, upsert)
     lcb_cmdstore_collection(cmd, scope_str, scope_len, collection_str, collection_len);
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_upsert_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_upsert_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdstore_timeout(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_upsert_options_ce, options, ZEND_STRL("expiry"), 0, &ret);
+        prop = pcbc_read_property(pcbc_upsert_options_ce, options, ("expiry"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdstore_expiry(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_upsert_options_ce, options, ZEND_STRL("durability_level"), 0, &ret);
+        prop = pcbc_read_property(pcbc_upsert_options_ce, options, ("durability_level"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdstore_durability(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_upsert_options_ce, options, ZEND_STRL("cas"), 0, &ret);
+        prop = pcbc_read_property(pcbc_upsert_options_ce, options, ("cas"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             zend_string *decoded = php_base64_decode_str(Z_STR_P(prop));
             if (decoded) {
@@ -419,7 +419,7 @@ PHP_METHOD(ReplaceOptions, cas)
     zend_string *decoded = php_base64_decode_str(arg);
     if (decoded) {
         if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
-            zend_update_property_str(pcbc_replace_options_ce, getThis(), ZEND_STRL("cas"), arg);
+            pcbc_update_property_str(pcbc_replace_options_ce, getThis(), ("cas"), arg);
         }
         zend_string_free(decoded);
     }
@@ -433,7 +433,7 @@ PHP_METHOD(ReplaceOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_replace_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_replace_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -444,7 +444,7 @@ PHP_METHOD(ReplaceOptions, expiry)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_replace_options_ce, getThis(), ZEND_STRL("expiry"), arg);
+    pcbc_update_property_long(pcbc_replace_options_ce, getThis(), ("expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -455,7 +455,7 @@ PHP_METHOD(ReplaceOptions, durabilityLevel)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_replace_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
+    pcbc_update_property_long(pcbc_replace_options_ce, getThis(), ("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -502,19 +502,19 @@ PHP_METHOD(Collection, replace)
     lcb_cmdstore_collection(cmd, scope_str, scope_len, collection_str, collection_len);
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_replace_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_replace_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdstore_timeout(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_replace_options_ce, options, ZEND_STRL("expiry"), 0, &ret);
+        prop = pcbc_read_property(pcbc_replace_options_ce, options, ("expiry"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdstore_expiry(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_replace_options_ce, options, ZEND_STRL("durability_level"), 0, &ret);
+        prop = pcbc_read_property(pcbc_replace_options_ce, options, ("durability_level"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdstore_durability(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_replace_options_ce, options, ZEND_STRL("cas"), 0, &ret);
+        prop = pcbc_read_property(pcbc_replace_options_ce, options, ("cas"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             zend_string *decoded = php_base64_decode_str(Z_STR_P(prop));
             if (decoded) {
@@ -592,7 +592,7 @@ PHP_METHOD(AppendOptions, cas)
     zend_string *decoded = php_base64_decode_str(arg);
     if (decoded) {
         if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
-            zend_update_property_str(pcbc_append_options_ce, getThis(), ZEND_STRL("cas"), arg);
+            pcbc_update_property_str(pcbc_append_options_ce, getThis(), ("cas"), arg);
         }
         zend_string_free(decoded);
     }
@@ -606,7 +606,7 @@ PHP_METHOD(AppendOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_append_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_append_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -617,7 +617,7 @@ PHP_METHOD(AppendOptions, durabilityLevel)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_append_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
+    pcbc_update_property_long(pcbc_append_options_ce, getThis(), ("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -659,15 +659,15 @@ PHP_METHOD(BinaryCollection, append)
     lcb_cmdstore_collection(cmd, scope_str, scope_len, collection_str, collection_len);
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_append_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_append_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdstore_timeout(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_append_options_ce, options, ZEND_STRL("durability_level"), 0, &ret);
+        prop = pcbc_read_property(pcbc_append_options_ce, options, ("durability_level"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdstore_durability(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_append_options_ce, options, ZEND_STRL("cas"), 0, &ret);
+        prop = pcbc_read_property(pcbc_append_options_ce, options, ("cas"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             zend_string *decoded = php_base64_decode_str(Z_STR_P(prop));
             if (decoded) {
@@ -719,7 +719,7 @@ PHP_METHOD(PrependOptions, cas)
     zend_string *decoded = php_base64_decode_str(arg);
     if (decoded) {
         if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
-            zend_update_property_str(pcbc_prepend_options_ce, getThis(), ZEND_STRL("cas"), arg);
+            pcbc_update_property_str(pcbc_prepend_options_ce, getThis(), ("cas"), arg);
         }
         zend_string_free(decoded);
     }
@@ -733,7 +733,7 @@ PHP_METHOD(PrependOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_prepend_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_prepend_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -744,7 +744,7 @@ PHP_METHOD(PrependOptions, durabilityLevel)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_prepend_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
+    pcbc_update_property_long(pcbc_prepend_options_ce, getThis(), ("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -786,15 +786,15 @@ PHP_METHOD(BinaryCollection, prepend)
     lcb_cmdstore_collection(cmd, scope_str, scope_len, collection_str, collection_len);
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_append_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_append_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdstore_timeout(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_append_options_ce, options, ZEND_STRL("durability_level"), 0, &ret);
+        prop = pcbc_read_property(pcbc_append_options_ce, options, ("durability_level"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdstore_durability(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_append_options_ce, options, ZEND_STRL("cas"), 0, &ret);
+        prop = pcbc_read_property(pcbc_append_options_ce, options, ("cas"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             zend_string *decoded = php_base64_decode_str(Z_STR_P(prop));
             if (decoded) {

--- a/src/couchbase/bucket/store.c
+++ b/src/couchbase/bucket/store.c
@@ -31,14 +31,12 @@ struct store_cookie {
 
 void store_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSTORE *resp)
 {
-    TSRMLS_FETCH();
-
     const lcb_KEY_VALUE_ERROR_CONTEXT *ectx = NULL;
     struct store_cookie *cookie = NULL;
     lcb_respstore_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respstore_status(resp);
-    zend_update_property_long(pcbc_store_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
+    zend_update_property_long(pcbc_store_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
 
     lcb_respstore_error_context(resp, &ectx);
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_store_result_impl_ce, "err_ctx");
@@ -51,7 +49,7 @@ void store_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSTORE *res
             uint64_t data;
             lcb_respstore_cas(resp, &data);
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_store_result_impl_ce, return_value, ZEND_STRL("cas"), b64 TSRMLS_CC);
+            zend_update_property_str(pcbc_store_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
             zend_string_release(b64);
         }
         {
@@ -62,22 +60,22 @@ void store_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSTORE *res
                 object_init_ex(&val, pcbc_mutation_token_impl_ce);
 
                 zend_update_property_long(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_id"),
-                                          token.vbid_ TSRMLS_CC);
+                                          token.vbid_);
                 b64 = php_base64_encode((unsigned char *)&token.uuid_, sizeof(token.uuid_));
-                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_uuid"), b64 TSRMLS_CC);
+                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_uuid"), b64);
                 zend_string_release(b64);
                 b64 = php_base64_encode((unsigned char *)&token.seqno_, sizeof(token.seqno_));
                 zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("sequence_number"),
-                                         b64 TSRMLS_CC);
+                                         b64);
                 zend_string_release(b64);
 
                 const char *bucket;
                 lcb_cntl(instance, LCB_CNTL_GET, LCB_CNTL_BUCKETNAME, &bucket);
                 zend_update_property_string(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("bucket_name"),
-                                            bucket TSRMLS_CC);
+                                            bucket);
 
                 zend_update_property(pcbc_store_result_impl_ce, return_value, ZEND_STRL("mutation_token"),
-                                     &val TSRMLS_CC);
+                                     &val);
                 zval_ptr_dtor(&val);
             }
         }
@@ -85,7 +83,7 @@ void store_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSTORE *res
     if (lcb_respstore_observe_attached(resp)) {
         int store_ok;
         lcb_respstore_observe_stored(resp, &store_ok);
-        zend_update_property_bool(pcbc_store_result_impl_ce, return_value, ZEND_STRL("is_stored"), store_ok TSRMLS_CC);
+        zend_update_property_bool(pcbc_store_result_impl_ce, return_value, ZEND_STRL("is_stored"), store_ok);
         if (store_ok) {
             set_property_num(uint16_t, lcb_respstore_observe_num_persisted, pcbc_store_result_impl_ce, "num_persisted");
             set_property_num(uint16_t, lcb_respstore_observe_num_replicated, pcbc_store_result_impl_ce,
@@ -99,33 +97,33 @@ zend_class_entry *pcbc_insert_options_ce;
 PHP_METHOD(InsertOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_insert_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_insert_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(InsertOptions, expiry)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_insert_options_ce, getThis(), ZEND_STRL("expiry"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_insert_options_ce, getThis(), ZEND_STRL("expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(InsertOptions, durabilityLevel)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_insert_options_ce, getThis(), ZEND_STRL("durability_level"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_insert_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -156,7 +154,7 @@ PHP_METHOD(Collection, insert)
     zval *value, *options = NULL;
     lcb_STATUS err = LCB_ERR_INVALID_ARGUMENT;
 
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Sz|O!", &id, &value, &options, pcbc_insert_options_ce);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "Sz|O!", &id, &value, &options, pcbc_insert_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -202,7 +200,7 @@ PHP_METHOD(Collection, insert)
     size_t nbytes;
     uint32_t flags;
     uint8_t datatype;
-    rv = pcbc_encode_value(bucket, value, &bytes, &nbytes, &flags, &datatype TSRMLS_CC);
+    rv = pcbc_encode_value(bucket, value, &bytes, &nbytes, &flags, &datatype);
     if (span) {
         lcbtrace_span_finish(span, LCBTRACE_NOW);
     }
@@ -240,14 +238,14 @@ zend_class_entry *pcbc_upsert_options_ce;
 PHP_METHOD(UpsertOptions, cas)
 {
     zend_string *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
     zend_string *decoded = php_base64_decode_str(arg);
     if (decoded) {
         if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
-            zend_update_property_str(pcbc_upsert_options_ce, getThis(), ZEND_STRL("cas"), arg TSRMLS_CC);
+            zend_update_property_str(pcbc_upsert_options_ce, getThis(), ZEND_STRL("cas"), arg);
         }
         zend_string_free(decoded);
     }
@@ -257,33 +255,33 @@ PHP_METHOD(UpsertOptions, cas)
 PHP_METHOD(UpsertOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_upsert_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_upsert_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(UpsertOptions, expiry)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_upsert_options_ce, getThis(), ZEND_STRL("expiry"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_upsert_options_ce, getThis(), ZEND_STRL("expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(UpsertOptions, durabilityLevel)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_upsert_options_ce, getThis(), ZEND_STRL("durability_level"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_upsert_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -319,7 +317,7 @@ PHP_METHOD(Collection, upsert)
     zval *value, *options = NULL;
     lcb_STATUS err = LCB_ERR_INVALID_ARGUMENT;
 
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Sz|O!", &id, &value, &options, pcbc_upsert_options_ce);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "Sz|O!", &id, &value, &options, pcbc_upsert_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -376,7 +374,7 @@ PHP_METHOD(Collection, upsert)
     uint32_t flags;
     uint8_t datatype;
 
-    rv = pcbc_encode_value(bucket, value, &bytes, &nbytes, &flags, &datatype TSRMLS_CC);
+    rv = pcbc_encode_value(bucket, value, &bytes, &nbytes, &flags, &datatype);
     if (span) {
         lcbtrace_span_finish(span, LCBTRACE_NOW);
     }
@@ -414,14 +412,14 @@ zend_class_entry *pcbc_replace_options_ce;
 PHP_METHOD(ReplaceOptions, cas)
 {
     zend_string *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
     zend_string *decoded = php_base64_decode_str(arg);
     if (decoded) {
         if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
-            zend_update_property_str(pcbc_replace_options_ce, getThis(), ZEND_STRL("cas"), arg TSRMLS_CC);
+            zend_update_property_str(pcbc_replace_options_ce, getThis(), ZEND_STRL("cas"), arg);
         }
         zend_string_free(decoded);
     }
@@ -431,33 +429,33 @@ PHP_METHOD(ReplaceOptions, cas)
 PHP_METHOD(ReplaceOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_replace_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_replace_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(ReplaceOptions, expiry)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_replace_options_ce, getThis(), ZEND_STRL("expiry"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_replace_options_ce, getThis(), ZEND_STRL("expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(ReplaceOptions, durabilityLevel)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_replace_options_ce, getThis(), ZEND_STRL("durability_level"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_replace_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -493,7 +491,7 @@ PHP_METHOD(Collection, replace)
     zval *value, *options = NULL;
     lcb_STATUS err = LCB_ERR_INVALID_ARGUMENT;
 
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Sz|O!", &id, &value, &options, pcbc_replace_options_ce);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "Sz|O!", &id, &value, &options, pcbc_replace_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -549,7 +547,7 @@ PHP_METHOD(Collection, replace)
     size_t nbytes;
     uint32_t flags;
     uint8_t datatype;
-    rv = pcbc_encode_value(bucket, value, &bytes, &nbytes, &flags, &datatype TSRMLS_CC);
+    rv = pcbc_encode_value(bucket, value, &bytes, &nbytes, &flags, &datatype);
     if (span) {
         lcbtrace_span_finish(span, LCBTRACE_NOW);
     }
@@ -587,14 +585,14 @@ zend_class_entry *pcbc_append_options_ce;
 PHP_METHOD(AppendOptions, cas)
 {
     zend_string *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
     zend_string *decoded = php_base64_decode_str(arg);
     if (decoded) {
         if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
-            zend_update_property_str(pcbc_append_options_ce, getThis(), ZEND_STRL("cas"), arg TSRMLS_CC);
+            zend_update_property_str(pcbc_append_options_ce, getThis(), ZEND_STRL("cas"), arg);
         }
         zend_string_free(decoded);
     }
@@ -604,22 +602,22 @@ PHP_METHOD(AppendOptions, cas)
 PHP_METHOD(AppendOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_append_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_append_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(AppendOptions, durabilityLevel)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_append_options_ce, getThis(), ZEND_STRL("durability_level"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_append_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -650,7 +648,7 @@ PHP_METHOD(BinaryCollection, append)
     zval *options = NULL;
     lcb_STATUS err;
 
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SS|O!", &id, &value, &options, pcbc_append_options_ce);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "SS|O!", &id, &value, &options, pcbc_append_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -714,14 +712,14 @@ zend_class_entry *pcbc_prepend_options_ce;
 PHP_METHOD(PrependOptions, cas)
 {
     zend_string *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
     zend_string *decoded = php_base64_decode_str(arg);
     if (decoded) {
         if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
-            zend_update_property_str(pcbc_prepend_options_ce, getThis(), ZEND_STRL("cas"), arg TSRMLS_CC);
+            zend_update_property_str(pcbc_prepend_options_ce, getThis(), ZEND_STRL("cas"), arg);
         }
         zend_string_free(decoded);
     }
@@ -731,22 +729,22 @@ PHP_METHOD(PrependOptions, cas)
 PHP_METHOD(PrependOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_prepend_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_prepend_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(PrependOptions, durabilityLevel)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_prepend_options_ce, getThis(), ZEND_STRL("durability_level"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_prepend_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -777,7 +775,7 @@ PHP_METHOD(BinaryCollection, prepend)
     zval *options = NULL;
     lcb_STATUS err;
 
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SS|O!", &id, &value, &options, pcbc_prepend_options_ce);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "SS|O!", &id, &value, &options, pcbc_prepend_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -841,46 +839,46 @@ PHP_MINIT_FUNCTION(CollectionStore)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "InsertOptions", pcbc_insert_options_methods);
-    pcbc_insert_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_insert_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_insert_options_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_insert_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_insert_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_insert_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_insert_options_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_insert_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "UpsertOptions", pcbc_upsert_options_methods);
-    pcbc_upsert_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_upsert_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_upsert_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_upsert_options_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_upsert_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_upsert_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_upsert_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_upsert_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_upsert_options_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_upsert_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ReplaceOptions", pcbc_replace_options_methods);
-    pcbc_replace_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_replace_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_replace_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_replace_options_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_replace_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_replace_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_replace_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_replace_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_replace_options_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_replace_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "AppendOptions", pcbc_append_options_methods);
-    pcbc_append_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_append_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_append_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_append_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_append_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_append_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_append_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_append_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "PrependOptions", pcbc_prepend_options_methods);
-    pcbc_prepend_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_prepend_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_prepend_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_prepend_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_prepend_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_prepend_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_prepend_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_prepend_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "DurabilityLevel", pcbc_durability_level_methods);
-    pcbc_durability_level_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_declare_class_constant_long(pcbc_durability_level_ce, ZEND_STRL("NONE"), LCB_DURABILITYLEVEL_NONE TSRMLS_CC);
+    pcbc_durability_level_ce = zend_register_internal_interface(&ce);
+    zend_declare_class_constant_long(pcbc_durability_level_ce, ZEND_STRL("NONE"), LCB_DURABILITYLEVEL_NONE);
     zend_declare_class_constant_long(pcbc_durability_level_ce, ZEND_STRL("MAJORITY"),
-                                     LCB_DURABILITYLEVEL_MAJORITY TSRMLS_CC);
+                                     LCB_DURABILITYLEVEL_MAJORITY);
     zend_declare_class_constant_long(pcbc_durability_level_ce, ZEND_STRL("MAJORITY_AND_PERSIST_TO_ACTIVE"),
-                                     LCB_DURABILITYLEVEL_MAJORITY_AND_PERSIST_TO_ACTIVE TSRMLS_CC);
+                                     LCB_DURABILITYLEVEL_MAJORITY_AND_PERSIST_TO_ACTIVE);
     zend_declare_class_constant_long(pcbc_durability_level_ce, ZEND_STRL("PERSIST_TO_MAJORITY"),
-                                     LCB_DURABILITYLEVEL_PERSIST_TO_MAJORITY TSRMLS_CC);
+                                     LCB_DURABILITYLEVEL_PERSIST_TO_MAJORITY);
 
     return SUCCESS;
 }

--- a/src/couchbase/bucket/subdoc.c
+++ b/src/couchbase/bucket/subdoc.c
@@ -51,7 +51,7 @@ void subdoc_lookup_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
     lcb_respsubdoc_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respsubdoc_status(resp);
-    zend_update_property_long(pcbc_lookup_in_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_lookup_in_result_impl_ce, return_value, ("status"), cookie->rc);
 
     lcb_respsubdoc_error_context(resp, &ectx);
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_lookup_in_result_impl_ce, "err_ctx");
@@ -62,21 +62,21 @@ void subdoc_lookup_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
         lcb_respsubdoc_cas(resp, &data);
         zend_string *b64;
         b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-        zend_update_property_str(pcbc_lookup_in_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
+        pcbc_update_property_str(pcbc_lookup_in_result_impl_ce, return_value, ("cas"), b64);
         zend_string_release(b64);
     }
     size_t num_results = lcb_respsubdoc_result_size(resp);
     size_t idx;
     zval data;
     array_init(&data);
-    zend_update_property(pcbc_lookup_in_result_impl_ce, return_value, ZEND_STRL("data"), &data);
+    pcbc_update_property(pcbc_lookup_in_result_impl_ce, return_value, ("data"), &data);
     Z_DELREF(data);
     for (idx = 0; idx < num_results; idx++) {
         zval entry;
         array_init(&entry);
         object_init_ex(&entry, pcbc_lookup_in_result_entry_ce);
 
-        zend_update_property_long(pcbc_lookup_in_result_entry_ce, &entry, ZEND_STRL("code"),
+        pcbc_update_property_long(pcbc_lookup_in_result_entry_ce, &entry, ("code"),
                                   lcb_respsubdoc_result_status(resp, idx));
         const char *bytes;
         size_t nbytes;
@@ -92,7 +92,7 @@ void subdoc_lookup_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
                          last_error);
             }
         }
-        zend_update_property(pcbc_lookup_in_result_entry_ce, &entry, ZEND_STRL("value"), &value);
+        pcbc_update_property(pcbc_lookup_in_result_entry_ce, &entry, ("value"), &value);
         add_index_zval(&data, idx, &entry);
         Z_TRY_ADDREF(entry);
     }
@@ -105,7 +105,7 @@ void subdoc_mutate_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
     lcb_respsubdoc_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respsubdoc_status(resp);
-    zend_update_property_long(pcbc_mutate_in_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_mutate_in_result_impl_ce, return_value, ("status"), cookie->rc);
 
     lcb_respsubdoc_error_context(resp, &ectx);
 
@@ -117,7 +117,7 @@ void subdoc_mutate_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
         lcb_respsubdoc_cas(resp, &data);
         zend_string *b64;
         b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-        zend_update_property_str(pcbc_mutate_in_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
+        pcbc_update_property_str(pcbc_mutate_in_result_impl_ce, return_value, ("cas"), b64);
         zend_string_release(b64);
         {
             lcb_MUTATION_TOKEN token = {0};
@@ -126,22 +126,22 @@ void subdoc_mutate_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
                 zval val;
                 object_init_ex(&val, pcbc_mutation_token_impl_ce);
 
-                zend_update_property_long(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_id"),
+                pcbc_update_property_long(pcbc_mutation_token_impl_ce, &val, ("partition_id"),
                                           token.vbid_);
                 b64 = php_base64_encode((unsigned char *)&token.uuid_, sizeof(token.uuid_));
-                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_uuid"), b64);
+                pcbc_update_property_str(pcbc_mutation_token_impl_ce, &val, ("partition_uuid"), b64);
                 zend_string_release(b64);
                 b64 = php_base64_encode((unsigned char *)&token.seqno_, sizeof(token.seqno_));
-                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("sequence_number"),
+                pcbc_update_property_str(pcbc_mutation_token_impl_ce, &val, ("sequence_number"),
                                          b64);
                 zend_string_release(b64);
 
                 const char *bucket;
                 lcb_cntl(instance, LCB_CNTL_GET, LCB_CNTL_BUCKETNAME, &bucket);
-                zend_update_property_string(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("bucket_name"),
+                pcbc_update_property_string(pcbc_mutation_token_impl_ce, &val, ("bucket_name"),
                                             bucket);
 
-                zend_update_property(pcbc_mutate_in_result_impl_ce, return_value, ZEND_STRL("mutation_token"),
+                pcbc_update_property(pcbc_mutate_in_result_impl_ce, return_value, ("mutation_token"),
                                      &val);
                 zval_ptr_dtor(&val);
             }
@@ -151,14 +151,14 @@ void subdoc_mutate_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
     size_t idx;
     zval data;
     array_init(&data);
-    zend_update_property(pcbc_mutate_in_result_impl_ce, return_value, ZEND_STRL("data"), &data);
+    pcbc_update_property(pcbc_mutate_in_result_impl_ce, return_value, ("data"), &data);
     Z_DELREF(data);
     for (idx = 0; idx < num_results; idx++) {
         zval entry;
         array_init(&entry);
         object_init_ex(&entry, pcbc_mutate_in_result_entry_ce);
 
-        zend_update_property_long(pcbc_mutate_in_result_entry_ce, &entry, ZEND_STRL("code"),
+        pcbc_update_property_long(pcbc_mutate_in_result_entry_ce, &entry, ("code"),
                                   lcb_respsubdoc_result_status(resp, idx));
         const char *bytes;
         size_t nbytes;
@@ -174,7 +174,7 @@ void subdoc_mutate_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
                          last_error);
             }
         }
-        zend_update_property(pcbc_mutate_in_result_entry_ce, &entry, ZEND_STRL("value"), &value);
+        pcbc_update_property(pcbc_mutate_in_result_entry_ce, &entry, ("value"), &value);
         add_index_zval(&data, idx, &entry);
         Z_TRY_ADDREF(entry);
     }
@@ -189,7 +189,7 @@ PHP_METHOD(LookupInOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_lookup_in_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_lookup_in_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -200,7 +200,7 @@ PHP_METHOD(LookupInOptions, withExpiry)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_lookup_in_options_ce, getThis(), ZEND_STRL("with_expiry"), arg);
+    pcbc_update_property_bool(pcbc_lookup_in_options_ce, getThis(), ("with_expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -243,24 +243,24 @@ PHP_METHOD(Collection, lookupIn)
     {
         flags = 0;
         if (Z_OBJCE_P(val) == pcbc_lookup_get_spec_ce) {
-            if (Z_TYPE_P(zend_read_property(pcbc_lookup_get_spec_ce, val, ZEND_STRL("is_xattr"), 0, &tmp)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(pcbc_lookup_get_spec_ce, val, ("is_xattr"), 0, &tmp)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTRPATH;
             }
-            prop = zend_read_property(pcbc_lookup_get_spec_ce, val, ZEND_STRL("path"), 0, &tmp);
+            prop = pcbc_read_property(pcbc_lookup_get_spec_ce, val, ("path"), 0, &tmp);
             lcb_subdocspecs_get(operations, idx, flags, Z_STRVAL_P(prop), Z_STRLEN_P(prop));
         } else if (Z_OBJCE_P(val) == pcbc_lookup_count_spec_ce) {
-            if (Z_TYPE_P(zend_read_property(pcbc_lookup_count_spec_ce, val, ZEND_STRL("is_xattr"), 0, &tmp)) ==
+            if (Z_TYPE_P(pcbc_read_property(pcbc_lookup_count_spec_ce, val, ("is_xattr"), 0, &tmp)) ==
                 IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTRPATH;
             }
-            prop = zend_read_property(pcbc_lookup_count_spec_ce, val, ZEND_STRL("path"), 0, &tmp);
+            prop = pcbc_read_property(pcbc_lookup_count_spec_ce, val, ("path"), 0, &tmp);
             lcb_subdocspecs_get_count(operations, idx, flags, Z_STRVAL_P(prop), Z_STRLEN_P(prop));
         } else if (Z_OBJCE_P(val) == pcbc_lookup_exists_spec_ce) {
-            if (Z_TYPE_P(zend_read_property(pcbc_lookup_exists_spec_ce, val, ZEND_STRL("is_xattr"), 0, &tmp)) ==
+            if (Z_TYPE_P(pcbc_read_property(pcbc_lookup_exists_spec_ce, val, ("is_xattr"), 0, &tmp)) ==
                 IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTRPATH;
             }
-            prop = zend_read_property(pcbc_lookup_exists_spec_ce, val, ZEND_STRL("path"), 0, &tmp);
+            prop = pcbc_read_property(pcbc_lookup_exists_spec_ce, val, ("path"), 0, &tmp);
             lcb_subdocspecs_exists(operations, idx, flags, Z_STRVAL_P(prop), Z_STRLEN_P(prop));
         } else {
             /* TODO: raise argument exception */
@@ -277,7 +277,7 @@ PHP_METHOD(Collection, lookupIn)
     lcb_cmdsubdoc_key(cmd, ZSTR_VAL(id), ZSTR_LEN(id));
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_lookup_in_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_lookup_in_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdsubdoc_timeout(cmd, Z_LVAL_P(prop));
         }
@@ -323,7 +323,7 @@ PHP_METHOD(MutateInOptions, cas)
     zend_string *decoded = php_base64_decode_str(arg);
     if (decoded) {
         if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
-            zend_update_property_str(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("cas"), arg);
+            pcbc_update_property_str(pcbc_mutate_in_options_ce, getThis(), ("cas"), arg);
         }
         zend_string_free(decoded);
     }
@@ -337,7 +337,7 @@ PHP_METHOD(MutateInOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_mutate_in_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -348,7 +348,7 @@ PHP_METHOD(MutateInOptions, expiry)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("expiry"), arg);
+    pcbc_update_property_long(pcbc_mutate_in_options_ce, getThis(), ("expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -359,7 +359,7 @@ PHP_METHOD(MutateInOptions, durabilityLevel)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
+    pcbc_update_property_long(pcbc_mutate_in_options_ce, getThis(), ("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -370,7 +370,7 @@ PHP_METHOD(MutateInOptions, storeSemantics)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("store_semantics"), arg);
+    pcbc_update_property_long(pcbc_mutate_in_options_ce, getThis(), ("store_semantics"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -428,115 +428,115 @@ PHP_METHOD(Collection, mutateIn)
     {
         flags = 0;
         if (Z_OBJCE_P(entry) == pcbc_mutate_insert_spec_ce) {
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("is_xattr"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("is_xattr"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTRPATH;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("create_path"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("create_path"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_MKINTERMEDIATES;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("expand_macros"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("expand_macros"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTR_MACROVALUES;
             }
-            path = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("path"), 0, &rv1);
-            value = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("value"), 0, &rv2);
+            path = pcbc_read_property(Z_OBJCE_P(entry), entry, ("path"), 0, &rv1);
+            value = pcbc_read_property(Z_OBJCE_P(entry), entry, ("value"), 0, &rv2);
             lcb_subdocspecs_dict_add(operations, idx, flags, Z_STRVAL_P(path), Z_STRLEN_P(path), Z_STRVAL_P(value),
                                      Z_STRLEN_P(value));
         } else if (Z_OBJCE_P(entry) == pcbc_mutate_upsert_spec_ce) {
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("is_xattr"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("is_xattr"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTRPATH;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("create_path"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("create_path"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_MKINTERMEDIATES;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("expand_macros"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("expand_macros"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTR_MACROVALUES;
             }
-            path = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("path"), 0, &rv1);
-            value = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("value"), 0, &rv2);
+            path = pcbc_read_property(Z_OBJCE_P(entry), entry, ("path"), 0, &rv1);
+            value = pcbc_read_property(Z_OBJCE_P(entry), entry, ("value"), 0, &rv2);
             lcb_subdocspecs_dict_upsert(operations, idx, flags, Z_STRVAL_P(path), Z_STRLEN_P(path), Z_STRVAL_P(value),
                                         Z_STRLEN_P(value));
         } else if (Z_OBJCE_P(entry) == pcbc_mutate_replace_spec_ce) {
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("is_xattr"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("is_xattr"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTRPATH;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("expand_macros"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("expand_macros"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTR_MACROVALUES;
             }
-            path = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("path"), 0, &rv1);
-            value = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("value"), 0, &rv2);
+            path = pcbc_read_property(Z_OBJCE_P(entry), entry, ("path"), 0, &rv1);
+            value = pcbc_read_property(Z_OBJCE_P(entry), entry, ("value"), 0, &rv2);
             lcb_subdocspecs_replace(operations, idx, flags, Z_STRVAL_P(path), Z_STRLEN_P(path), Z_STRVAL_P(value),
                                     Z_STRLEN_P(value));
         } else if (Z_OBJCE_P(entry) == pcbc_mutate_remove_spec_ce) {
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("is_xattr"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("is_xattr"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTRPATH;
             }
-            path = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("path"), 0, &rv1);
+            path = pcbc_read_property(Z_OBJCE_P(entry), entry, ("path"), 0, &rv1);
             lcb_subdocspecs_remove(operations, idx, flags, Z_STRVAL_P(path), Z_STRLEN_P(path));
         } else if (Z_OBJCE_P(entry) == pcbc_mutate_array_append_spec_ce) {
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("is_xattr"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("is_xattr"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTRPATH;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("create_path"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("create_path"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_MKINTERMEDIATES;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("expand_macros"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("expand_macros"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTR_MACROVALUES;
             }
-            path = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("path"), 0, &rv1);
-            value = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("value"), 0, &rv2);
+            path = pcbc_read_property(Z_OBJCE_P(entry), entry, ("path"), 0, &rv1);
+            value = pcbc_read_property(Z_OBJCE_P(entry), entry, ("value"), 0, &rv2);
             lcb_subdocspecs_array_add_last(operations, idx, flags, Z_STRVAL_P(path), Z_STRLEN_P(path),
                                            Z_STRVAL_P(value), Z_STRLEN_P(value));
         } else if (Z_OBJCE_P(entry) == pcbc_mutate_array_prepend_spec_ce) {
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("is_xattr"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("is_xattr"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTRPATH;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("create_path"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("create_path"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_MKINTERMEDIATES;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("expand_macros"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("expand_macros"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTR_MACROVALUES;
             }
-            path = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("path"), 0, &rv1);
-            value = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("value"), 0, &rv2);
+            path = pcbc_read_property(Z_OBJCE_P(entry), entry, ("path"), 0, &rv1);
+            value = pcbc_read_property(Z_OBJCE_P(entry), entry, ("value"), 0, &rv2);
             lcb_subdocspecs_array_add_first(operations, idx, flags, Z_STRVAL_P(path), Z_STRLEN_P(path),
                                             Z_STRVAL_P(value), Z_STRLEN_P(value));
         } else if (Z_OBJCE_P(entry) == pcbc_mutate_array_insert_spec_ce) {
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("is_xattr"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("is_xattr"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTRPATH;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("create_path"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("create_path"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_MKINTERMEDIATES;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("expand_macros"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("expand_macros"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTR_MACROVALUES;
             }
-            path = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("path"), 0, &rv1);
-            value = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("value"), 0, &rv2);
+            path = pcbc_read_property(Z_OBJCE_P(entry), entry, ("path"), 0, &rv1);
+            value = pcbc_read_property(Z_OBJCE_P(entry), entry, ("value"), 0, &rv2);
             lcb_subdocspecs_array_insert(operations, idx, flags, Z_STRVAL_P(path), Z_STRLEN_P(path), Z_STRVAL_P(value),
                                          Z_STRLEN_P(value));
         } else if (Z_OBJCE_P(entry) == pcbc_mutate_array_add_unique_spec_ce) {
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("is_xattr"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("is_xattr"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTRPATH;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("create_path"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("create_path"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_MKINTERMEDIATES;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("expand_macros"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("expand_macros"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTR_MACROVALUES;
             }
-            path = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("path"), 0, &rv1);
-            value = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("value"), 0, &rv2);
+            path = pcbc_read_property(Z_OBJCE_P(entry), entry, ("path"), 0, &rv1);
+            value = pcbc_read_property(Z_OBJCE_P(entry), entry, ("value"), 0, &rv2);
             lcb_subdocspecs_array_add_unique(operations, idx, flags, Z_STRVAL_P(path), Z_STRLEN_P(path),
                                              Z_STRVAL_P(value), Z_STRLEN_P(value));
         } else if (Z_OBJCE_P(entry) == pcbc_mutate_counter_spec_ce) {
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("is_xattr"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("is_xattr"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_XATTRPATH;
             }
-            if (Z_TYPE_P(zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("create_path"), 0, &rv1)) == IS_TRUE) {
+            if (Z_TYPE_P(pcbc_read_property(Z_OBJCE_P(entry), entry, ("create_path"), 0, &rv1)) == IS_TRUE) {
                 flags |= LCB_SUBDOCSPECS_F_MKINTERMEDIATES;
             }
-            path = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("path"), 0, &rv1);
-            value = zend_read_property(Z_OBJCE_P(entry), entry, ZEND_STRL("delta"), 0, &rv2);
+            path = pcbc_read_property(Z_OBJCE_P(entry), entry, ("path"), 0, &rv1);
+            value = pcbc_read_property(Z_OBJCE_P(entry), entry, ("delta"), 0, &rv2);
             lcb_subdocspecs_counter(operations, idx, flags, Z_STRVAL_P(path), Z_STRLEN_P(path), Z_LVAL_P(value));
         } else {
             /* TODO: raise argument exception */
@@ -553,23 +553,23 @@ PHP_METHOD(Collection, mutateIn)
     lcb_cmdsubdoc_key(cmd, ZSTR_VAL(id), ZSTR_LEN(id));
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_mutate_in_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_mutate_in_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdsubdoc_timeout(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_mutate_in_options_ce, options, ZEND_STRL("expiry"), 0, &ret);
+        prop = pcbc_read_property(pcbc_mutate_in_options_ce, options, ("expiry"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdsubdoc_expiry(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_mutate_in_options_ce, options, ZEND_STRL("durability_level"), 0, &ret);
+        prop = pcbc_read_property(pcbc_mutate_in_options_ce, options, ("durability_level"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdsubdoc_durability(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_mutate_in_options_ce, options, ZEND_STRL("store_semantics"), 0, &ret);
+        prop = pcbc_read_property(pcbc_mutate_in_options_ce, options, ("store_semantics"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdsubdoc_store_semantics(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_mutate_in_options_ce, options, ZEND_STRL("cas"), 0, &ret);
+        prop = pcbc_read_property(pcbc_mutate_in_options_ce, options, ("cas"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             zend_string *decoded = php_base64_decode_str(Z_STR_P(prop));
             if (decoded) {

--- a/src/couchbase/bucket/subdoc.c
+++ b/src/couchbase/bucket/subdoc.c
@@ -46,14 +46,12 @@ struct subdoc_cookie {
 
 void subdoc_lookup_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSUBDOC *resp)
 {
-    TSRMLS_FETCH();
-
     const lcb_KEY_VALUE_ERROR_CONTEXT *ectx = NULL;
     struct subdoc_cookie *cookie = NULL;
     lcb_respsubdoc_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respsubdoc_status(resp);
-    zend_update_property_long(pcbc_lookup_in_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
+    zend_update_property_long(pcbc_lookup_in_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
 
     lcb_respsubdoc_error_context(resp, &ectx);
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_lookup_in_result_impl_ce, "err_ctx");
@@ -64,14 +62,14 @@ void subdoc_lookup_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
         lcb_respsubdoc_cas(resp, &data);
         zend_string *b64;
         b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-        zend_update_property_str(pcbc_lookup_in_result_impl_ce, return_value, ZEND_STRL("cas"), b64 TSRMLS_CC);
+        zend_update_property_str(pcbc_lookup_in_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
         zend_string_release(b64);
     }
     size_t num_results = lcb_respsubdoc_result_size(resp);
     size_t idx;
     zval data;
     array_init(&data);
-    zend_update_property(pcbc_lookup_in_result_impl_ce, return_value, ZEND_STRL("data"), &data TSRMLS_CC);
+    zend_update_property(pcbc_lookup_in_result_impl_ce, return_value, ZEND_STRL("data"), &data);
     Z_DELREF(data);
     for (idx = 0; idx < num_results; idx++) {
         zval entry;
@@ -79,7 +77,7 @@ void subdoc_lookup_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
         object_init_ex(&entry, pcbc_lookup_in_result_entry_ce);
 
         zend_update_property_long(pcbc_lookup_in_result_entry_ce, &entry, ZEND_STRL("code"),
-                                  lcb_respsubdoc_result_status(resp, idx) TSRMLS_CC);
+                                  lcb_respsubdoc_result_status(resp, idx));
         const char *bytes;
         size_t nbytes;
         lcb_respsubdoc_result_value(resp, idx, &bytes, &nbytes);
@@ -94,7 +92,7 @@ void subdoc_lookup_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
                          last_error);
             }
         }
-        zend_update_property(pcbc_lookup_in_result_entry_ce, &entry, ZEND_STRL("value"), &value TSRMLS_CC);
+        zend_update_property(pcbc_lookup_in_result_entry_ce, &entry, ZEND_STRL("value"), &value);
         add_index_zval(&data, idx, &entry);
         Z_TRY_ADDREF(entry);
     }
@@ -102,14 +100,12 @@ void subdoc_lookup_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
 
 void subdoc_mutate_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSUBDOC *resp)
 {
-    TSRMLS_FETCH();
-
     const lcb_KEY_VALUE_ERROR_CONTEXT *ectx = NULL;
     struct subdoc_cookie *cookie = NULL;
     lcb_respsubdoc_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respsubdoc_status(resp);
-    zend_update_property_long(pcbc_mutate_in_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
+    zend_update_property_long(pcbc_mutate_in_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
 
     lcb_respsubdoc_error_context(resp, &ectx);
 
@@ -121,7 +117,7 @@ void subdoc_mutate_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
         lcb_respsubdoc_cas(resp, &data);
         zend_string *b64;
         b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-        zend_update_property_str(pcbc_mutate_in_result_impl_ce, return_value, ZEND_STRL("cas"), b64 TSRMLS_CC);
+        zend_update_property_str(pcbc_mutate_in_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
         zend_string_release(b64);
         {
             lcb_MUTATION_TOKEN token = {0};
@@ -131,22 +127,22 @@ void subdoc_mutate_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
                 object_init_ex(&val, pcbc_mutation_token_impl_ce);
 
                 zend_update_property_long(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_id"),
-                                          token.vbid_ TSRMLS_CC);
+                                          token.vbid_);
                 b64 = php_base64_encode((unsigned char *)&token.uuid_, sizeof(token.uuid_));
-                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_uuid"), b64 TSRMLS_CC);
+                zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("partition_uuid"), b64);
                 zend_string_release(b64);
                 b64 = php_base64_encode((unsigned char *)&token.seqno_, sizeof(token.seqno_));
                 zend_update_property_str(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("sequence_number"),
-                                         b64 TSRMLS_CC);
+                                         b64);
                 zend_string_release(b64);
 
                 const char *bucket;
                 lcb_cntl(instance, LCB_CNTL_GET, LCB_CNTL_BUCKETNAME, &bucket);
                 zend_update_property_string(pcbc_mutation_token_impl_ce, &val, ZEND_STRL("bucket_name"),
-                                            bucket TSRMLS_CC);
+                                            bucket);
 
                 zend_update_property(pcbc_mutate_in_result_impl_ce, return_value, ZEND_STRL("mutation_token"),
-                                     &val TSRMLS_CC);
+                                     &val);
                 zval_ptr_dtor(&val);
             }
         }
@@ -155,7 +151,7 @@ void subdoc_mutate_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
     size_t idx;
     zval data;
     array_init(&data);
-    zend_update_property(pcbc_mutate_in_result_impl_ce, return_value, ZEND_STRL("data"), &data TSRMLS_CC);
+    zend_update_property(pcbc_mutate_in_result_impl_ce, return_value, ZEND_STRL("data"), &data);
     Z_DELREF(data);
     for (idx = 0; idx < num_results; idx++) {
         zval entry;
@@ -163,7 +159,7 @@ void subdoc_mutate_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
         object_init_ex(&entry, pcbc_mutate_in_result_entry_ce);
 
         zend_update_property_long(pcbc_mutate_in_result_entry_ce, &entry, ZEND_STRL("code"),
-                                  lcb_respsubdoc_result_status(resp, idx) TSRMLS_CC);
+                                  lcb_respsubdoc_result_status(resp, idx));
         const char *bytes;
         size_t nbytes;
         lcb_respsubdoc_result_value(resp, idx, &bytes, &nbytes);
@@ -178,7 +174,7 @@ void subdoc_mutate_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPSU
                          last_error);
             }
         }
-        zend_update_property(pcbc_mutate_in_result_entry_ce, &entry, ZEND_STRL("value"), &value TSRMLS_CC);
+        zend_update_property(pcbc_mutate_in_result_entry_ce, &entry, ZEND_STRL("value"), &value);
         add_index_zval(&data, idx, &entry);
         Z_TRY_ADDREF(entry);
     }
@@ -189,22 +185,22 @@ zend_class_entry *pcbc_lookup_in_options_ce;
 PHP_METHOD(LookupInOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_lookup_in_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_lookup_in_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(LookupInOptions, withExpiry)
 {
     zend_bool arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "b", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_lookup_in_options_ce, getThis(), ZEND_STRL("with_expiry"), arg TSRMLS_CC);
+    zend_update_property_bool(pcbc_lookup_in_options_ce, getThis(), ZEND_STRL("with_expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -232,7 +228,7 @@ PHP_METHOD(Collection, lookupIn)
     int rv;
 
     rv =
-        zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sh|O!", &id, &spec, &options, pcbc_lookup_in_options_ce);
+        zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sh|O!", &id, &spec, &options, pcbc_lookup_in_options_ce);
     if (rv == FAILURE) {
         return;
     }
@@ -320,14 +316,14 @@ zend_class_entry *pcbc_mutate_in_options_ce;
 PHP_METHOD(MutateInOptions, cas)
 {
     zend_string *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
     zend_string *decoded = php_base64_decode_str(arg);
     if (decoded) {
         if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
-            zend_update_property_str(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("cas"), arg TSRMLS_CC);
+            zend_update_property_str(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("cas"), arg);
         }
         zend_string_free(decoded);
     }
@@ -337,44 +333,44 @@ PHP_METHOD(MutateInOptions, cas)
 PHP_METHOD(MutateInOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(MutateInOptions, expiry)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("expiry"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("expiry"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(MutateInOptions, durabilityLevel)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("durability_level"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("durability_level"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(MutateInOptions, storeSemantics)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("store_semantics"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_mutate_in_options_ce, getThis(), ZEND_STRL("store_semantics"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -417,7 +413,7 @@ PHP_METHOD(Collection, mutateIn)
     int rv;
 
     rv =
-        zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sh|O!", &id, &spec, &options, pcbc_mutate_in_options_ce);
+        zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sh|O!", &id, &spec, &options, pcbc_mutate_in_options_ce);
     if (rv == FAILURE) {
         return;
     }
@@ -621,23 +617,23 @@ PHP_MINIT_FUNCTION(CollectionSubdoc)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "LookupInOptions", pcbc_lookup_in_options_methods);
-    pcbc_lookup_in_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_lookup_in_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_lookup_in_options_ce, ZEND_STRL("with_expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_lookup_in_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_lookup_in_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_lookup_in_options_ce, ZEND_STRL("with_expiry"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateInOptions", pcbc_mutate_in_options_methods);
-    pcbc_mutate_in_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_options_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_options_ce, ZEND_STRL("store_semantics"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutate_in_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_mutate_in_options_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_in_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_in_options_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_in_options_ce, ZEND_STRL("durability_level"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_in_options_ce, ZEND_STRL("store_semantics"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "StoreSemantics", pcbc_store_semantics_methods);
-    pcbc_store_semantics_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_declare_class_constant_long(pcbc_store_semantics_ce, ZEND_STRL("REPLACE"), LCB_SUBDOC_STORE_REPLACE TSRMLS_CC);
-    zend_declare_class_constant_long(pcbc_store_semantics_ce, ZEND_STRL("UPSERT"), LCB_SUBDOC_STORE_UPSERT TSRMLS_CC);
-    zend_declare_class_constant_long(pcbc_store_semantics_ce, ZEND_STRL("INSERT"), LCB_SUBDOC_STORE_INSERT TSRMLS_CC);
+    pcbc_store_semantics_ce = zend_register_internal_interface(&ce);
+    zend_declare_class_constant_long(pcbc_store_semantics_ce, ZEND_STRL("REPLACE"), LCB_SUBDOC_STORE_REPLACE);
+    zend_declare_class_constant_long(pcbc_store_semantics_ce, ZEND_STRL("UPSERT"), LCB_SUBDOC_STORE_UPSERT);
+    zend_declare_class_constant_long(pcbc_store_semantics_ce, ZEND_STRL("INSERT"), LCB_SUBDOC_STORE_INSERT);
 
     return SUCCESS;
 }

--- a/src/couchbase/bucket/touch.c
+++ b/src/couchbase/bucket/touch.c
@@ -32,7 +32,7 @@ void touch_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPTOUCH *res
     lcb_resptouch_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_resptouch_status(resp);
-    zend_update_property_long(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_mutation_result_impl_ce, return_value, ("status"), cookie->rc);
 
     lcb_resptouch_error_context(resp, &ectx);
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_mutation_result_impl_ce, "err_ctx");
@@ -45,7 +45,7 @@ void touch_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPTOUCH *res
             uint64_t data;
             lcb_resptouch_cas(resp, &data);
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
+            pcbc_update_property_str(pcbc_mutation_result_impl_ce, return_value, ("cas"), b64);
             zend_string_release(b64);
         }
     }
@@ -60,7 +60,7 @@ PHP_METHOD(TouchOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_touch_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_touch_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -97,7 +97,7 @@ PHP_METHOD(Collection, touch)
     lcb_cmdtouch_expiry(cmd, expiry);
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_touch_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_touch_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdtouch_timeout(cmd, Z_LVAL_P(prop));
         }

--- a/src/couchbase/bucket/touch.c
+++ b/src/couchbase/bucket/touch.c
@@ -27,14 +27,12 @@ struct touch_cookie {
 
 void touch_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPTOUCH *resp)
 {
-    TSRMLS_FETCH();
-
     const lcb_KEY_VALUE_ERROR_CONTEXT *ectx = NULL;
     struct touch_cookie *cookie = NULL;
     lcb_resptouch_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_resptouch_status(resp);
-    zend_update_property_long(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
+    zend_update_property_long(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
 
     lcb_resptouch_error_context(resp, &ectx);
     set_property_str(ectx, lcb_errctx_kv_context, pcbc_mutation_result_impl_ce, "err_ctx");
@@ -47,7 +45,7 @@ void touch_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPTOUCH *res
             uint64_t data;
             lcb_resptouch_cas(resp, &data);
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("cas"), b64 TSRMLS_CC);
+            zend_update_property_str(pcbc_mutation_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
             zend_string_release(b64);
         }
     }
@@ -58,11 +56,11 @@ zend_class_entry *pcbc_touch_options_ce;
 PHP_METHOD(TouchOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_touch_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_touch_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -86,7 +84,7 @@ PHP_METHOD(Collection, touch)
     zval *options = NULL;
 
     int rv =
-        zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sl|O!", &id, &expiry, &options, pcbc_touch_options_ce);
+        zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sl|O!", &id, &expiry, &options, pcbc_touch_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -136,8 +134,8 @@ PHP_MINIT_FUNCTION(CollectionTouch)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "TouchOptions", pcbc_touch_options_methods);
-    pcbc_touch_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_touch_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_touch_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_touch_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/bucket/unlock.c
+++ b/src/couchbase/bucket/unlock.c
@@ -32,7 +32,7 @@ void unlock_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPUNLOCK *r
     lcb_respunlock_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respunlock_status(resp);
-    zend_update_property_long(pcbc_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_result_impl_ce, return_value, ("status"), cookie->rc);
 
     lcb_respunlock_error_context(resp, &ectx);
 
@@ -46,7 +46,7 @@ void unlock_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPUNLOCK *r
             uint64_t data;
             lcb_respunlock_cas(resp, &data);
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
+            pcbc_update_property_str(pcbc_result_impl_ce, return_value, ("cas"), b64);
             zend_string_release(b64);
         }
     }
@@ -61,7 +61,7 @@ PHP_METHOD(UnlockOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_unlock_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_unlock_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -102,7 +102,7 @@ PHP_METHOD(Collection, unlock)
     }
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_unlock_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_unlock_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdunlock_timeout(cmd, Z_LVAL_P(prop));
         }

--- a/src/couchbase/bucket/unlock.c
+++ b/src/couchbase/bucket/unlock.c
@@ -27,14 +27,12 @@ struct unlock_cookie {
 
 void unlock_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPUNLOCK *resp)
 {
-    TSRMLS_FETCH();
-
     const lcb_KEY_VALUE_ERROR_CONTEXT *ectx = NULL;
     struct unlock_cookie *cookie = NULL;
     lcb_respunlock_cookie(resp, (void **)&cookie);
     zval *return_value = cookie->return_value;
     cookie->rc = lcb_respunlock_status(resp);
-    zend_update_property_long(pcbc_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
+    zend_update_property_long(pcbc_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
 
     lcb_respunlock_error_context(resp, &ectx);
 
@@ -48,7 +46,7 @@ void unlock_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPUNLOCK *r
             uint64_t data;
             lcb_respunlock_cas(resp, &data);
             b64 = php_base64_encode((unsigned char *)&data, sizeof(data));
-            zend_update_property_str(pcbc_result_impl_ce, return_value, ZEND_STRL("cas"), b64 TSRMLS_CC);
+            zend_update_property_str(pcbc_result_impl_ce, return_value, ZEND_STRL("cas"), b64);
             zend_string_release(b64);
         }
     }
@@ -59,11 +57,11 @@ zend_class_entry *pcbc_unlock_options_ce;
 PHP_METHOD(UnlockOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_unlock_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_unlock_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -85,7 +83,7 @@ PHP_METHOD(Collection, unlock)
     zend_string *id, *cas;
     zval *options = NULL;
 
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SS|O!", &id, &cas, &options, pcbc_unlock_options_ce);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "SS|O!", &id, &cas, &options, pcbc_unlock_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -141,8 +139,8 @@ PHP_MINIT_FUNCTION(CollectionUnlock)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "UnlockOptions", pcbc_unlock_options_methods);
-    pcbc_unlock_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_unlock_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_unlock_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_unlock_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/bucket/view.c
+++ b/src/couchbase/bucket/view.c
@@ -42,8 +42,8 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
 
     zval *return_value = cookie->return_value;
 
-    zend_update_property_long(pcbc_view_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
-    zend_update_property_long(pcbc_view_result_impl_ce, return_value, ZEND_STRL("http_status"), htstatus);
+    pcbc_update_property_long(pcbc_view_result_impl_ce, return_value, ("status"), cookie->rc);
+    pcbc_update_property_long(pcbc_view_result_impl_ce, return_value, ("http_status"), htstatus);
 
     int last_error;
     if (cookie->rc == LCB_SUCCESS) {
@@ -64,13 +64,13 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
 
                     mval = zend_symtable_str_find(marr, ZEND_STRL("total_rows"));
                     if (mval && Z_TYPE_P(mval) == IS_LONG) {
-                        zend_update_property(pcbc_view_meta_data_impl_ce, &meta, ZEND_STRL("total_rows"),
+                        pcbc_update_property(pcbc_view_meta_data_impl_ce, &meta, ("total_rows"),
                                              mval);
                     }
                     zval_dtor(&value);
                 }
             }
-            zend_update_property(pcbc_view_result_impl_ce, return_value, ZEND_STRL("meta"), &meta);
+            pcbc_update_property(pcbc_view_result_impl_ce, return_value, ("meta"), &meta);
             zval_ptr_dtor(&meta);
         } else {
             zval entry;
@@ -80,7 +80,7 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
             size_t id_len;
             lcb_respview_doc_id(resp, &id_str, &id_len);
             if (id_len) {
-                zend_update_property_stringl(pcbc_view_result_entry_ce, &entry, ZEND_STRL("id"), id_str,
+                pcbc_update_property_stringl(pcbc_view_result_entry_ce, &entry, ("id"), id_str,
                                              id_len);
             }
 
@@ -94,7 +94,7 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
                     pcbc_log(LOGARGS(instance, WARN), "Failed to decode VIEW key as JSON: json_last_error=%d",
                              last_error);
                 } else {
-                    zend_update_property(pcbc_view_result_entry_ce, &entry, ZEND_STRL("key"), &key);
+                    pcbc_update_property(pcbc_view_result_entry_ce, &entry, ("key"), &key);
                 }
             }
 
@@ -108,7 +108,7 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
                     pcbc_log(LOGARGS(instance, WARN), "Failed to decode VIEW value as JSON: json_last_error=%d",
                              last_error);
                 } else {
-                    zend_update_property(pcbc_view_result_entry_ce, &entry, ZEND_STRL("value"), &value);
+                    pcbc_update_property(pcbc_view_result_entry_ce, &entry, ("value"), &value);
                 }
             }
 
@@ -125,14 +125,14 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
                         pcbc_log(LOGARGS(instance, WARN), "Failed to decode VIEW document as JSON: json_last_error=%d",
                                  last_error);
                     } else {
-                        zend_update_property(pcbc_view_result_entry_ce, &entry, ZEND_STRL("document"),
+                        pcbc_update_property(pcbc_view_result_entry_ce, &entry, ("document"),
                                              &document);
                     }
                 }
             }
 
             zval *rows, rv;
-            rows = zend_read_property(pcbc_view_result_impl_ce, return_value, ZEND_STRL("rows"), 0, &rv);
+            rows = pcbc_read_property(pcbc_view_result_impl_ce, return_value, ("rows"), 0, &rv);
             add_next_index_zval(rows, &entry);
         }
     } else {
@@ -144,10 +144,10 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
             PCBC_JSON_COPY_DECODE(&body, body_str, body_len, PHP_JSON_OBJECT_AS_ARRAY, last_error);
             if (last_error) {
                 pcbc_log(LOGARGS(instance, WARN), "Failed to decode VIEW body as JSON: json_last_error=%d", last_error);
-                zend_update_property_stringl(pcbc_view_result_impl_ce, return_value, ZEND_STRL("body_str"), body_str,
+                pcbc_update_property_stringl(pcbc_view_result_impl_ce, return_value, ("body_str"), body_str,
                                              body_len);
             } else {
-                zend_update_property(pcbc_view_result_impl_ce, return_value, ZEND_STRL("body"), &body);
+                pcbc_update_property(pcbc_view_result_impl_ce, return_value, ("body"), &body);
             }
         }
     }
@@ -168,7 +168,7 @@ PHP_METHOD(ViewOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_view_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_view_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -180,9 +180,9 @@ PHP_METHOD(ViewOptions, includeDocuments)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_view_options_ce, getThis(), ZEND_STRL("include_docs"), arg);
+    pcbc_update_property_bool(pcbc_view_options_ce, getThis(), ("include_docs"), arg);
     if (mcd) {
-        zend_update_property_long(pcbc_view_options_ce, getThis(), ZEND_STRL("max_concurrent_docs"), mcd);
+        pcbc_update_property_long(pcbc_view_options_ce, getThis(), ("max_concurrent_docs"), mcd);
     }
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -195,11 +195,11 @@ PHP_METHOD(ViewOptions, key)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), 0, &rv1);
+    data = pcbc_read_property(pcbc_view_options_ce, getThis(), ("query"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
+        pcbc_update_property(pcbc_view_options_ce, getThis(), ("query"), data);
         Z_DELREF_P(data);
     }
     {
@@ -225,11 +225,11 @@ PHP_METHOD(ViewOptions, limit)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), 0, &rv1);
+    data = pcbc_read_property(pcbc_view_options_ce, getThis(), ("query"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
+        pcbc_update_property(pcbc_view_options_ce, getThis(), ("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_long_ex(data, ZEND_STRL("limit"), arg);
@@ -244,11 +244,11 @@ PHP_METHOD(ViewOptions, skip)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), 0, &rv1);
+    data = pcbc_read_property(pcbc_view_options_ce, getThis(), ("query"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
+        pcbc_update_property(pcbc_view_options_ce, getThis(), ("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_long_ex(data, ZEND_STRL("skip"), arg);
@@ -263,11 +263,11 @@ PHP_METHOD(ViewOptions, scanConsistency)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), 0, &rv1);
+    data = pcbc_read_property(pcbc_view_options_ce, getThis(), ("query"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
+        pcbc_update_property(pcbc_view_options_ce, getThis(), ("query"), data);
         Z_DELREF_P(data);
     }
     switch (arg) {
@@ -292,11 +292,11 @@ PHP_METHOD(ViewOptions, order)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), 0, &rv1);
+    data = pcbc_read_property(pcbc_view_options_ce, getThis(), ("query"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
+        pcbc_update_property(pcbc_view_options_ce, getThis(), ("query"), data);
         Z_DELREF_P(data);
     }
     switch (arg) {
@@ -318,11 +318,11 @@ PHP_METHOD(ViewOptions, reduce)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), 0, &rv1);
+    data = pcbc_read_property(pcbc_view_options_ce, getThis(), ("query"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
+        pcbc_update_property(pcbc_view_options_ce, getThis(), ("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_string_ex(data, ZEND_STRL("reduce"), arg ? "true" : "false");
@@ -337,11 +337,11 @@ PHP_METHOD(ViewOptions, group)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), 0, &rv1);
+    data = pcbc_read_property(pcbc_view_options_ce, getThis(), ("query"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
+        pcbc_update_property(pcbc_view_options_ce, getThis(), ("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_string_ex(data, ZEND_STRL("group"), arg ? "true" : "false");
@@ -356,11 +356,11 @@ PHP_METHOD(ViewOptions, groupLevel)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), 0, &rv1);
+    data = pcbc_read_property(pcbc_view_options_ce, getThis(), ("query"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
+        pcbc_update_property(pcbc_view_options_ce, getThis(), ("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_long_ex(data, ZEND_STRL("group_level"), arg);
@@ -376,11 +376,11 @@ PHP_METHOD(ViewOptions, range)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), 0, &rv1);
+    data = pcbc_read_property(pcbc_view_options_ce, getThis(), ("query"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
+        pcbc_update_property(pcbc_view_options_ce, getThis(), ("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_string_ex(data, ZEND_STRL("inclusive_end"), inclusive_end ? "true" : "false");
@@ -421,11 +421,11 @@ PHP_METHOD(ViewOptions, idRange)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), 0, &rv1);
+    data = pcbc_read_property(pcbc_view_options_ce, getThis(), ("query"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
+        pcbc_update_property(pcbc_view_options_ce, getThis(), ("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_string_ex(data, ZEND_STRL("inclusive_end"), inclusive_end ? "true" : "false");
@@ -445,11 +445,11 @@ PHP_METHOD(ViewOptions, raw)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), 0, &rv1);
+    data = pcbc_read_property(pcbc_view_options_ce, getThis(), ("query"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
+        pcbc_update_property(pcbc_view_options_ce, getThis(), ("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_str_ex(data, ZSTR_VAL(key), ZSTR_LEN(key), zend_string_copy(value));
@@ -465,11 +465,11 @@ PHP_METHOD(ViewOptions, keys)
         RETURN_NULL();
     }
     zval *data, rv1;
-    data = zend_read_property(pcbc_view_options_ce, getThis(), ZEND_STRL("body"), 0, &rv1);
+    data = pcbc_read_property(pcbc_view_options_ce, getThis(), ("body"), 0, &rv1);
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("body"), data);
+        pcbc_update_property(pcbc_view_options_ce, getThis(), ("body"), data);
         Z_DELREF_P(data);
     }
     add_assoc_zval_ex(data, ZEND_STRL("keys"), arg);
@@ -584,11 +584,11 @@ PHP_METHOD(Bucket, viewQuery)
     smart_str query_str = {0}, body_str = {0};
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_view_options_ce, options, ZEND_STRL("timeout"), 0, &ret);
+        prop = pcbc_read_property(pcbc_view_options_ce, options, ("timeout"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdview_timeout(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_view_options_ce, options, ZEND_STRL("include_docs"), 0, &ret);
+        prop = pcbc_read_property(pcbc_view_options_ce, options, ("include_docs"), 0, &ret);
         switch (Z_TYPE_P(prop)) {
         case IS_TRUE:
             lcb_cmdview_include_docs(cmd, 1);
@@ -597,11 +597,11 @@ PHP_METHOD(Bucket, viewQuery)
             lcb_cmdview_include_docs(cmd, 0);
             break;
         }
-        prop = zend_read_property(pcbc_view_options_ce, options, ZEND_STRL("max_concurrent_docs"), 0, &ret);
+        prop = pcbc_read_property(pcbc_view_options_ce, options, ("max_concurrent_docs"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             lcb_cmdview_max_concurrent_docs(cmd, Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_view_options_ce, options, ZEND_STRL("query"), 0, &ret);
+        prop = pcbc_read_property(pcbc_view_options_ce, options, ("query"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_ARRAY) {
             php_url_encode_hash_ex(HASH_OF(prop), &query_str, NULL, 0, NULL, 0, NULL, 0, NULL, NULL,
                                         PHP_QUERY_RFC1738);
@@ -609,7 +609,7 @@ PHP_METHOD(Bucket, viewQuery)
                 lcb_cmdview_option_string(cmd, ZSTR_VAL(query_str.s), ZSTR_LEN(query_str.s));
             }
         }
-        prop = zend_read_property(pcbc_view_options_ce, options, ZEND_STRL("body"), 0, &ret);
+        prop = pcbc_read_property(pcbc_view_options_ce, options, ("body"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_ARRAY) {
             int last_error;
             PCBC_JSON_ENCODE(&body_str, prop, 0, last_error);
@@ -643,7 +643,7 @@ PHP_METHOD(Bucket, viewQuery)
     }
     zval rows;
     array_init(&rows);
-    zend_update_property(pcbc_view_result_impl_ce, return_value, ZEND_STRL("rows"), &rows);
+    pcbc_update_property(pcbc_view_result_impl_ce, return_value, ("rows"), &rows);
     Z_DELREF(rows);
     struct view_cookie cookie = {LCB_SUCCESS, return_value};
     lcb_STATUS err = lcb_view(obj->conn->lcb, &cookie, cmd);

--- a/src/couchbase/bucket/view.c
+++ b/src/couchbase/bucket/view.c
@@ -603,15 +603,10 @@ PHP_METHOD(Bucket, viewQuery)
         }
         prop = zend_read_property(pcbc_view_options_ce, options, ZEND_STRL("query"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_ARRAY) {
-            rv = php_url_encode_hash_ex(HASH_OF(prop), &query_str, NULL, 0, NULL, 0, NULL, 0, NULL, NULL,
+            php_url_encode_hash_ex(HASH_OF(prop), &query_str, NULL, 0, NULL, 0, NULL, 0, NULL, NULL,
                                         PHP_QUERY_RFC1738);
-            if (rv == FAILURE) {
-                pcbc_log(LOGARGS(obj->conn->lcb, WARN), "Failed to encode views query options as RFC1738 string");
-                smart_str_free(&query_str);
-            } else {
-                if (!PCBC_SMARTSTR_EMPTY(query_str)) {
-                    lcb_cmdview_option_string(cmd, ZSTR_VAL(query_str.s), ZSTR_LEN(query_str.s));
-                }
+            if (!PCBC_SMARTSTR_EMPTY(query_str)) {
+                lcb_cmdview_option_string(cmd, ZSTR_VAL(query_str.s), ZSTR_LEN(query_str.s));
             }
         }
         prop = zend_read_property(pcbc_view_options_ce, options, ZEND_STRL("body"), 0, &ret);

--- a/src/couchbase/bucket/view.c
+++ b/src/couchbase/bucket/view.c
@@ -31,8 +31,6 @@ struct view_cookie {
 
 static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RESPVIEW *resp)
 {
-    TSRMLS_FETCH();
-
     struct view_cookie *cookie;
     lcb_respview_cookie(resp, (void **)&cookie);
     cookie->rc = lcb_respview_status(resp);
@@ -44,8 +42,8 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
 
     zval *return_value = cookie->return_value;
 
-    zend_update_property_long(pcbc_view_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc TSRMLS_CC);
-    zend_update_property_long(pcbc_view_result_impl_ce, return_value, ZEND_STRL("http_status"), htstatus TSRMLS_CC);
+    zend_update_property_long(pcbc_view_result_impl_ce, return_value, ZEND_STRL("status"), cookie->rc);
+    zend_update_property_long(pcbc_view_result_impl_ce, return_value, ZEND_STRL("http_status"), htstatus);
 
     int last_error;
     if (cookie->rc == LCB_SUCCESS) {
@@ -67,12 +65,12 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
                     mval = zend_symtable_str_find(marr, ZEND_STRL("total_rows"));
                     if (mval && Z_TYPE_P(mval) == IS_LONG) {
                         zend_update_property(pcbc_view_meta_data_impl_ce, &meta, ZEND_STRL("total_rows"),
-                                             mval TSRMLS_CC);
+                                             mval);
                     }
                     zval_dtor(&value);
                 }
             }
-            zend_update_property(pcbc_view_result_impl_ce, return_value, ZEND_STRL("meta"), &meta TSRMLS_CC);
+            zend_update_property(pcbc_view_result_impl_ce, return_value, ZEND_STRL("meta"), &meta);
             zval_ptr_dtor(&meta);
         } else {
             zval entry;
@@ -83,7 +81,7 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
             lcb_respview_doc_id(resp, &id_str, &id_len);
             if (id_len) {
                 zend_update_property_stringl(pcbc_view_result_entry_ce, &entry, ZEND_STRL("id"), id_str,
-                                             id_len TSRMLS_CC);
+                                             id_len);
             }
 
             const char *key_str;
@@ -96,7 +94,7 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
                     pcbc_log(LOGARGS(instance, WARN), "Failed to decode VIEW key as JSON: json_last_error=%d",
                              last_error);
                 } else {
-                    zend_update_property(pcbc_view_result_entry_ce, &entry, ZEND_STRL("key"), &key TSRMLS_CC);
+                    zend_update_property(pcbc_view_result_entry_ce, &entry, ZEND_STRL("key"), &key);
                 }
             }
 
@@ -110,7 +108,7 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
                     pcbc_log(LOGARGS(instance, WARN), "Failed to decode VIEW value as JSON: json_last_error=%d",
                              last_error);
                 } else {
-                    zend_update_property(pcbc_view_result_entry_ce, &entry, ZEND_STRL("value"), &value TSRMLS_CC);
+                    zend_update_property(pcbc_view_result_entry_ce, &entry, ZEND_STRL("value"), &value);
                 }
             }
 
@@ -128,7 +126,7 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
                                  last_error);
                     } else {
                         zend_update_property(pcbc_view_result_entry_ce, &entry, ZEND_STRL("document"),
-                                             &document TSRMLS_CC);
+                                             &document);
                     }
                 }
             }
@@ -147,9 +145,9 @@ static void viewrow_callback(lcb_INSTANCE *instance, int ignoreme, const lcb_RES
             if (last_error) {
                 pcbc_log(LOGARGS(instance, WARN), "Failed to decode VIEW body as JSON: json_last_error=%d", last_error);
                 zend_update_property_stringl(pcbc_view_result_impl_ce, return_value, ZEND_STRL("body_str"), body_str,
-                                             body_len TSRMLS_CC);
+                                             body_len);
             } else {
-                zend_update_property(pcbc_view_result_impl_ce, return_value, ZEND_STRL("body"), &body TSRMLS_CC);
+                zend_update_property(pcbc_view_result_impl_ce, return_value, ZEND_STRL("body"), &body);
             }
         }
     }
@@ -166,11 +164,11 @@ zend_class_entry *pcbc_view_options_ce;
 PHP_METHOD(ViewOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_view_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_view_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -178,13 +176,13 @@ PHP_METHOD(ViewOptions, includeDocuments)
 {
     zend_bool arg;
     zend_long mcd = 0;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b|l", &arg, &mcd);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "b|l", &arg, &mcd);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_view_options_ce, getThis(), ZEND_STRL("include_docs"), arg TSRMLS_CC);
+    zend_update_property_bool(pcbc_view_options_ce, getThis(), ZEND_STRL("include_docs"), arg);
     if (mcd) {
-        zend_update_property_long(pcbc_view_options_ce, getThis(), ZEND_STRL("max_concurrent_docs"), mcd TSRMLS_CC);
+        zend_update_property_long(pcbc_view_options_ce, getThis(), ZEND_STRL("max_concurrent_docs"), mcd);
     }
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -192,7 +190,7 @@ PHP_METHOD(ViewOptions, includeDocuments)
 PHP_METHOD(ViewOptions, key)
 {
     zval *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "z", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -201,7 +199,7 @@ PHP_METHOD(ViewOptions, key)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data TSRMLS_CC);
+        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
         Z_DELREF_P(data);
     }
     {
@@ -214,7 +212,7 @@ PHP_METHOD(ViewOptions, key)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        add_assoc_str_ex(data, ZEND_STRL("key"), buf.s TSRMLS_CC);
+        add_assoc_str_ex(data, ZEND_STRL("key"), buf.s);
     }
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -222,7 +220,7 @@ PHP_METHOD(ViewOptions, key)
 PHP_METHOD(ViewOptions, limit)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -231,7 +229,7 @@ PHP_METHOD(ViewOptions, limit)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data TSRMLS_CC);
+        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_long_ex(data, ZEND_STRL("limit"), arg);
@@ -241,7 +239,7 @@ PHP_METHOD(ViewOptions, limit)
 PHP_METHOD(ViewOptions, skip)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -250,7 +248,7 @@ PHP_METHOD(ViewOptions, skip)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data TSRMLS_CC);
+        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_long_ex(data, ZEND_STRL("skip"), arg);
@@ -260,7 +258,7 @@ PHP_METHOD(ViewOptions, skip)
 PHP_METHOD(ViewOptions, scanConsistency)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -269,7 +267,7 @@ PHP_METHOD(ViewOptions, scanConsistency)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data TSRMLS_CC);
+        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
         Z_DELREF_P(data);
     }
     switch (arg) {
@@ -289,7 +287,7 @@ PHP_METHOD(ViewOptions, scanConsistency)
 PHP_METHOD(ViewOptions, order)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -298,7 +296,7 @@ PHP_METHOD(ViewOptions, order)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data TSRMLS_CC);
+        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
         Z_DELREF_P(data);
     }
     switch (arg) {
@@ -315,7 +313,7 @@ PHP_METHOD(ViewOptions, order)
 PHP_METHOD(ViewOptions, reduce)
 {
     zend_bool arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "b", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -324,7 +322,7 @@ PHP_METHOD(ViewOptions, reduce)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data TSRMLS_CC);
+        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_string_ex(data, ZEND_STRL("reduce"), arg ? "true" : "false");
@@ -334,7 +332,7 @@ PHP_METHOD(ViewOptions, reduce)
 PHP_METHOD(ViewOptions, group)
 {
     zend_bool arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "b", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -343,7 +341,7 @@ PHP_METHOD(ViewOptions, group)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data TSRMLS_CC);
+        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_string_ex(data, ZEND_STRL("group"), arg ? "true" : "false");
@@ -353,7 +351,7 @@ PHP_METHOD(ViewOptions, group)
 PHP_METHOD(ViewOptions, groupLevel)
 {
     zend_long arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -362,7 +360,7 @@ PHP_METHOD(ViewOptions, groupLevel)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data TSRMLS_CC);
+        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_long_ex(data, ZEND_STRL("group_level"), arg);
@@ -373,7 +371,7 @@ PHP_METHOD(ViewOptions, range)
 {
     zval *start, *end = NULL;
     zend_bool inclusive_end = 0;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zz!|b", &start, &end, &inclusive_end);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "zz!|b", &start, &end, &inclusive_end);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -382,7 +380,7 @@ PHP_METHOD(ViewOptions, range)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data TSRMLS_CC);
+        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_string_ex(data, ZEND_STRL("inclusive_end"), inclusive_end ? "true" : "false");
@@ -396,7 +394,7 @@ PHP_METHOD(ViewOptions, range)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        add_assoc_str_ex(data, ZEND_STRL("startkey"), buf.s TSRMLS_CC);
+        add_assoc_str_ex(data, ZEND_STRL("startkey"), buf.s);
     }
     if (end != NULL) {
         smart_str buf = {0};
@@ -408,7 +406,7 @@ PHP_METHOD(ViewOptions, range)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        add_assoc_str_ex(data, ZEND_STRL("endkey"), buf.s TSRMLS_CC);
+        add_assoc_str_ex(data, ZEND_STRL("endkey"), buf.s);
     }
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -418,7 +416,7 @@ PHP_METHOD(ViewOptions, idRange)
 {
     zend_string *start, *end = NULL;
     zend_bool inclusive_end = 0;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SS!|b", &start, &end, &inclusive_end);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "SS!|b", &start, &end, &inclusive_end);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -427,13 +425,13 @@ PHP_METHOD(ViewOptions, idRange)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data TSRMLS_CC);
+        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
         Z_DELREF_P(data);
     }
     add_assoc_string_ex(data, ZEND_STRL("inclusive_end"), inclusive_end ? "true" : "false");
-    add_assoc_str_ex(data, ZEND_STRL("startkey_docid"), zend_string_copy(start) TSRMLS_CC);
+    add_assoc_str_ex(data, ZEND_STRL("startkey_docid"), zend_string_copy(start));
     if (end != NULL) {
-        add_assoc_str_ex(data, ZEND_STRL("endkey_docid"), zend_string_copy(end) TSRMLS_CC);
+        add_assoc_str_ex(data, ZEND_STRL("endkey_docid"), zend_string_copy(end));
     }
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -442,7 +440,7 @@ PHP_METHOD(ViewOptions, idRange)
 PHP_METHOD(ViewOptions, raw)
 {
     zend_string *key, *value;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SS", &key, &value);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "SS", &key, &value);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -451,10 +449,10 @@ PHP_METHOD(ViewOptions, raw)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data TSRMLS_CC);
+        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("query"), data);
         Z_DELREF_P(data);
     }
-    add_assoc_str_ex(data, ZSTR_VAL(key), ZSTR_LEN(key), zend_string_copy(value) TSRMLS_CC);
+    add_assoc_str_ex(data, ZSTR_VAL(key), ZSTR_LEN(key), zend_string_copy(value));
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -462,7 +460,7 @@ PHP_METHOD(ViewOptions, raw)
 PHP_METHOD(ViewOptions, keys)
 {
     zval *arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "a", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -471,7 +469,7 @@ PHP_METHOD(ViewOptions, keys)
     if (Z_TYPE_P(data) == IS_NULL) {
         array_init(&rv1);
         data = &rv1;
-        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("body"), data TSRMLS_CC);
+        zend_update_property(pcbc_view_options_ce, getThis(), ZEND_STRL("body"), data);
         Z_DELREF_P(data);
     }
     add_assoc_zval_ex(data, ZEND_STRL("keys"), arg);
@@ -568,7 +566,7 @@ PHP_METHOD(Bucket, viewQuery)
     zend_string *view_name;
     zval *options = NULL;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SS|O!", &design_doc, &view_name, &options,
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "SS|O!", &design_doc, &view_name, &options,
                                pcbc_view_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
@@ -606,7 +604,7 @@ PHP_METHOD(Bucket, viewQuery)
         prop = zend_read_property(pcbc_view_options_ce, options, ZEND_STRL("query"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_ARRAY) {
             rv = php_url_encode_hash_ex(HASH_OF(prop), &query_str, NULL, 0, NULL, 0, NULL, 0, NULL, NULL,
-                                        PHP_QUERY_RFC1738 TSRMLS_CC);
+                                        PHP_QUERY_RFC1738);
             if (rv == FAILURE) {
                 pcbc_log(LOGARGS(obj->conn->lcb, WARN), "Failed to encode views query options as RFC1738 string");
                 smart_str_free(&query_str);
@@ -650,7 +648,7 @@ PHP_METHOD(Bucket, viewQuery)
     }
     zval rows;
     array_init(&rows);
-    zend_update_property(pcbc_view_result_impl_ce, return_value, ZEND_STRL("rows"), &rows TSRMLS_CC);
+    zend_update_property(pcbc_view_result_impl_ce, return_value, ZEND_STRL("rows"), &rows);
     Z_DELREF(rows);
     struct view_cookie cookie = {LCB_SUCCESS, return_value};
     lcb_STATUS err = lcb_view(obj->conn->lcb, &cookie, cmd);
@@ -674,25 +672,25 @@ PHP_MINIT_FUNCTION(BucketView)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ViewOptions", pcbc_view_options_methods);
-    pcbc_view_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_view_options_ce = zend_register_internal_class(&ce);
 
-    zend_declare_property_null(pcbc_view_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_options_ce, ZEND_STRL("include_docs"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_options_ce, ZEND_STRL("max_concurrent_docs"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_view_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_options_ce, ZEND_STRL("include_docs"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_options_ce, ZEND_STRL("max_concurrent_docs"), ZEND_ACC_PRIVATE);
 
-    zend_declare_property_null(pcbc_view_options_ce, ZEND_STRL("query"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_options_ce, ZEND_STRL("body"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_view_options_ce, ZEND_STRL("query"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_options_ce, ZEND_STRL("body"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ViewScanConsistency", pcbc_view_consistency_methods);
-    pcbc_view_consistency_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_declare_class_constant_long(pcbc_view_consistency_ce, ZEND_STRL("NOT_BOUNDED"), 0 TSRMLS_CC);
-    zend_declare_class_constant_long(pcbc_view_consistency_ce, ZEND_STRL("REQUEST_PLUS"), 1 TSRMLS_CC);
-    zend_declare_class_constant_long(pcbc_view_consistency_ce, ZEND_STRL("UPDATE_AFTER"), 2 TSRMLS_CC);
+    pcbc_view_consistency_ce = zend_register_internal_interface(&ce);
+    zend_declare_class_constant_long(pcbc_view_consistency_ce, ZEND_STRL("NOT_BOUNDED"), 0);
+    zend_declare_class_constant_long(pcbc_view_consistency_ce, ZEND_STRL("REQUEST_PLUS"), 1);
+    zend_declare_class_constant_long(pcbc_view_consistency_ce, ZEND_STRL("UPDATE_AFTER"), 2);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ViewOrdering", pcbc_view_order_methods);
-    pcbc_view_order_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_declare_class_constant_long(pcbc_view_order_ce, ZEND_STRL("ASCENDING"), 0 TSRMLS_CC);
-    zend_declare_class_constant_long(pcbc_view_order_ce, ZEND_STRL("DESCENDING"), 1 TSRMLS_CC);
+    pcbc_view_order_ce = zend_register_internal_interface(&ce);
+    zend_declare_class_constant_long(pcbc_view_order_ce, ZEND_STRL("ASCENDING"), 0);
+    zend_declare_class_constant_long(pcbc_view_order_ce, ZEND_STRL("DESCENDING"), 1);
 
     return SUCCESS;
 }

--- a/src/couchbase/cert_authenticator.c
+++ b/src/couchbase/cert_authenticator.c
@@ -44,20 +44,20 @@ zend_function_entry cert_authenticator_methods[] = {
 
 zend_object_handlers cert_authenticator_handlers;
 
-static void cert_authenticator_free_object(zend_object *object TSRMLS_DC)
+static void cert_authenticator_free_object(zend_object *object)
 {
     pcbc_cert_authenticator_t *obj = Z_CERT_AUTHENTICATOR_OBJ(object);
 
-    zend_object_std_dtor(&obj->std TSRMLS_CC);
+    zend_object_std_dtor(&obj->std);
 }
 
-static zend_object *authenticator_create_object(zend_class_entry *class_type TSRMLS_DC)
+static zend_object *authenticator_create_object(zend_class_entry *class_type)
 {
     pcbc_cert_authenticator_t *obj = NULL;
 
     obj = PCBC_ALLOC_OBJECT_T(pcbc_cert_authenticator_t, class_type);
 
-    zend_object_std_init(&obj->std, class_type TSRMLS_CC);
+    zend_object_std_init(&obj->std, class_type);
     object_properties_init(&obj->std, class_type);
 
     obj->std.handlers = &cert_authenticator_handlers;
@@ -69,11 +69,11 @@ PHP_MINIT_FUNCTION(CertAuthenticator)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "CertAuthenticator", cert_authenticator_methods);
-    pcbc_cert_authenticator_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_cert_authenticator_ce = zend_register_internal_class(&ce);
     pcbc_cert_authenticator_ce->create_object = authenticator_create_object;
     PCBC_CE_DISABLE_SERIALIZATION(pcbc_cert_authenticator_ce);
 
-    zend_class_implements(pcbc_cert_authenticator_ce TSRMLS_CC, 1, pcbc_authenticator_ce);
+    zend_class_implements(pcbc_cert_authenticator_ce, 1, pcbc_authenticator_ce);
 
     memcpy(&cert_authenticator_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     cert_authenticator_handlers.free_obj = cert_authenticator_free_object;

--- a/src/couchbase/cluster.c
+++ b/src/couchbase/cluster.c
@@ -107,13 +107,13 @@ PHP_METHOD(Cluster, __construct)
         RETURN_NULL();
     }
     zval *prop, ret;
-    prop = zend_read_property(pcbc_cluster_options_ce, options, ZEND_STRL("username"), 0, &ret);
+    prop = pcbc_read_property(pcbc_cluster_options_ce, options, ("username"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_STRING) {
         zend_type_error("Username option must be specified");
         RETURN_NULL();
     }
     obj->username = estrndup(Z_STRVAL_P(prop), Z_STRLEN_P(prop));
-    prop = zend_read_property(pcbc_cluster_options_ce, options, ZEND_STRL("password"), 0, &ret);
+    prop = pcbc_read_property(pcbc_cluster_options_ce, options, ("password"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_STRING) {
         zend_type_error("Password option must be specified");
         RETURN_NULL();
@@ -151,7 +151,7 @@ PHP_METHOD(Cluster, buckets)
     }
 
     object_init_ex(return_value, pcbc_bucket_manager_ce);
-    zend_update_property(pcbc_bucket_manager_ce, return_value, ZEND_STRL("cluster"), getThis());
+    pcbc_update_property(pcbc_bucket_manager_ce, return_value, ("cluster"), getThis());
 }
 
 PHP_METHOD(Cluster, queryIndexes)
@@ -161,7 +161,7 @@ PHP_METHOD(Cluster, queryIndexes)
     }
 
     object_init_ex(return_value, pcbc_query_index_manager_ce);
-    zend_update_property(pcbc_query_index_manager_ce, return_value, ZEND_STRL("cluster"), getThis());
+    pcbc_update_property(pcbc_query_index_manager_ce, return_value, ("cluster"), getThis());
 }
 
 PHP_METHOD(Cluster, searchIndexes)
@@ -170,7 +170,7 @@ PHP_METHOD(Cluster, searchIndexes)
         RETURN_NULL();
     }
     object_init_ex(return_value, pcbc_search_index_manager_ce);
-    zend_update_property(pcbc_search_index_manager_ce, return_value, ZEND_STRL("cluster"), getThis());
+    pcbc_update_property(pcbc_search_index_manager_ce, return_value, ("cluster"), getThis());
 }
 
 PHP_METHOD(Cluster, users)
@@ -179,7 +179,7 @@ PHP_METHOD(Cluster, users)
         RETURN_NULL();
     }
     object_init_ex(return_value, pcbc_user_manager_ce);
-    zend_update_property(pcbc_user_manager_ce, return_value, ZEND_STRL("cluster"), getThis());
+    pcbc_update_property(pcbc_user_manager_ce, return_value, ("cluster"), getThis());
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_Cluster_constructor, 0, 0, 2)
@@ -266,13 +266,18 @@ static zend_object *pcbc_cluster_create_object(zend_class_entry *class_type)
     return &obj->std;
 }
 
+#if PHP_VERSION_ID < 80000
 static HashTable *pcbc_cluster_get_debug_info(zval *object, int *is_temp)
 {
-    pcbc_cluster_t *obj = NULL;
+    pcbc_cluster_t *obj = Z_CLUSTER_OBJ_P(object);
+#else
+static HashTable *pcbc_cluster_get_debug_info(zend_object *object, int *is_temp)
+{
+    pcbc_cluster_t *obj = pcbc_cluster_fetch_object(object);
+#endif
     zval retval;
 
     *is_temp = 1;
-    obj = Z_CLUSTER_OBJ_P(object);
 
     array_init(&retval);
     add_assoc_string(&retval, "connstr", obj->connstr);

--- a/src/couchbase/cluster_options.c
+++ b/src/couchbase/cluster_options.c
@@ -22,12 +22,12 @@ zend_class_entry *pcbc_cluster_options_ce;
 PHP_METHOD(ClusterOptions, credentials)
 {
     zend_string *username, *password;
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "SS", &username, &password);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "SS", &username, &password);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_cluster_options_ce, getThis(), ZEND_STRL("username"), username TSRMLS_CC);
-    zend_update_property_str(pcbc_cluster_options_ce, getThis(), ZEND_STRL("password"), password TSRMLS_CC);
+    zend_update_property_str(pcbc_cluster_options_ce, getThis(), ZEND_STRL("username"), username);
+    zend_update_property_str(pcbc_cluster_options_ce, getThis(), ZEND_STRL("password"), password);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -48,10 +48,10 @@ PHP_MINIT_FUNCTION(ClusterOptions)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ClusterOptions", cluster_options_methods);
-    pcbc_cluster_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_cluster_options_ce = zend_register_internal_class(&ce);
 
-    zend_declare_property_null(pcbc_cluster_options_ce, ZEND_STRL("username"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_cluster_options_ce, ZEND_STRL("password"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_cluster_options_ce, ZEND_STRL("username"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_cluster_options_ce, ZEND_STRL("password"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/cluster_options.c
+++ b/src/couchbase/cluster_options.c
@@ -26,8 +26,8 @@ PHP_METHOD(ClusterOptions, credentials)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_cluster_options_ce, getThis(), ZEND_STRL("username"), username);
-    zend_update_property_str(pcbc_cluster_options_ce, getThis(), ZEND_STRL("password"), password);
+    pcbc_update_property_str(pcbc_cluster_options_ce, getThis(), ("username"), username);
+    pcbc_update_property_str(pcbc_cluster_options_ce, getThis(), ("password"), password);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 

--- a/src/couchbase/collection.c
+++ b/src/couchbase/collection.c
@@ -32,9 +32,9 @@ PHP_METHOD(Scope, __construct)
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_collection_ce, getThis(), ZEND_STRL("bucket"), bucket);
+    pcbc_update_property(pcbc_collection_ce, getThis(), ("bucket"), bucket);
     if (name) {
-        zend_update_property_str(pcbc_collection_ce, getThis(), ZEND_STRL("name"), name);
+        pcbc_update_property_str(pcbc_collection_ce, getThis(), ("name"), name);
     }
 }
 
@@ -45,7 +45,7 @@ PHP_METHOD(Scope, name)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_scope_ce, getThis(), ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_scope_ce, getThis(), ("name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -60,13 +60,13 @@ PHP_METHOD(Scope, collection)
     }
 
     object_init_ex(return_value, pcbc_collection_ce);
-    zend_update_property_str(pcbc_collection_ce, return_value, ZEND_STRL("name"), name);
+    pcbc_update_property_str(pcbc_collection_ce, return_value, ("name"), name);
 
     zval *bucket, *scope, rv1, rv2;
-    scope = zend_read_property(pcbc_scope_ce, getThis(), ZEND_STRL("name"), 0, &rv1);
-    zend_update_property(pcbc_collection_ce, return_value, ZEND_STRL("scope"), scope);
-    bucket = zend_read_property(pcbc_scope_ce, getThis(), ZEND_STRL("bucket"), 0, &rv2);
-    zend_update_property(pcbc_collection_ce, return_value, ZEND_STRL("bucket"), bucket);
+    scope = pcbc_read_property(pcbc_scope_ce, getThis(), ("name"), 0, &rv1);
+    pcbc_update_property(pcbc_collection_ce, return_value, ("scope"), scope);
+    bucket = pcbc_read_property(pcbc_scope_ce, getThis(), ("bucket"), 0, &rv2);
+    pcbc_update_property(pcbc_collection_ce, return_value, ("bucket"), bucket);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_Scope___construct, 0, 0, 1)
@@ -100,12 +100,12 @@ PHP_METHOD(Collection, __construct)
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_collection_ce, getThis(), ZEND_STRL("bucket"), bucket);
+    pcbc_update_property(pcbc_collection_ce, getThis(), ("bucket"), bucket);
     if (scope) {
-        zend_update_property_str(pcbc_collection_ce, getThis(), ZEND_STRL("scope"), scope);
+        pcbc_update_property_str(pcbc_collection_ce, getThis(), ("scope"), scope);
     }
     if (name) {
-        zend_update_property_str(pcbc_collection_ce, getThis(), ZEND_STRL("name"), name);
+        pcbc_update_property_str(pcbc_collection_ce, getThis(), ("name"), name);
     }
 }
 
@@ -116,12 +116,12 @@ PHP_METHOD(Collection, binary)
     }
     object_init_ex(return_value, pcbc_binary_collection_ce);
     zval *bucket, *scope, *collection, rv1, rv2, rv3;
-    bucket = zend_read_property(pcbc_collection_ce, getThis(), ZEND_STRL("bucket"), 0, &rv2);
-    zend_update_property(pcbc_binary_collection_ce, return_value, ZEND_STRL("bucket"), bucket);
-    collection = zend_read_property(pcbc_collection_ce, getThis(), ZEND_STRL("name"), 0, &rv3);
-    zend_update_property(pcbc_binary_collection_ce, return_value, ZEND_STRL("name"), collection);
-    scope = zend_read_property(pcbc_collection_ce, getThis(), ZEND_STRL("scope"), 0, &rv1);
-    zend_update_property(pcbc_binary_collection_ce, return_value, ZEND_STRL("scope"), scope);
+    bucket = pcbc_read_property(pcbc_collection_ce, getThis(), ("bucket"), 0, &rv2);
+    pcbc_update_property(pcbc_binary_collection_ce, return_value, ("bucket"), bucket);
+    collection = pcbc_read_property(pcbc_collection_ce, getThis(), ("name"), 0, &rv3);
+    pcbc_update_property(pcbc_binary_collection_ce, return_value, ("name"), collection);
+    scope = pcbc_read_property(pcbc_collection_ce, getThis(), ("scope"), 0, &rv1);
+    pcbc_update_property(pcbc_binary_collection_ce, return_value, ("scope"), scope);
 }
 
 PHP_METHOD(Collection, name)
@@ -131,7 +131,7 @@ PHP_METHOD(Collection, name)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_collection_ce, getThis(), ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_collection_ce, getThis(), ("name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -142,7 +142,7 @@ PHP_METHOD(BinaryCollection, name)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_binary_collection_ce, getThis(), ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_binary_collection_ce, getThis(), ("name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 

--- a/src/couchbase/collection.c
+++ b/src/couchbase/collection.c
@@ -27,14 +27,14 @@ PHP_METHOD(Scope, __construct)
     zend_string *name = NULL;
     zval *bucket;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "OS!", &bucket, pcbc_bucket_ce, &name);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "OS!", &bucket, pcbc_bucket_ce, &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_collection_ce, getThis(), ZEND_STRL("bucket"), bucket TSRMLS_CC);
+    zend_update_property(pcbc_collection_ce, getThis(), ZEND_STRL("bucket"), bucket);
     if (name) {
-        zend_update_property_str(pcbc_collection_ce, getThis(), ZEND_STRL("name"), name TSRMLS_CC);
+        zend_update_property_str(pcbc_collection_ce, getThis(), ZEND_STRL("name"), name);
     }
 }
 
@@ -54,19 +54,19 @@ PHP_METHOD(Scope, collection)
     int rv;
     zend_string *name;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
     object_init_ex(return_value, pcbc_collection_ce);
-    zend_update_property_str(pcbc_collection_ce, return_value, ZEND_STRL("name"), name TSRMLS_CC);
+    zend_update_property_str(pcbc_collection_ce, return_value, ZEND_STRL("name"), name);
 
     zval *bucket, *scope, rv1, rv2;
     scope = zend_read_property(pcbc_scope_ce, getThis(), ZEND_STRL("name"), 0, &rv1);
-    zend_update_property(pcbc_collection_ce, return_value, ZEND_STRL("scope"), scope TSRMLS_CC);
+    zend_update_property(pcbc_collection_ce, return_value, ZEND_STRL("scope"), scope);
     bucket = zend_read_property(pcbc_scope_ce, getThis(), ZEND_STRL("bucket"), 0, &rv2);
-    zend_update_property(pcbc_collection_ce, return_value, ZEND_STRL("bucket"), bucket TSRMLS_CC);
+    zend_update_property(pcbc_collection_ce, return_value, ZEND_STRL("bucket"), bucket);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_Scope___construct, 0, 0, 1)
@@ -95,17 +95,17 @@ PHP_METHOD(Collection, __construct)
     zend_string *scope = NULL, *name = NULL;
     zval *bucket;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "OS!S!", &bucket, pcbc_bucket_ce, &scope, &name);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "OS!S!", &bucket, pcbc_bucket_ce, &scope, &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_collection_ce, getThis(), ZEND_STRL("bucket"), bucket TSRMLS_CC);
+    zend_update_property(pcbc_collection_ce, getThis(), ZEND_STRL("bucket"), bucket);
     if (scope) {
-        zend_update_property_str(pcbc_collection_ce, getThis(), ZEND_STRL("scope"), scope TSRMLS_CC);
+        zend_update_property_str(pcbc_collection_ce, getThis(), ZEND_STRL("scope"), scope);
     }
     if (name) {
-        zend_update_property_str(pcbc_collection_ce, getThis(), ZEND_STRL("name"), name TSRMLS_CC);
+        zend_update_property_str(pcbc_collection_ce, getThis(), ZEND_STRL("name"), name);
     }
 }
 
@@ -117,11 +117,11 @@ PHP_METHOD(Collection, binary)
     object_init_ex(return_value, pcbc_binary_collection_ce);
     zval *bucket, *scope, *collection, rv1, rv2, rv3;
     bucket = zend_read_property(pcbc_collection_ce, getThis(), ZEND_STRL("bucket"), 0, &rv2);
-    zend_update_property(pcbc_binary_collection_ce, return_value, ZEND_STRL("bucket"), bucket TSRMLS_CC);
+    zend_update_property(pcbc_binary_collection_ce, return_value, ZEND_STRL("bucket"), bucket);
     collection = zend_read_property(pcbc_collection_ce, getThis(), ZEND_STRL("name"), 0, &rv3);
-    zend_update_property(pcbc_binary_collection_ce, return_value, ZEND_STRL("name"), collection TSRMLS_CC);
+    zend_update_property(pcbc_binary_collection_ce, return_value, ZEND_STRL("name"), collection);
     scope = zend_read_property(pcbc_collection_ce, getThis(), ZEND_STRL("scope"), 0, &rv1);
-    zend_update_property(pcbc_binary_collection_ce, return_value, ZEND_STRL("scope"), scope TSRMLS_CC);
+    zend_update_property(pcbc_binary_collection_ce, return_value, ZEND_STRL("scope"), scope);
 }
 
 PHP_METHOD(Collection, name)
@@ -318,24 +318,24 @@ PHP_MINIT_FUNCTION(Collection)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "Collection", collection_methods);
-    pcbc_collection_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_collection_ce = zend_register_internal_class(&ce);
 
-    zend_declare_property_null(pcbc_collection_ce, ZEND_STRL("bucket"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_collection_ce, ZEND_STRL("scope"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_collection_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_collection_ce, ZEND_STRL("bucket"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_collection_ce, ZEND_STRL("scope"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_collection_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "BinaryCollection", binary_collection_methods);
-    pcbc_binary_collection_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_binary_collection_ce = zend_register_internal_class(&ce);
 
-    zend_declare_property_null(pcbc_binary_collection_ce, ZEND_STRL("bucket"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_binary_collection_ce, ZEND_STRL("scope"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_binary_collection_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_binary_collection_ce, ZEND_STRL("bucket"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_binary_collection_ce, ZEND_STRL("scope"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_binary_collection_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "Scope", scope_methods);
-    pcbc_scope_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_scope_ce = zend_register_internal_class(&ce);
 
-    zend_declare_property_null(pcbc_scope_ce, ZEND_STRL("bucket"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_scope_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_scope_ce, ZEND_STRL("bucket"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_scope_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/crypto.c
+++ b/src/couchbase/crypto.c
@@ -53,7 +53,7 @@ static const char *pcbc_crypto_get_key_id(struct lcbcrypto_PROVIDER *provider)
     ZVAL_UNDEF(&fname);
     PCBC_STRING(fname, "getKeyId");
 
-    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 0, NULL, 1, NULL);
+    rv = call_user_function(EG(function_table), zprovider, &fname, &retval, 0, NULL);
     if (rv == FAILURE || EG(exception) || Z_ISUNDEF(retval)) {
         return NULL;
     }
@@ -74,7 +74,7 @@ static lcb_STATUS pcbc_crypto_generate_iv(struct lcbcrypto_PROVIDER *provider, u
     ZVAL_UNDEF(&fname);
     PCBC_STRING(fname, "generateIV");
 
-    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 0, NULL, 1, NULL);
+    rv = call_user_function(EG(function_table), zprovider, &fname, &retval, 0, NULL);
     if (rv == FAILURE || EG(exception) || Z_ISUNDEF(retval)) {
         return LCB_ERR_INVALID_ARGUMENT;
     }
@@ -106,7 +106,7 @@ static lcb_STATUS pcbc_crypto_sign(struct lcbcrypto_PROVIDER *provider, const lc
     }
     PCBC_STRING(fname, "sign");
 
-    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 1, &param, 1, NULL);
+    rv = call_user_function(EG(function_table), zprovider, &fname, &retval, 1, &param, 1, NULL);
 
     zval_ptr_dtor(&param);
     if (rv == FAILURE || EG(exception) || Z_ISUNDEF(retval)) {
@@ -143,7 +143,7 @@ static lcb_STATUS pcbc_crypto_verify_signature(struct lcbcrypto_PROVIDER *provid
     PCBC_STRINGL(params[1], sig, sig_len);
     PCBC_STRING(fname, "verifySignature");
 
-    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 2, params, 1, NULL);
+    rv = call_user_function(EG(function_table), zprovider, &fname, &retval, 2, params);
 
     zval_ptr_dtor(&params[0]);
     zval_ptr_dtor(&params[1]);
@@ -181,7 +181,7 @@ static lcb_STATUS pcbc_crypto_encrypt(struct lcbcrypto_PROVIDER *provider, const
     }
     PCBC_STRING(fname, "encrypt");
 
-    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 2, params, 1, NULL);
+    rv = call_user_function(EG(function_table), zprovider, &fname, &retval);
 
     zval_ptr_dtor(&params[0]);
     zval_ptr_dtor(&params[1]);
@@ -219,7 +219,7 @@ static lcb_STATUS pcbc_crypto_decrypt(struct lcbcrypto_PROVIDER *provider, const
     }
     PCBC_STRING(fname, "decrypt");
 
-    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 2, params, 1, NULL);
+    rv = call_user_function(EG(function_table), zprovider, &fname, &retval, 2, params);
 
     zval_ptr_dtor(&params[0]);
     zval_ptr_dtor(&params[1]);
@@ -257,14 +257,14 @@ void pcbc_crypto_register(pcbc_bucket_t *obj, const char *name, int name_len, zv
         ZVAL_UNDEF(&fname);
 
         PCBC_STRING(fname, "generateIV");
-        rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 0, NULL, 1, NULL);
+        rv = call_user_function(EG(function_table), zprovider, &fname, &retval, 0, NULL);
         if (!(rv == FAILURE || EG(exception) || Z_ISUNDEF(retval) || Z_TYPE_P(&retval) == IS_NULL)) {
             provider->v.v1.generate_iv = pcbc_crypto_generate_iv;
         }
 
         PCBC_STRING(fname, "sign");
         array_init_size(&param, 0);
-        rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 1, &param, 1, NULL);
+        rv = call_user_function(EG(function_table), zprovider, &fname, &retval, 1, &param);
         if (!(rv == FAILURE || EG(exception) || Z_ISUNDEF(retval) || Z_TYPE_P(&retval) == IS_NULL)) {
             provider->v.v1.sign = pcbc_crypto_sign;
             provider->v.v1.verify_signature = pcbc_crypto_verify_signature;

--- a/src/couchbase/crypto.c
+++ b/src/couchbase/crypto.c
@@ -49,12 +49,11 @@ static const char *pcbc_crypto_get_key_id(struct lcbcrypto_PROVIDER *provider)
     int rv;
     zval fname;
     zval retval;
-    TSRMLS_FETCH();
 
     ZVAL_UNDEF(&fname);
     PCBC_STRING(fname, "getKeyId");
 
-    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 0, NULL, 1, NULL TSRMLS_CC);
+    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 0, NULL, 1, NULL);
     if (rv == FAILURE || EG(exception) || Z_ISUNDEF(retval)) {
         return NULL;
     }
@@ -71,12 +70,11 @@ static lcb_STATUS pcbc_crypto_generate_iv(struct lcbcrypto_PROVIDER *provider, u
     int rv;
     zval fname;
     zval retval;
-    TSRMLS_FETCH();
 
     ZVAL_UNDEF(&fname);
     PCBC_STRING(fname, "generateIV");
 
-    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 0, NULL, 1, NULL TSRMLS_CC);
+    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 0, NULL, 1, NULL);
     if (rv == FAILURE || EG(exception) || Z_ISUNDEF(retval)) {
         return LCB_ERR_INVALID_ARGUMENT;
     }
@@ -98,7 +96,6 @@ static lcb_STATUS pcbc_crypto_sign(struct lcbcrypto_PROVIDER *provider, const lc
     zval param;
     zval fname;
     zval retval;
-    TSRMLS_FETCH();
 
     ZVAL_UNDEF(&fname);
     ZVAL_UNDEF(&param);
@@ -109,7 +106,7 @@ static lcb_STATUS pcbc_crypto_sign(struct lcbcrypto_PROVIDER *provider, const lc
     }
     PCBC_STRING(fname, "sign");
 
-    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 1, &param, 1, NULL TSRMLS_CC);
+    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 1, &param, 1, NULL);
 
     zval_ptr_dtor(&param);
     if (rv == FAILURE || EG(exception) || Z_ISUNDEF(retval)) {
@@ -134,7 +131,6 @@ static lcb_STATUS pcbc_crypto_verify_signature(struct lcbcrypto_PROVIDER *provid
     zval params[2];
     zval fname;
     zval retval;
-    TSRMLS_FETCH();
 
     ZVAL_UNDEF(&fname);
     ZVAL_UNDEF(&params[0]);
@@ -147,7 +143,7 @@ static lcb_STATUS pcbc_crypto_verify_signature(struct lcbcrypto_PROVIDER *provid
     PCBC_STRINGL(params[1], sig, sig_len);
     PCBC_STRING(fname, "verifySignature");
 
-    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 2, params, 1, NULL TSRMLS_CC);
+    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 2, params, 1, NULL);
 
     zval_ptr_dtor(&params[0]);
     zval_ptr_dtor(&params[1]);
@@ -172,7 +168,6 @@ static lcb_STATUS pcbc_crypto_encrypt(struct lcbcrypto_PROVIDER *provider, const
     zval params[2];
     zval fname;
     zval retval;
-    TSRMLS_FETCH();
 
     ZVAL_UNDEF(&fname);
     ZVAL_UNDEF(&params[0]);
@@ -186,7 +181,7 @@ static lcb_STATUS pcbc_crypto_encrypt(struct lcbcrypto_PROVIDER *provider, const
     }
     PCBC_STRING(fname, "encrypt");
 
-    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 2, params, 1, NULL TSRMLS_CC);
+    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 2, params, 1, NULL);
 
     zval_ptr_dtor(&params[0]);
     zval_ptr_dtor(&params[1]);
@@ -211,7 +206,6 @@ static lcb_STATUS pcbc_crypto_decrypt(struct lcbcrypto_PROVIDER *provider, const
     zval params[2];
     zval fname;
     zval retval;
-    TSRMLS_FETCH();
 
     ZVAL_UNDEF(&fname);
     ZVAL_UNDEF(&params[0]);
@@ -225,7 +219,7 @@ static lcb_STATUS pcbc_crypto_decrypt(struct lcbcrypto_PROVIDER *provider, const
     }
     PCBC_STRING(fname, "decrypt");
 
-    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 2, params, 1, NULL TSRMLS_CC);
+    rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 2, params, 1, NULL);
 
     zval_ptr_dtor(&params[0]);
     zval_ptr_dtor(&params[1]);
@@ -242,7 +236,7 @@ static lcb_STATUS pcbc_crypto_decrypt(struct lcbcrypto_PROVIDER *provider, const
     return LCB_ERR_INVALID_ARGUMENT;
 }
 
-void pcbc_crypto_register(pcbc_bucket_t *obj, const char *name, int name_len, zval *zprovider TSRMLS_DC)
+void pcbc_crypto_register(pcbc_bucket_t *obj, const char *name, int name_len, zval *zprovider)
 {
     lcbcrypto_PROVIDER *provider = ecalloc(1, sizeof(lcbcrypto_PROVIDER));
 
@@ -263,14 +257,14 @@ void pcbc_crypto_register(pcbc_bucket_t *obj, const char *name, int name_len, zv
         ZVAL_UNDEF(&fname);
 
         PCBC_STRING(fname, "generateIV");
-        rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 0, NULL, 1, NULL TSRMLS_CC);
+        rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 0, NULL, 1, NULL);
         if (!(rv == FAILURE || EG(exception) || Z_ISUNDEF(retval) || Z_TYPE_P(&retval) == IS_NULL)) {
             provider->v.v1.generate_iv = pcbc_crypto_generate_iv;
         }
 
         PCBC_STRING(fname, "sign");
         array_init_size(&param, 0);
-        rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 1, &param, 1, NULL TSRMLS_CC);
+        rv = call_user_function_ex(EG(function_table), zprovider, &fname, &retval, 1, &param, 1, NULL);
         if (!(rv == FAILURE || EG(exception) || Z_ISUNDEF(retval) || Z_TYPE_P(&retval) == IS_NULL)) {
             provider->v.v1.sign = pcbc_crypto_sign;
             provider->v.v1.verify_signature = pcbc_crypto_verify_signature;
@@ -286,13 +280,13 @@ void pcbc_crypto_register(pcbc_bucket_t *obj, const char *name, int name_len, zv
     lcbcrypto_register(obj->conn->lcb, name, provider);
 }
 
-void pcbc_crypto_unregister(pcbc_bucket_t *obj, const char *name, int name_len TSRMLS_DC)
+void pcbc_crypto_unregister(pcbc_bucket_t *obj, const char *name, int name_len)
 {
     lcbcrypto_unregister(obj->conn->lcb, name);
 }
 
 void pcbc_crypto_encrypt_fields(pcbc_bucket_t *obj, zval *document, zval *options, const char *prefix,
-                                zval *return_value TSRMLS_DC)
+                                zval *return_value)
 {
     smart_str buf = {0};
     int last_error;
@@ -362,7 +356,7 @@ void pcbc_crypto_encrypt_fields(pcbc_bucket_t *obj, zval *document, zval *option
 }
 
 void pcbc_crypto_decrypt_fields(pcbc_bucket_t *obj, zval *document, zval *options, const char *prefix,
-                                zval *return_value TSRMLS_DC)
+                                zval *return_value)
 {
     smart_str buf = {0};
     int last_error;
@@ -517,11 +511,11 @@ PHP_MINIT_FUNCTION(CryptoProvider)
 {
     zend_class_entry ce;
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "CryptoProvider", crypto_provider_methods);
-    pcbc_crypto_provider_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_crypto_provider_ce = zend_register_internal_class(&ce);
 
     zend_declare_class_constant_long(pcbc_crypto_provider_ce, ZEND_STRL("KEY_TYPE_ENCRYPT"),
-                                     LCBCRYPTO_KEY_ENCRYPT TSRMLS_CC);
+                                     LCBCRYPTO_KEY_ENCRYPT);
     zend_declare_class_constant_long(pcbc_crypto_provider_ce, ZEND_STRL("KEY_TYPE_DECRYPT"),
-                                     LCBCRYPTO_KEY_DECRYPT TSRMLS_CC);
+                                     LCBCRYPTO_KEY_DECRYPT);
     return SUCCESS;
 }

--- a/src/couchbase/lookup_spec.c
+++ b/src/couchbase/lookup_spec.c
@@ -70,25 +70,25 @@ PHP_MINIT_FUNCTION(LookupInSpec)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "LookupInSpec", pcbc_lookup_in_spec_methods);
-    pcbc_lookup_in_spec_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_lookup_in_spec_ce = zend_register_internal_interface(&ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "LookupGetSpec", pcbc_lookup_get_spec_methods);
-    pcbc_lookup_get_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_lookup_get_spec_ce TSRMLS_CC, 1, pcbc_lookup_in_spec_ce);
-    zend_declare_property_null(pcbc_lookup_get_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_lookup_get_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_lookup_get_spec_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_lookup_get_spec_ce, 1, pcbc_lookup_in_spec_ce);
+    zend_declare_property_null(pcbc_lookup_get_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_lookup_get_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "LookupCountSpec", pcbc_lookup_count_spec_methods);
-    pcbc_lookup_count_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_lookup_count_spec_ce TSRMLS_CC, 1, pcbc_lookup_in_spec_ce);
-    zend_declare_property_null(pcbc_lookup_count_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_lookup_count_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_lookup_count_spec_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_lookup_count_spec_ce, 1, pcbc_lookup_in_spec_ce);
+    zend_declare_property_null(pcbc_lookup_count_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_lookup_count_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "LookupExistsSpec", pcbc_lookup_exists_spec_methods);
-    pcbc_lookup_exists_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_lookup_exists_spec_ce TSRMLS_CC, 1, pcbc_lookup_in_spec_ce);
-    zend_declare_property_null(pcbc_lookup_exists_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_lookup_exists_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_lookup_exists_spec_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_lookup_exists_spec_ce, 1, pcbc_lookup_in_spec_ce);
+    zend_declare_property_null(pcbc_lookup_exists_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_lookup_exists_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE);
     return SUCCESS;
 }
 
@@ -97,12 +97,12 @@ PHP_METHOD(LookupGetSpec, __construct)
     zend_string *path;
     zend_bool is_xattr = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|b", &path, &is_xattr);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|b", &path, &is_xattr);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_lookup_get_spec_ce, getThis(), ZEND_STRL("path"), path TSRMLS_CC);
-    zend_update_property_bool(pcbc_lookup_get_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr TSRMLS_CC);
+    zend_update_property_str(pcbc_lookup_get_spec_ce, getThis(), ZEND_STRL("path"), path);
+    zend_update_property_bool(pcbc_lookup_get_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
 }
 
 PHP_METHOD(LookupCountSpec, __construct)
@@ -110,12 +110,12 @@ PHP_METHOD(LookupCountSpec, __construct)
     zend_string *path;
     zend_bool is_xattr = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|b", &path, &is_xattr);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|b", &path, &is_xattr);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_lookup_count_spec_ce, getThis(), ZEND_STRL("path"), path TSRMLS_CC);
-    zend_update_property_bool(pcbc_lookup_count_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr TSRMLS_CC);
+    zend_update_property_str(pcbc_lookup_count_spec_ce, getThis(), ZEND_STRL("path"), path);
+    zend_update_property_bool(pcbc_lookup_count_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
 }
 
 PHP_METHOD(LookupExistsSpec, __construct)
@@ -123,12 +123,12 @@ PHP_METHOD(LookupExistsSpec, __construct)
     zend_string *path;
     zend_bool is_xattr = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|b", &path, &is_xattr);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|b", &path, &is_xattr);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_lookup_exists_spec_ce, getThis(), ZEND_STRL("path"), path TSRMLS_CC);
-    zend_update_property_bool(pcbc_lookup_exists_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr TSRMLS_CC);
+    zend_update_property_str(pcbc_lookup_exists_spec_ce, getThis(), ZEND_STRL("path"), path);
+    zend_update_property_bool(pcbc_lookup_exists_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
 }
 
 /*

--- a/src/couchbase/lookup_spec.c
+++ b/src/couchbase/lookup_spec.c
@@ -101,8 +101,8 @@ PHP_METHOD(LookupGetSpec, __construct)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_lookup_get_spec_ce, getThis(), ZEND_STRL("path"), path);
-    zend_update_property_bool(pcbc_lookup_get_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
+    pcbc_update_property_str(pcbc_lookup_get_spec_ce, getThis(), ("path"), path);
+    pcbc_update_property_bool(pcbc_lookup_get_spec_ce, getThis(), ("is_xattr"), is_xattr);
 }
 
 PHP_METHOD(LookupCountSpec, __construct)
@@ -114,8 +114,8 @@ PHP_METHOD(LookupCountSpec, __construct)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_lookup_count_spec_ce, getThis(), ZEND_STRL("path"), path);
-    zend_update_property_bool(pcbc_lookup_count_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
+    pcbc_update_property_str(pcbc_lookup_count_spec_ce, getThis(), ("path"), path);
+    pcbc_update_property_bool(pcbc_lookup_count_spec_ce, getThis(), ("is_xattr"), is_xattr);
 }
 
 PHP_METHOD(LookupExistsSpec, __construct)
@@ -127,8 +127,8 @@ PHP_METHOD(LookupExistsSpec, __construct)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_lookup_exists_spec_ce, getThis(), ZEND_STRL("path"), path);
-    zend_update_property_bool(pcbc_lookup_exists_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
+    pcbc_update_property_str(pcbc_lookup_exists_spec_ce, getThis(), ("path"), path);
+    pcbc_update_property_bool(pcbc_lookup_exists_spec_ce, getThis(), ("is_xattr"), is_xattr);
 }
 
 /*

--- a/src/couchbase/managers/bucket_manager.c
+++ b/src/couchbase/managers/bucket_manager.c
@@ -33,30 +33,30 @@ static void httpcb_getBucket(void *ctx, zval *return_value, zval *response)
 
     mval = zend_symtable_str_find(marr, ZEND_STRL("name"));
     if (mval && Z_TYPE_P(mval) == IS_STRING) {
-        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("name"), mval);
+        pcbc_update_property(pcbc_bucket_settings_ce, return_value, ("name"), mval);
     }
     mval = zend_symtable_str_find(marr, ZEND_STRL("replicaNumber"));
     if (mval && Z_TYPE_P(mval) == IS_LONG) {
-        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("num_replicas"), mval);
+        pcbc_update_property(pcbc_bucket_settings_ce, return_value, ("num_replicas"), mval);
     }
     mval = zend_symtable_str_find(marr, ZEND_STRL("replicaIndex"));
-    zend_update_property_bool(pcbc_bucket_settings_ce, return_value, ZEND_STRL("replica_indexes"),
+    pcbc_update_property_bool(pcbc_bucket_settings_ce, return_value, ("replica_indexes"),
                               mval != NULL);
     mval = zend_symtable_str_find(marr, ZEND_STRL("bucketType"));
     if (mval && Z_TYPE_P(mval) == IS_STRING) {
-        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("bucket_type"), mval);
+        pcbc_update_property(pcbc_bucket_settings_ce, return_value, ("bucket_type"), mval);
     }
     mval = zend_symtable_str_find(marr, ZEND_STRL("evictionPolicy"));
     if (mval && Z_TYPE_P(mval) == IS_STRING) {
-        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("eviction_policy"), mval);
+        pcbc_update_property(pcbc_bucket_settings_ce, return_value, ("eviction_policy"), mval);
     }
     mval = zend_symtable_str_find(marr, ZEND_STRL("maxTTL"));
     if (mval && Z_TYPE_P(mval) == IS_LONG) {
-        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("max_ttl"), mval);
+        pcbc_update_property(pcbc_bucket_settings_ce, return_value, ("max_ttl"), mval);
     }
     mval = zend_symtable_str_find(marr, ZEND_STRL("compressionMode"));
     if (mval && Z_TYPE_P(mval) == IS_STRING) {
-        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("compression_mode"), mval);
+        pcbc_update_property(pcbc_bucket_settings_ce, return_value, ("compression_mode"), mval);
     }
 
     {
@@ -64,7 +64,7 @@ static void httpcb_getBucket(void *ctx, zval *return_value, zval *response)
         if (quota && Z_TYPE_P(quota) == IS_ARRAY) {
             mval = zend_symtable_str_find(Z_ARRVAL_P(quota), ZEND_STRL("ram"));
             if (mval && Z_TYPE_P(mval) == IS_LONG) {
-                zend_update_property_long(pcbc_bucket_settings_ce, return_value, ZEND_STRL("ram_quota_mb"),
+                pcbc_update_property_long(pcbc_bucket_settings_ce, return_value, ("ram_quota_mb"),
                                           Z_LVAL_P(mval) / (1024 * 1024));
             }
         }
@@ -73,7 +73,7 @@ static void httpcb_getBucket(void *ctx, zval *return_value, zval *response)
         zval *controllers = zend_symtable_str_find(marr, ZEND_STRL("controllers"));
         if (controllers && Z_TYPE_P(controllers) == IS_ARRAY) {
             mval = zend_symtable_str_find(Z_ARRVAL_P(controllers), ZEND_STRL("flush"));
-            zend_update_property_bool(pcbc_bucket_settings_ce, return_value, ZEND_STRL("flush_enabled"),
+            pcbc_update_property_bool(pcbc_bucket_settings_ce, return_value, ("flush_enabled"),
                                       mval && Z_TYPE_P(mval) == IS_STRING);
         }
     }
@@ -92,7 +92,7 @@ PHP_METHOD(BucketManager, getBucket)
         return;
     }
 
-    prop = zend_read_property(pcbc_bucket_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_bucket_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -131,7 +131,7 @@ PHP_METHOD(BucketManager, getAllBuckets)
         RETURN_NULL();
     }
 
-    prop = zend_read_property(pcbc_bucket_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_bucket_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -158,7 +158,7 @@ PHP_METHOD(BucketManager, createBucket)
         RETURN_NULL();
     }
 
-    prop = zend_read_property(pcbc_bucket_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_bucket_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     {
@@ -167,37 +167,37 @@ PHP_METHOD(BucketManager, createBucket)
         array_init(&payload);
 
         add_assoc_string(&payload, "authType", "sasl");
-        prop = zend_read_property(pcbc_bucket_settings_ce, settings, ZEND_STRL("name"), 0, &ret);
+        prop = pcbc_read_property(pcbc_bucket_settings_ce, settings, ("name"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             add_assoc_zval(&payload, "name", prop);
         }
-        prop = zend_read_property(pcbc_bucket_settings_ce, settings, ZEND_STRL("bucket_type"), 0, &ret);
+        prop = pcbc_read_property(pcbc_bucket_settings_ce, settings, ("bucket_type"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             add_assoc_zval(&payload, "bucketType", prop);
         }
-        prop = zend_read_property(pcbc_bucket_settings_ce, settings, ZEND_STRL("ram_quota_mb"), 0, &ret);
+        prop = pcbc_read_property(pcbc_bucket_settings_ce, settings, ("ram_quota_mb"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             add_assoc_zval(&payload, "ramQuotaMB", prop);
         }
-        prop = zend_read_property(pcbc_bucket_settings_ce, settings, ZEND_STRL("num_replicas"), 0, &ret);
+        prop = pcbc_read_property(pcbc_bucket_settings_ce, settings, ("num_replicas"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             add_assoc_zval(&payload, "replicaNumber", prop);
         }
-        prop = zend_read_property(pcbc_bucket_settings_ce, settings, ZEND_STRL("eviction_policy"), 0, &ret);
+        prop = pcbc_read_property(pcbc_bucket_settings_ce, settings, ("eviction_policy"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             add_assoc_zval(&payload, "evictionPolicy", prop);
         }
-        prop = zend_read_property(pcbc_bucket_settings_ce, settings, ZEND_STRL("compression_mode"), 0, &ret);
+        prop = pcbc_read_property(pcbc_bucket_settings_ce, settings, ("compression_mode"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_STRING) {
             add_assoc_zval(&payload, "compressionMode", prop);
         }
-        prop = zend_read_property(pcbc_bucket_settings_ce, settings, ZEND_STRL("max_ttl"), 0, &ret);
+        prop = pcbc_read_property(pcbc_bucket_settings_ce, settings, ("max_ttl"), 0, &ret);
         if (Z_TYPE_P(prop) == IS_LONG) {
             add_assoc_zval(&payload, "maxTTL", prop);
         }
-        prop = zend_read_property(pcbc_bucket_settings_ce, settings, ZEND_STRL("flush_enabled"), 0, &ret);
+        prop = pcbc_read_property(pcbc_bucket_settings_ce, settings, ("flush_enabled"), 0, &ret);
         add_assoc_bool(&payload, "flushEnabled", Z_TYPE_P(prop) == IS_TRUE);
-        prop = zend_read_property(pcbc_bucket_settings_ce, settings, ZEND_STRL("replica_indexes"), 0, &ret);
+        prop = pcbc_read_property(pcbc_bucket_settings_ce, settings, ("replica_indexes"), 0, &ret);
         add_assoc_bool(&payload, "replicaIndex", Z_TYPE_P(prop) == IS_TRUE);
 
         php_url_encode_hash_ex(HASH_OF(&payload), &buf, NULL, 0, NULL, 0, NULL, 0, NULL, NULL,
@@ -234,7 +234,7 @@ PHP_METHOD(BucketManager, removeBucket)
         RETURN_NULL();
     }
 
-    prop = zend_read_property(pcbc_bucket_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_bucket_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -260,7 +260,7 @@ PHP_METHOD(BucketManager, flush)
         return;
     }
 
-    prop = zend_read_property(pcbc_bucket_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_bucket_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -451,7 +451,7 @@ PHP_METHOD(BucketSettings, name)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_bucket_settings_ce, getThis(), ("name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -462,7 +462,7 @@ PHP_METHOD(BucketSettings, setName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("name"), val);
+    pcbc_update_property_str(pcbc_bucket_settings_ce, getThis(), ("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -473,7 +473,7 @@ PHP_METHOD(BucketSettings, flushEnabled)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("flush_enabled"), 0, &rv);
+    prop = pcbc_read_property(pcbc_bucket_settings_ce, getThis(), ("flush_enabled"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -484,7 +484,7 @@ PHP_METHOD(BucketSettings, enableFlush)
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("flush_enabled"), val);
+    pcbc_update_property_bool(pcbc_bucket_settings_ce, getThis(), ("flush_enabled"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -495,7 +495,7 @@ PHP_METHOD(BucketSettings, ramQuotaMb)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("ram_quota_mb"), 0, &rv);
+    prop = pcbc_read_property(pcbc_bucket_settings_ce, getThis(), ("ram_quota_mb"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -506,7 +506,7 @@ PHP_METHOD(BucketSettings, setRamQuotaMb)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("ram_quota_mb"), val);
+    pcbc_update_property_long(pcbc_bucket_settings_ce, getThis(), ("ram_quota_mb"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -517,7 +517,7 @@ PHP_METHOD(BucketSettings, numReplicas)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("num_replicas"), 0, &rv);
+    prop = pcbc_read_property(pcbc_bucket_settings_ce, getThis(), ("num_replicas"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -528,7 +528,7 @@ PHP_METHOD(BucketSettings, setNumReplicas)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("num_replicas"), val);
+    pcbc_update_property_long(pcbc_bucket_settings_ce, getThis(), ("num_replicas"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -539,7 +539,7 @@ PHP_METHOD(BucketSettings, replicaIndexes)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("replica_indexes"), 0, &rv);
+    prop = pcbc_read_property(pcbc_bucket_settings_ce, getThis(), ("replica_indexes"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -550,7 +550,7 @@ PHP_METHOD(BucketSettings, enableReplicaIndexes)
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("replica_indexes"), val);
+    pcbc_update_property_bool(pcbc_bucket_settings_ce, getThis(), ("replica_indexes"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -561,7 +561,7 @@ PHP_METHOD(BucketSettings, bucketType)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("bucket_type"), 0, &rv);
+    prop = pcbc_read_property(pcbc_bucket_settings_ce, getThis(), ("bucket_type"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -572,7 +572,7 @@ PHP_METHOD(BucketSettings, setBucketType)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("bucket_type"), val);
+    pcbc_update_property_str(pcbc_bucket_settings_ce, getThis(), ("bucket_type"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -583,7 +583,7 @@ PHP_METHOD(BucketSettings, evictionPolicy)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("eviction_policy"), 0, &rv);
+    prop = pcbc_read_property(pcbc_bucket_settings_ce, getThis(), ("eviction_policy"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -594,7 +594,7 @@ PHP_METHOD(BucketSettings, setEvictionPolicy)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("eviction_policy"), val);
+    pcbc_update_property_str(pcbc_bucket_settings_ce, getThis(), ("eviction_policy"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -605,7 +605,7 @@ PHP_METHOD(BucketSettings, maxTtl)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("max_ttl"), 0, &rv);
+    prop = pcbc_read_property(pcbc_bucket_settings_ce, getThis(), ("max_ttl"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -616,7 +616,7 @@ PHP_METHOD(BucketSettings, setMaxTtl)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("max_ttl"), val);
+    pcbc_update_property_long(pcbc_bucket_settings_ce, getThis(), ("max_ttl"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -627,7 +627,7 @@ PHP_METHOD(BucketSettings, compressionMode)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("compression_mode"), 0, &rv);
+    prop = pcbc_read_property(pcbc_bucket_settings_ce, getThis(), ("compression_mode"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -638,7 +638,7 @@ PHP_METHOD(BucketSettings, setCompressionMode)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("compression_mode"), val);
+    pcbc_update_property_str(pcbc_bucket_settings_ce, getThis(), ("compression_mode"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 

--- a/src/couchbase/managers/bucket_manager.c
+++ b/src/couchbase/managers/bucket_manager.c
@@ -200,7 +200,7 @@ PHP_METHOD(BucketManager, createBucket)
         prop = zend_read_property(pcbc_bucket_settings_ce, settings, ZEND_STRL("replica_indexes"), 0, &ret);
         add_assoc_bool(&payload, "replicaIndex", Z_TYPE_P(prop) == IS_TRUE);
 
-        rv = php_url_encode_hash_ex(HASH_OF(&payload), &buf, NULL, 0, NULL, 0, NULL, 0, NULL, NULL,
+        php_url_encode_hash_ex(HASH_OF(&payload), &buf, NULL, 0, NULL, 0, NULL, 0, NULL, NULL,
                                     PHP_QUERY_RFC1738);
         zval_ptr_dtor(&payload);
         if (rv == FAILURE) {

--- a/src/couchbase/managers/bucket_manager.c
+++ b/src/couchbase/managers/bucket_manager.c
@@ -33,30 +33,30 @@ static void httpcb_getBucket(void *ctx, zval *return_value, zval *response)
 
     mval = zend_symtable_str_find(marr, ZEND_STRL("name"));
     if (mval && Z_TYPE_P(mval) == IS_STRING) {
-        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("name"), mval TSRMLS_CC);
+        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("name"), mval);
     }
     mval = zend_symtable_str_find(marr, ZEND_STRL("replicaNumber"));
     if (mval && Z_TYPE_P(mval) == IS_LONG) {
-        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("num_replicas"), mval TSRMLS_CC);
+        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("num_replicas"), mval);
     }
     mval = zend_symtable_str_find(marr, ZEND_STRL("replicaIndex"));
     zend_update_property_bool(pcbc_bucket_settings_ce, return_value, ZEND_STRL("replica_indexes"),
-                              mval != NULL TSRMLS_CC);
+                              mval != NULL);
     mval = zend_symtable_str_find(marr, ZEND_STRL("bucketType"));
     if (mval && Z_TYPE_P(mval) == IS_STRING) {
-        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("bucket_type"), mval TSRMLS_CC);
+        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("bucket_type"), mval);
     }
     mval = zend_symtable_str_find(marr, ZEND_STRL("evictionPolicy"));
     if (mval && Z_TYPE_P(mval) == IS_STRING) {
-        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("eviction_policy"), mval TSRMLS_CC);
+        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("eviction_policy"), mval);
     }
     mval = zend_symtable_str_find(marr, ZEND_STRL("maxTTL"));
     if (mval && Z_TYPE_P(mval) == IS_LONG) {
-        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("max_ttl"), mval TSRMLS_CC);
+        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("max_ttl"), mval);
     }
     mval = zend_symtable_str_find(marr, ZEND_STRL("compressionMode"));
     if (mval && Z_TYPE_P(mval) == IS_STRING) {
-        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("compression_mode"), mval TSRMLS_CC);
+        zend_update_property(pcbc_bucket_settings_ce, return_value, ZEND_STRL("compression_mode"), mval);
     }
 
     {
@@ -65,7 +65,7 @@ static void httpcb_getBucket(void *ctx, zval *return_value, zval *response)
             mval = zend_symtable_str_find(Z_ARRVAL_P(quota), ZEND_STRL("ram"));
             if (mval && Z_TYPE_P(mval) == IS_LONG) {
                 zend_update_property_long(pcbc_bucket_settings_ce, return_value, ZEND_STRL("ram_quota_mb"),
-                                          Z_LVAL_P(mval) / (1024 * 1024) TSRMLS_CC);
+                                          Z_LVAL_P(mval) / (1024 * 1024));
             }
         }
     }
@@ -74,7 +74,7 @@ static void httpcb_getBucket(void *ctx, zval *return_value, zval *response)
         if (controllers && Z_TYPE_P(controllers) == IS_ARRAY) {
             mval = zend_symtable_str_find(Z_ARRVAL_P(controllers), ZEND_STRL("flush"));
             zend_update_property_bool(pcbc_bucket_settings_ce, return_value, ZEND_STRL("flush_enabled"),
-                                      mval && Z_TYPE_P(mval) == IS_STRING TSRMLS_CC);
+                                      mval && Z_TYPE_P(mval) == IS_STRING);
         }
     }
 }
@@ -87,7 +87,7 @@ PHP_METHOD(BucketManager, getBucket)
     char *path;
     int rv, path_len;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         return;
     }
@@ -101,7 +101,7 @@ PHP_METHOD(BucketManager, getBucket)
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
     path_len = spprintf(&path, 0, "/pools/default/buckets/%*s", (int)ZSTR_LEN(name), ZSTR_VAL(name));
     lcb_cmdhttp_path(cmd, path, path_len);
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getBucket, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getBucket, NULL);
     efree(path);
 }
 
@@ -139,7 +139,7 @@ PHP_METHOD(BucketManager, getAllBuckets)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_GET);
     lcb_cmdhttp_path(cmd, path, strlen(path));
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getAllBuckets, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getAllBuckets, NULL);
 }
 
 PHP_METHOD(BucketManager, createBucket)
@@ -153,7 +153,7 @@ PHP_METHOD(BucketManager, createBucket)
     pcbc_cluster_t *cluster = NULL;
     zval *prop, val;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "O|z", &settings, pcbc_bucket_settings_ce, &options);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O|z", &settings, pcbc_bucket_settings_ce, &options);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -201,7 +201,7 @@ PHP_METHOD(BucketManager, createBucket)
         add_assoc_bool(&payload, "replicaIndex", Z_TYPE_P(prop) == IS_TRUE);
 
         rv = php_url_encode_hash_ex(HASH_OF(&payload), &buf, NULL, 0, NULL, 0, NULL, 0, NULL, NULL,
-                                    PHP_QUERY_RFC1738 TSRMLS_CC);
+                                    PHP_QUERY_RFC1738);
         zval_ptr_dtor(&payload);
         if (rv == FAILURE) {
             smart_str_free(&buf);
@@ -217,7 +217,7 @@ PHP_METHOD(BucketManager, createBucket)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_POST);
     lcb_cmdhttp_path(cmd, path, strlen(path));
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     smart_str_free(&buf);
 }
 
@@ -229,7 +229,7 @@ PHP_METHOD(BucketManager, removeBucket)
     pcbc_cluster_t *cluster = NULL;
     zval *prop, val;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -243,7 +243,7 @@ PHP_METHOD(BucketManager, removeBucket)
     path_len = spprintf(&path, 0, "/pools/default/buckets/%*s", (int)ZSTR_LEN(name), ZSTR_VAL(name));
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
 }
 
@@ -255,7 +255,7 @@ PHP_METHOD(BucketManager, flush)
     char *path;
     int rv, path_len;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         return;
     }
@@ -269,7 +269,7 @@ PHP_METHOD(BucketManager, flush)
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
     path_len = spprintf(&path, 0, "/pools/default/buckets/%*s/controller/doFlush", (int)ZSTR_LEN(name), ZSTR_VAL(name));
     lcb_cmdhttp_path(cmd, path, path_len);
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
 }
 
@@ -420,27 +420,27 @@ PHP_MINIT_FUNCTION(BucketManager)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "BucketManager", my_bucket_manager_methods);
-    pcbc_bucket_manager_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_bucket_manager_ce, ZEND_STRL("cluster"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_bucket_manager_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_bucket_manager_ce, ZEND_STRL("cluster"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "BucketSettings", bucket_settings_methods);
-    pcbc_bucket_settings_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("flush_enabled"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("ram_quota_mb"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("num_replicas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("replica_indexes"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("bucket_type"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("eviction_policy"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("max_ttl"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("compression_mode"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_bucket_settings_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("flush_enabled"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("ram_quota_mb"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("num_replicas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("replica_indexes"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("bucket_type"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("eviction_policy"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("max_ttl"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_bucket_settings_ce, ZEND_STRL("compression_mode"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "EvictionPolicy", pcbc_eviction_policy_methods);
-    pcbc_eviction_policy_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_eviction_policy_ce, ZEND_STRL("FULL"), ZEND_STRL("fullEviction") TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_eviction_policy_ce, ZEND_STRL("VALUE_ONLY"), ZEND_STRL("valueOnly") TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_eviction_policy_ce, ZEND_STRL("NO_EVICTION"), ZEND_STRL("noEviction") TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_eviction_policy_ce, ZEND_STRL("NOT_RECENTLY_USED"), ZEND_STRL("nruEviction") TSRMLS_CC);
+    pcbc_eviction_policy_ce = zend_register_internal_interface(&ce);
+    zend_declare_class_constant_stringl(pcbc_eviction_policy_ce, ZEND_STRL("FULL"), ZEND_STRL("fullEviction"));
+    zend_declare_class_constant_stringl(pcbc_eviction_policy_ce, ZEND_STRL("VALUE_ONLY"), ZEND_STRL("valueOnly"));
+    zend_declare_class_constant_stringl(pcbc_eviction_policy_ce, ZEND_STRL("NO_EVICTION"), ZEND_STRL("noEviction"));
+    zend_declare_class_constant_stringl(pcbc_eviction_policy_ce, ZEND_STRL("NOT_RECENTLY_USED"), ZEND_STRL("nruEviction"));
     return SUCCESS;
 }
 
@@ -458,11 +458,11 @@ PHP_METHOD(BucketSettings, name)
 PHP_METHOD(BucketSettings, setName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -480,11 +480,11 @@ PHP_METHOD(BucketSettings, flushEnabled)
 PHP_METHOD(BucketSettings, enableFlush)
 {
     zend_bool val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("flush_enabled"), val TSRMLS_CC);
+    zend_update_property_bool(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("flush_enabled"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -502,11 +502,11 @@ PHP_METHOD(BucketSettings, ramQuotaMb)
 PHP_METHOD(BucketSettings, setRamQuotaMb)
 {
     zend_long val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("ram_quota_mb"), val TSRMLS_CC);
+    zend_update_property_long(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("ram_quota_mb"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -524,11 +524,11 @@ PHP_METHOD(BucketSettings, numReplicas)
 PHP_METHOD(BucketSettings, setNumReplicas)
 {
     zend_long val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("num_replicas"), val TSRMLS_CC);
+    zend_update_property_long(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("num_replicas"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -546,11 +546,11 @@ PHP_METHOD(BucketSettings, replicaIndexes)
 PHP_METHOD(BucketSettings, enableReplicaIndexes)
 {
     zend_bool val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("replica_indexes"), val TSRMLS_CC);
+    zend_update_property_bool(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("replica_indexes"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -568,11 +568,11 @@ PHP_METHOD(BucketSettings, bucketType)
 PHP_METHOD(BucketSettings, setBucketType)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("bucket_type"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("bucket_type"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -590,11 +590,11 @@ PHP_METHOD(BucketSettings, evictionPolicy)
 PHP_METHOD(BucketSettings, setEvictionPolicy)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("eviction_policy"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("eviction_policy"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -612,11 +612,11 @@ PHP_METHOD(BucketSettings, maxTtl)
 PHP_METHOD(BucketSettings, setMaxTtl)
 {
     zend_long val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("max_ttl"), val TSRMLS_CC);
+    zend_update_property_long(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("max_ttl"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -634,11 +634,11 @@ PHP_METHOD(BucketSettings, compressionMode)
 PHP_METHOD(BucketSettings, setCompressionMode)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("compression_mode"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_bucket_settings_ce, getThis(), ZEND_STRL("compression_mode"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 

--- a/src/couchbase/managers/collection_manager.c
+++ b/src/couchbase/managers/collection_manager.c
@@ -37,11 +37,11 @@ static void httpcb_getScope(void *ctx, zval *return_value, zval *response)
     if (!scope_name || Z_TYPE_P(scope_name) != IS_STRING) {
         return;
     }
-    zend_update_property(pcbc_scope_spec_ce, return_value, ZEND_STRL("name"), scope_name TSRMLS_CC);
+    zend_update_property(pcbc_scope_spec_ce, return_value, ZEND_STRL("name"), scope_name);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("uid"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
         zend_long uid = ZEND_STRTOL(Z_STRVAL_P(val), NULL, 16);
-        zend_update_property_long(pcbc_scope_spec_ce, return_value, ZEND_STRL("uid"), uid TSRMLS_CC);
+        zend_update_property_long(pcbc_scope_spec_ce, return_value, ZEND_STRL("uid"), uid);
     }
     zval collections;
     array_init(&collections);
@@ -52,21 +52,21 @@ static void httpcb_getScope(void *ctx, zval *return_value, zval *response)
         {
             zval collection;
             object_init_ex(&collection, pcbc_collection_spec_ce);
-            zend_update_property(pcbc_collection_spec_ce, &collection, ZEND_STRL("scope_name"), scope_name TSRMLS_CC);
+            zend_update_property(pcbc_collection_spec_ce, &collection, ZEND_STRL("scope_name"), scope_name);
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_collection_spec_ce, &collection, ZEND_STRL("name"), val TSRMLS_CC);
+                zend_update_property(pcbc_collection_spec_ce, &collection, ZEND_STRL("name"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("uid"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
                 zend_long uid = ZEND_STRTOL(Z_STRVAL_P(val), NULL, 16);
-                zend_update_property_long(pcbc_scope_spec_ce, return_value, ZEND_STRL("uid"), uid TSRMLS_CC);
+                zend_update_property_long(pcbc_scope_spec_ce, return_value, ZEND_STRL("uid"), uid);
             }
             add_next_index_zval(&collections, &collection);
         }
         ZEND_HASH_FOREACH_END();
     }
-    zend_update_property(pcbc_scope_spec_ce, return_value, ZEND_STRL("collections"), &collections TSRMLS_CC);
+    zend_update_property(pcbc_scope_spec_ce, return_value, ZEND_STRL("collections"), &collections);
     zval_delref_p(&collections);
 }
 
@@ -108,7 +108,7 @@ PHP_METHOD(CollectionManager, getAllScopes)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_GET);
     path_len = spprintf(&path, 0, "/pools/default/buckets/%s/collections", bucket->conn->bucketname);
     lcb_cmdhttp_path(cmd, path, path_len);
-    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, httpcb_getAllScopes, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, httpcb_getAllScopes, NULL);
     efree(path);
 }
 
@@ -147,7 +147,7 @@ PHP_METHOD(CollectionManager, getScope)
     char *path;
     size_t path_len;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "z", &scope);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "z", &scope);
     if (rv == FAILURE || Z_TYPE_P(scope) != IS_STRING) {
         RETURN_NULL();
     }
@@ -160,7 +160,7 @@ PHP_METHOD(CollectionManager, getScope)
     path_len = spprintf(&path, 0, "/pools/default/buckets/%s/collections", bucket->conn->bucketname);
     lcb_cmdhttp_path(cmd, path, path_len);
     ZVAL_ZVAL(return_value, scope, 0, NULL);
-    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, httpcb_getSingleScope, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, httpcb_getSingleScope, NULL);
     efree(path);
 }
 
@@ -170,7 +170,7 @@ PHP_METHOD(CollectionManager, createScope)
     zval *prop, val;
     zend_string *scope;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &scope);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &scope);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -191,7 +191,7 @@ PHP_METHOD(CollectionManager, createScope)
     zend_string_free(str);
     lcb_cmdhttp_body(cmd, payload, payload_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(payload);
     efree(path);
 }
@@ -204,7 +204,7 @@ PHP_METHOD(CollectionManager, dropScope)
     char *path;
     size_t path_len;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &scope);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &scope);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -217,7 +217,7 @@ PHP_METHOD(CollectionManager, dropScope)
     path_len = spprintf(&path, 0, "/pools/default/buckets/%s/collections/%.*s", bucket->conn->bucketname,
                         (int)ZSTR_LEN(scope), ZSTR_VAL(scope));
     lcb_cmdhttp_path(cmd, path, path_len);
-    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
 }
 
@@ -227,7 +227,7 @@ PHP_METHOD(CollectionManager, createCollection)
     zval *prop, val, val1, val2, val3;
     zval *collection, *name, *scope_name, *max_expiry;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "O", &collection, pcbc_collection_spec_ce);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O", &collection, pcbc_collection_spec_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -259,7 +259,7 @@ PHP_METHOD(CollectionManager, createCollection)
     }
     lcb_cmdhttp_body(cmd, payload, payload_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(payload);
     efree(path);
 }
@@ -272,7 +272,7 @@ PHP_METHOD(CollectionManager, dropCollection)
     char *path;
     size_t path_len;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "O", &collection, pcbc_collection_spec_ce);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O", &collection, pcbc_collection_spec_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -291,7 +291,7 @@ PHP_METHOD(CollectionManager, dropCollection)
     path_len = spprintf(&path, 0, "/pools/default/buckets/%s/collections/%.*s/%.*s", bucket->conn->bucketname,
                         (int)Z_STRLEN_P(scope_name), Z_STRVAL_P(scope_name), (int)Z_STRLEN_P(name), Z_STRVAL_P(name));
     lcb_cmdhttp_path(cmd, path, path_len);
-    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
 }
 
@@ -391,33 +391,33 @@ PHP_METHOD(CollectionSpec, scopeName)
 PHP_METHOD(CollectionSpec, setName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_collection_spec_ce, getThis(), ZEND_STRL("name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_collection_spec_ce, getThis(), ZEND_STRL("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(CollectionSpec, setScopeName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_collection_spec_ce, getThis(), ZEND_STRL("scope_name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_collection_spec_ce, getThis(), ZEND_STRL("scope_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(CollectionSpec, setMaxExpiry)
 {
     zend_long val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_collection_spec_ce, getThis(), ZEND_STRL("max_expiry"), val TSRMLS_CC);
+    zend_update_property_long(pcbc_collection_spec_ce, getThis(), ZEND_STRL("max_expiry"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -450,20 +450,20 @@ PHP_MINIT_FUNCTION(CollectionManager)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "CollectionManager", collection_manager_methods);
-    pcbc_collection_manager_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_collection_manager_ce, ZEND_STRL("bucket"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_collection_manager_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_collection_manager_ce, ZEND_STRL("bucket"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ScopeSpec", scope_spec_methods);
-    pcbc_scope_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_scope_spec_ce, ZEND_STRL("uid"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_scope_spec_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_scope_spec_ce, ZEND_STRL("collections"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_scope_spec_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_scope_spec_ce, ZEND_STRL("uid"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_scope_spec_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_scope_spec_ce, ZEND_STRL("collections"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "CollectionSpec", collection_spec_methods);
-    pcbc_collection_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_collection_spec_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_collection_spec_ce, ZEND_STRL("scope_name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_collection_spec_ce, ZEND_STRL("max_expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_collection_spec_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_collection_spec_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_collection_spec_ce, ZEND_STRL("scope_name"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_collection_spec_ce, ZEND_STRL("max_expiry"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/managers/collection_manager.c
+++ b/src/couchbase/managers/collection_manager.c
@@ -37,11 +37,11 @@ static void httpcb_getScope(void *ctx, zval *return_value, zval *response)
     if (!scope_name || Z_TYPE_P(scope_name) != IS_STRING) {
         return;
     }
-    zend_update_property(pcbc_scope_spec_ce, return_value, ZEND_STRL("name"), scope_name);
+    pcbc_update_property(pcbc_scope_spec_ce, return_value, ("name"), scope_name);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("uid"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
         zend_long uid = ZEND_STRTOL(Z_STRVAL_P(val), NULL, 16);
-        zend_update_property_long(pcbc_scope_spec_ce, return_value, ZEND_STRL("uid"), uid);
+        pcbc_update_property_long(pcbc_scope_spec_ce, return_value, ("uid"), uid);
     }
     zval collections;
     array_init(&collections);
@@ -52,21 +52,21 @@ static void httpcb_getScope(void *ctx, zval *return_value, zval *response)
         {
             zval collection;
             object_init_ex(&collection, pcbc_collection_spec_ce);
-            zend_update_property(pcbc_collection_spec_ce, &collection, ZEND_STRL("scope_name"), scope_name);
+            pcbc_update_property(pcbc_collection_spec_ce, &collection, ("scope_name"), scope_name);
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_collection_spec_ce, &collection, ZEND_STRL("name"), val);
+                pcbc_update_property(pcbc_collection_spec_ce, &collection, ("name"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("uid"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
                 zend_long uid = ZEND_STRTOL(Z_STRVAL_P(val), NULL, 16);
-                zend_update_property_long(pcbc_scope_spec_ce, return_value, ZEND_STRL("uid"), uid);
+                pcbc_update_property_long(pcbc_scope_spec_ce, return_value, ("uid"), uid);
             }
             add_next_index_zval(&collections, &collection);
         }
         ZEND_HASH_FOREACH_END();
     }
-    zend_update_property(pcbc_scope_spec_ce, return_value, ZEND_STRL("collections"), &collections);
+    pcbc_update_property(pcbc_scope_spec_ce, return_value, ("collections"), &collections);
     zval_delref_p(&collections);
 }
 
@@ -100,7 +100,7 @@ PHP_METHOD(CollectionManager, getAllScopes)
     if (zend_parse_parameters_none_throw() == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_collection_manager_ce, getThis(), ZEND_STRL("bucket"), 0, &val);
+    prop = pcbc_read_property(pcbc_collection_manager_ce, getThis(), ("bucket"), 0, &val);
     bucket = Z_BUCKET_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -151,7 +151,7 @@ PHP_METHOD(CollectionManager, getScope)
     if (rv == FAILURE || Z_TYPE_P(scope) != IS_STRING) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_collection_manager_ce, getThis(), ZEND_STRL("bucket"), 0, &val);
+    prop = pcbc_read_property(pcbc_collection_manager_ce, getThis(), ("bucket"), 0, &val);
     bucket = Z_BUCKET_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -174,7 +174,7 @@ PHP_METHOD(CollectionManager, createScope)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_collection_manager_ce, getThis(), ZEND_STRL("bucket"), 0, &val);
+    prop = pcbc_read_property(pcbc_collection_manager_ce, getThis(), ("bucket"), 0, &val);
     bucket = Z_BUCKET_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -208,7 +208,7 @@ PHP_METHOD(CollectionManager, dropScope)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_collection_manager_ce, getThis(), ZEND_STRL("bucket"), 0, &val);
+    prop = pcbc_read_property(pcbc_collection_manager_ce, getThis(), ("bucket"), 0, &val);
     bucket = Z_BUCKET_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -231,15 +231,15 @@ PHP_METHOD(CollectionManager, createCollection)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_collection_manager_ce, getThis(), ZEND_STRL("bucket"), 0, &val);
+    prop = pcbc_read_property(pcbc_collection_manager_ce, getThis(), ("bucket"), 0, &val);
     bucket = Z_BUCKET_OBJ_P(prop);
 
-    name = zend_read_property(pcbc_collection_spec_ce, collection, ZEND_STRL("name"), 0, &val1);
-    scope_name = zend_read_property(pcbc_collection_spec_ce, collection, ZEND_STRL("scope_name"), 0, &val2);
+    name = pcbc_read_property(pcbc_collection_spec_ce, collection, ("name"), 0, &val1);
+    scope_name = pcbc_read_property(pcbc_collection_spec_ce, collection, ("scope_name"), 0, &val2);
     if (name == NULL || Z_TYPE_P(name) != IS_STRING || scope_name == NULL || Z_TYPE_P(scope_name) != IS_STRING) {
         RETURN_NULL();
     }
-    max_expiry = zend_read_property(pcbc_collection_spec_ce, collection, ZEND_STRL("max_expiry"), 0, &val3);
+    max_expiry = pcbc_read_property(pcbc_collection_spec_ce, collection, ("max_expiry"), 0, &val3);
 
     lcb_CMDHTTP *cmd;
     lcb_cmdhttp_create(&cmd, LCB_HTTP_TYPE_MANAGEMENT);
@@ -276,11 +276,11 @@ PHP_METHOD(CollectionManager, dropCollection)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_collection_manager_ce, getThis(), ZEND_STRL("bucket"), 0, &val);
+    prop = pcbc_read_property(pcbc_collection_manager_ce, getThis(), ("bucket"), 0, &val);
     bucket = Z_BUCKET_OBJ_P(prop);
 
-    name = zend_read_property(pcbc_collection_spec_ce, collection, ZEND_STRL("name"), 0, &val1);
-    scope_name = zend_read_property(pcbc_collection_spec_ce, collection, ZEND_STRL("scope_name"), 0, &val2);
+    name = pcbc_read_property(pcbc_collection_spec_ce, collection, ("name"), 0, &val1);
+    scope_name = pcbc_read_property(pcbc_collection_spec_ce, collection, ("scope_name"), 0, &val2);
     if (name == NULL || Z_TYPE_P(name) != IS_STRING || scope_name == NULL || Z_TYPE_P(scope_name) != IS_STRING) {
         RETURN_NULL();
     }
@@ -337,7 +337,7 @@ PHP_METHOD(ScopeSpec, name)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_scope_spec_ce, getThis(), ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_scope_spec_ce, getThis(), ("name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -348,7 +348,7 @@ PHP_METHOD(ScopeSpec, collections)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_scope_spec_ce, getThis(), ZEND_STRL("collections"), 0, &rv);
+    prop = pcbc_read_property(pcbc_scope_spec_ce, getThis(), ("collections"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -373,7 +373,7 @@ PHP_METHOD(CollectionSpec, name)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_collection_spec_ce, getThis(), ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_collection_spec_ce, getThis(), ("name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -384,7 +384,7 @@ PHP_METHOD(CollectionSpec, scopeName)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_collection_spec_ce, getThis(), ZEND_STRL("scope_name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_collection_spec_ce, getThis(), ("scope_name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -395,7 +395,7 @@ PHP_METHOD(CollectionSpec, setName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_collection_spec_ce, getThis(), ZEND_STRL("name"), val);
+    pcbc_update_property_str(pcbc_collection_spec_ce, getThis(), ("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -406,7 +406,7 @@ PHP_METHOD(CollectionSpec, setScopeName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_collection_spec_ce, getThis(), ZEND_STRL("scope_name"), val);
+    pcbc_update_property_str(pcbc_collection_spec_ce, getThis(), ("scope_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -417,7 +417,7 @@ PHP_METHOD(CollectionSpec, setMaxExpiry)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_collection_spec_ce, getThis(), ZEND_STRL("max_expiry"), val);
+    pcbc_update_property_long(pcbc_collection_spec_ce, getThis(), ("max_expiry"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 

--- a/src/couchbase/managers/query_index_manager.c
+++ b/src/couchbase/managers/query_index_manager.c
@@ -44,33 +44,33 @@ static void httpcb_getAllIndexes(void *ctx, zval *return_value, zval *response)
             object_init_ex(&index, pcbc_query_index_ce);
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("name"), val);
+                pcbc_update_property(pcbc_query_index_ce, &index, ("name"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("using"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("type"), val);
+                pcbc_update_property(pcbc_query_index_ce, &index, ("type"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("is_primary"));
             if (val && (Z_TYPE_P(val) == IS_FALSE || Z_TYPE_P(val) == IS_TRUE)) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("is_primary"), val);
+                pcbc_update_property(pcbc_query_index_ce, &index, ("is_primary"), val);
             } else {
-                zend_update_property_bool(pcbc_query_index_ce, &index, ZEND_STRL("is_primary"), 0);
+                pcbc_update_property_bool(pcbc_query_index_ce, &index, ("is_primary"), 0);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("state"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("state"), val);
+                pcbc_update_property(pcbc_query_index_ce, &index, ("state"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("keyspace_id"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("keyspace"), val);
+                pcbc_update_property(pcbc_query_index_ce, &index, ("keyspace"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("index_key"));
             if (val && Z_TYPE_P(val) == IS_ARRAY) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("index_key"), val);
+                pcbc_update_property(pcbc_query_index_ce, &index, ("index_key"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("condition"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("condition"), val);
+                pcbc_update_property(pcbc_query_index_ce, &index, ("condition"), val);
             }
             add_next_index_zval(return_value, &index);
         }
@@ -88,7 +88,7 @@ PHP_METHOD(QueryIndexManager, getAllIndexes)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_query_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_query_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -111,8 +111,8 @@ static int errcb_createIndex(void *ctx, zval *return_value)
     zend_bool *ignore_exists_error = (zend_bool *)ctx;
     if (*ignore_exists_error && return_value) {
         zval *code, *msg, rv1, rv2;
-        msg = zend_read_property(pcbc_default_exception_ce, return_value, ZEND_STRL("message"), 0, &rv1);
-        code = zend_read_property(pcbc_default_exception_ce, return_value, ZEND_STRL("code"), 0, &rv2);
+        msg = pcbc_read_property(pcbc_default_exception_ce, return_value, ("message"), 0, &rv1);
+        code = pcbc_read_property(pcbc_default_exception_ce, return_value, ("code"), 0, &rv2);
         if (code && Z_TYPE_P(code) == IS_LONG && msg && Z_TYPE_P(msg) == IS_STRING) {
             if ((Z_LVAL_P(code) == 5000 || Z_LVAL_P(code) == 4300) && strstr(Z_STRVAL_P(msg), " already exist")) {
                 return 0;
@@ -135,26 +135,26 @@ PHP_METHOD(QueryIndexManager, createIndex)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_query_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_query_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     smart_str with_options = {0};
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_create_query_index_options_ce, options, ZEND_STRL("ignore_if_exists"), 0, &ret);
+        prop = pcbc_read_property(pcbc_create_query_index_options_ce, options, ("ignore_if_exists"), 0, &ret);
         if (prop && Z_TYPE_P(prop) == IS_TRUE) {
             ignore_exists_error = 1;
         }
-        prop = zend_read_property(pcbc_create_query_index_options_ce, options, ZEND_STRL("condition"), 0, &ret2);
+        prop = pcbc_read_property(pcbc_create_query_index_options_ce, options, ("condition"), 0, &ret2);
         if (prop && Z_TYPE_P(prop) == IS_STRING) {
             where = prop;
         }
         smart_str_appends(&with_options, "{");
-        prop = zend_read_property(pcbc_create_query_index_options_ce, options, ZEND_STRL("num_replicas"), 0, &ret);
+        prop = pcbc_read_property(pcbc_create_query_index_options_ce, options, ("num_replicas"), 0, &ret);
         if (prop && Z_TYPE_P(prop) == IS_LONG) {
             smart_str_append_printf(&with_options, "\\\"num_replicas\\\":%d", (int)Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_create_query_index_options_ce, options, ZEND_STRL("deferred"), 0, &ret);
+        prop = pcbc_read_property(pcbc_create_query_index_options_ce, options, ("deferred"), 0, &ret);
         if (prop && (Z_TYPE_P(prop) == IS_TRUE || Z_TYPE_P(prop) == IS_FALSE)) {
             if (ZSTR_LEN(with_options.s) > 2) {
                 smart_str_appendc(&with_options, ',');
@@ -216,29 +216,29 @@ PHP_METHOD(QueryIndexManager, createPrimaryIndex)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_query_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_query_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     smart_str with_options = {0};
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_create_query_primary_index_options_ce, options, ZEND_STRL("ignore_if_exists"), 0,
+        prop = pcbc_read_property(pcbc_create_query_primary_index_options_ce, options, ("ignore_if_exists"), 0,
                                   &ret);
         if (prop && Z_TYPE_P(prop) == IS_TRUE) {
             ignore_exists_error = 1;
         }
         prop =
-            zend_read_property(pcbc_create_query_primary_index_options_ce, options, ZEND_STRL("index_name"), 0, &val2);
+            pcbc_read_property(pcbc_create_query_primary_index_options_ce, options, ("index_name"), 0, &val2);
         if (prop && Z_TYPE_P(prop) == IS_STRING) {
             index = prop;
         }
         smart_str_appends(&with_options, "{");
         prop =
-            zend_read_property(pcbc_create_query_primary_index_options_ce, options, ZEND_STRL("num_replicas"), 0, &ret);
+            pcbc_read_property(pcbc_create_query_primary_index_options_ce, options, ("num_replicas"), 0, &ret);
         if (prop && Z_TYPE_P(prop) == IS_LONG) {
             smart_str_append_printf(&with_options, "\\\"num_replicas\\\":%d", (int)Z_LVAL_P(prop));
         }
-        prop = zend_read_property(pcbc_create_query_primary_index_options_ce, options, ZEND_STRL("deferred"), 0, &ret);
+        prop = pcbc_read_property(pcbc_create_query_primary_index_options_ce, options, ("deferred"), 0, &ret);
         if (prop && (Z_TYPE_P(prop) == IS_TRUE || Z_TYPE_P(prop) == IS_FALSE)) {
             if (ZSTR_LEN(with_options.s) > 2) {
                 smart_str_appendc(&with_options, ',');
@@ -279,8 +279,8 @@ static int errcb_dropIndex(void *ctx, zval *return_value)
     zend_bool *ignore_exists_error = (zend_bool *)ctx;
     if (*ignore_exists_error && return_value) {
         zval *code, *msg, rv1, rv2;
-        msg = zend_read_property(pcbc_default_exception_ce, return_value, ZEND_STRL("message"), 0, &rv1);
-        code = zend_read_property(pcbc_default_exception_ce, return_value, ZEND_STRL("code"), 0, &rv2);
+        msg = pcbc_read_property(pcbc_default_exception_ce, return_value, ("message"), 0, &rv1);
+        code = pcbc_read_property(pcbc_default_exception_ce, return_value, ("code"), 0, &rv2);
         if (code && Z_TYPE_P(code) == IS_LONG && msg && Z_TYPE_P(msg) == IS_STRING) {
             switch (Z_LVAL_P(code)) {
             case 5000:
@@ -310,13 +310,13 @@ PHP_METHOD(QueryIndexManager, dropIndex)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_query_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_query_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     if (options) {
         zval *prop, ret;
         prop =
-            zend_read_property(pcbc_drop_query_index_options_ce, options, ZEND_STRL("ignore_if_not_exists"), 0, &ret);
+            pcbc_read_property(pcbc_drop_query_index_options_ce, options, ("ignore_if_not_exists"), 0, &ret);
         if (prop && Z_TYPE_P(prop) == IS_TRUE) {
             ignore_not_exists_error = 1;
         }
@@ -349,17 +349,17 @@ PHP_METHOD(QueryIndexManager, dropPrimaryIndex)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_query_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_query_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     if (options) {
         zval *prop, ret;
-        prop = zend_read_property(pcbc_drop_query_primary_index_options_ce, options, ZEND_STRL("ignore_if_not_exists"),
+        prop = pcbc_read_property(pcbc_drop_query_primary_index_options_ce, options, ("ignore_if_not_exists"),
                                   0, &ret);
         if (prop && Z_TYPE_P(prop) == IS_TRUE) {
             ignore_not_exists_error = 1;
         }
-        prop = zend_read_property(pcbc_drop_query_primary_index_options_ce, options, ZEND_STRL("index_name"), 0, &val2);
+        prop = pcbc_read_property(pcbc_drop_query_primary_index_options_ce, options, ("index_name"), 0, &val2);
         if (prop && Z_TYPE_P(prop) == IS_STRING) {
             index = prop;
         }
@@ -458,7 +458,7 @@ PHP_METHOD(QueryIndexManager, watchIndexes)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_query_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_query_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     struct watch_context ctx;
@@ -470,7 +470,7 @@ PHP_METHOD(QueryIndexManager, watchIndexes)
 
     if (options) {
         zval ret;
-        prop = zend_read_property(pcbc_watch_query_indexes_options_ce, options, ZEND_STRL("watch_primary"), 0, &ret);
+        prop = pcbc_read_property(pcbc_watch_query_indexes_options_ce, options, ("watch_primary"), 0, &ret);
         if (prop && Z_TYPE_P(prop) == IS_TRUE) {
             ctx.watch_primary = 1;
         }
@@ -504,7 +504,7 @@ PHP_METHOD(QueryIndexManager, buildDeferredIndexes)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_query_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_query_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -581,7 +581,7 @@ PHP_METHOD(QueryIndex, name)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_index_ce, getThis(), ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_index_ce, getThis(), ("name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -592,7 +592,7 @@ PHP_METHOD(QueryIndex, isPrimary)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_index_ce, getThis(), ZEND_STRL("is_primary"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_index_ce, getThis(), ("is_primary"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -603,7 +603,7 @@ PHP_METHOD(QueryIndex, type)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_index_ce, getThis(), ZEND_STRL("type"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_index_ce, getThis(), ("type"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -614,7 +614,7 @@ PHP_METHOD(QueryIndex, state)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_index_ce, getThis(), ZEND_STRL("state"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_index_ce, getThis(), ("state"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -625,7 +625,7 @@ PHP_METHOD(QueryIndex, keyspace)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_index_ce, getThis(), ZEND_STRL("keyspace"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_index_ce, getThis(), ("keyspace"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -636,7 +636,7 @@ PHP_METHOD(QueryIndex, indexKey)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_index_ce, getThis(), ZEND_STRL("index_key"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_index_ce, getThis(), ("index_key"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -647,7 +647,7 @@ PHP_METHOD(QueryIndex, condition)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_index_ce, getThis(), ZEND_STRL("condition"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_index_ce, getThis(), ("condition"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -692,7 +692,7 @@ PHP_METHOD(CreateQueryIndexOptions, condition)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_create_query_index_options_ce, getThis(), ZEND_STRL("condition"), val);
+    pcbc_update_property_str(pcbc_create_query_index_options_ce, getThis(), ("condition"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -703,7 +703,7 @@ PHP_METHOD(CreateQueryIndexOptions, ignoreIfExists)
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_create_query_index_options_ce, getThis(), ZEND_STRL("ignore_if_exists"),
+    pcbc_update_property_bool(pcbc_create_query_index_options_ce, getThis(), ("ignore_if_exists"),
                               val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -715,7 +715,7 @@ PHP_METHOD(CreateQueryIndexOptions, deferred)
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_create_query_index_options_ce, getThis(), ZEND_STRL("deferred"), val);
+    pcbc_update_property_bool(pcbc_create_query_index_options_ce, getThis(), ("deferred"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -726,7 +726,7 @@ PHP_METHOD(CreateQueryIndexOptions, numReplicas)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_create_query_index_options_ce, getThis(), ZEND_STRL("num_replicas"), val);
+    pcbc_update_property_long(pcbc_create_query_index_options_ce, getThis(), ("num_replicas"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -767,7 +767,7 @@ PHP_METHOD(CreateQueryPrimaryIndexOptions, indexName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_create_query_primary_index_options_ce, getThis(), ZEND_STRL("index_name"),
+    pcbc_update_property_str(pcbc_create_query_primary_index_options_ce, getThis(), ("index_name"),
                              val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -779,7 +779,7 @@ PHP_METHOD(CreateQueryPrimaryIndexOptions, ignoreIfExists)
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_create_query_primary_index_options_ce, getThis(), ZEND_STRL("ignore_if_exists"),
+    pcbc_update_property_bool(pcbc_create_query_primary_index_options_ce, getThis(), ("ignore_if_exists"),
                               val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -791,7 +791,7 @@ PHP_METHOD(CreateQueryPrimaryIndexOptions, deferred)
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_create_query_primary_index_options_ce, getThis(), ZEND_STRL("deferred"),
+    pcbc_update_property_bool(pcbc_create_query_primary_index_options_ce, getThis(), ("deferred"),
                               val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -803,7 +803,7 @@ PHP_METHOD(CreateQueryPrimaryIndexOptions, numReplicas)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_create_query_primary_index_options_ce, getThis(), ZEND_STRL("num_replicas"),
+    pcbc_update_property_long(pcbc_create_query_primary_index_options_ce, getThis(), ("num_replicas"),
                               val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -845,7 +845,7 @@ PHP_METHOD(DropQueryIndexOptions, ignoreIfNotExists)
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_drop_query_index_options_ce, getThis(), ZEND_STRL("ignore_if_not_exists"),
+    pcbc_update_property_bool(pcbc_drop_query_index_options_ce, getThis(), ("ignore_if_not_exists"),
                               val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -869,7 +869,7 @@ PHP_METHOD(DropQueryPrimaryIndexOptions, indexName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_drop_query_primary_index_options_ce, getThis(), ZEND_STRL("index_name"),
+    pcbc_update_property_str(pcbc_drop_query_primary_index_options_ce, getThis(), ("index_name"),
                              val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -881,7 +881,7 @@ PHP_METHOD(DropQueryPrimaryIndexOptions, ignoreIfNotExists)
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_drop_query_primary_index_options_ce, getThis(), ZEND_STRL("ignore_if_not_exists"),
+    pcbc_update_property_bool(pcbc_drop_query_primary_index_options_ce, getThis(), ("ignore_if_not_exists"),
                               val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -911,7 +911,7 @@ PHP_METHOD(WatchQueryIndexesOptions, watchPrimary)
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_watch_query_indexes_options_ce, getThis(), ZEND_STRL("watch_primary"),
+    pcbc_update_property_bool(pcbc_watch_query_indexes_options_ce, getThis(), ("watch_primary"),
                               val);
     RETURN_ZVAL(getThis(), 1, 0);
 }

--- a/src/couchbase/managers/query_index_manager.c
+++ b/src/couchbase/managers/query_index_manager.c
@@ -44,33 +44,33 @@ static void httpcb_getAllIndexes(void *ctx, zval *return_value, zval *response)
             object_init_ex(&index, pcbc_query_index_ce);
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("name"), val TSRMLS_CC);
+                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("name"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("using"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("type"), val TSRMLS_CC);
+                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("type"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("is_primary"));
             if (val && (Z_TYPE_P(val) == IS_FALSE || Z_TYPE_P(val) == IS_TRUE)) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("is_primary"), val TSRMLS_CC);
+                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("is_primary"), val);
             } else {
-                zend_update_property_bool(pcbc_query_index_ce, &index, ZEND_STRL("is_primary"), 0 TSRMLS_CC);
+                zend_update_property_bool(pcbc_query_index_ce, &index, ZEND_STRL("is_primary"), 0);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("state"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("state"), val TSRMLS_CC);
+                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("state"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("keyspace_id"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("keyspace"), val TSRMLS_CC);
+                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("keyspace"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("index_key"));
             if (val && Z_TYPE_P(val) == IS_ARRAY) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("index_key"), val TSRMLS_CC);
+                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("index_key"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("condition"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("condition"), val TSRMLS_CC);
+                zend_update_property(pcbc_query_index_ce, &index, ZEND_STRL("condition"), val);
             }
             add_next_index_zval(return_value, &index);
         }
@@ -84,7 +84,7 @@ PHP_METHOD(QueryIndexManager, getAllIndexes)
     zval *prop, val;
     zend_string *bucket;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &bucket);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &bucket);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -102,7 +102,7 @@ PHP_METHOD(QueryIndexManager, getAllIndexes)
                            (int)ZSTR_LEN(bucket), ZSTR_VAL(bucket));
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_JSON, strlen(PCBC_CONTENT_TYPE_JSON));
     lcb_cmdhttp_body(cmd, payload, payload_len);
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getAllIndexes, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getAllIndexes, NULL);
     efree(payload);
 }
 
@@ -130,7 +130,7 @@ PHP_METHOD(QueryIndexManager, createIndex)
     zval *fields, *options = NULL, *where = NULL;
     zend_bool ignore_exists_error = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "SSa|O!", &bucket, &index, &fields, &options,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "SSa|O!", &bucket, &index, &fields, &options,
                                          pcbc_create_query_index_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
@@ -198,7 +198,7 @@ PHP_METHOD(QueryIndexManager, createIndex)
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_JSON, strlen(PCBC_CONTENT_TYPE_JSON));
     lcb_cmdhttp_body(cmd, ZSTR_VAL(payload.s), ZSTR_LEN(payload.s));
     pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, &ignore_exists_error, NULL,
-                      errcb_createIndex TSRMLS_CC);
+                      errcb_createIndex);
     smart_str_free(&with_options);
     smart_str_free(&payload);
 }
@@ -211,7 +211,7 @@ PHP_METHOD(QueryIndexManager, createPrimaryIndex)
     zval *index = NULL, *options = NULL;
     zend_bool ignore_exists_error = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|O!", &bucket, &options,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|O!", &bucket, &options,
                                          pcbc_create_query_primary_index_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
@@ -269,7 +269,7 @@ PHP_METHOD(QueryIndexManager, createPrimaryIndex)
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_JSON, strlen(PCBC_CONTENT_TYPE_JSON));
     lcb_cmdhttp_body(cmd, ZSTR_VAL(payload.s), ZSTR_LEN(payload.s));
     pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, &ignore_exists_error, NULL,
-                      errcb_createIndex TSRMLS_CC);
+                      errcb_createIndex);
     smart_str_free(&with_options);
     smart_str_free(&payload);
 }
@@ -305,7 +305,7 @@ PHP_METHOD(QueryIndexManager, dropIndex)
     zval *options = NULL;
     zend_bool ignore_not_exists_error = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "SS|O!", &bucket, &index, &options,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "SS|O!", &bucket, &index, &options,
                                          pcbc_drop_query_index_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
@@ -332,7 +332,7 @@ PHP_METHOD(QueryIndexManager, dropIndex)
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_JSON, strlen(PCBC_CONTENT_TYPE_JSON));
     lcb_cmdhttp_body(cmd, ZSTR_VAL(payload.s), ZSTR_LEN(payload.s));
     pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, &ignore_not_exists_error, NULL,
-                      errcb_dropIndex TSRMLS_CC);
+                      errcb_dropIndex);
     smart_str_free(&payload);
 }
 
@@ -344,7 +344,7 @@ PHP_METHOD(QueryIndexManager, dropPrimaryIndex)
     zval *options = NULL, *index = NULL;
     zend_bool ignore_not_exists_error = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|O!", &bucket, &options,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|O!", &bucket, &options,
                                          pcbc_drop_query_primary_index_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
@@ -380,7 +380,7 @@ PHP_METHOD(QueryIndexManager, dropPrimaryIndex)
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_JSON, strlen(PCBC_CONTENT_TYPE_JSON));
     lcb_cmdhttp_body(cmd, ZSTR_VAL(payload.s), ZSTR_LEN(payload.s));
     pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, &ignore_not_exists_error, NULL,
-                      errcb_dropIndex TSRMLS_CC);
+                      errcb_dropIndex);
     smart_str_free(&payload);
 }
 
@@ -453,7 +453,7 @@ PHP_METHOD(QueryIndexManager, watchIndexes)
     zval *indexes = NULL, *options = NULL;
     zend_long timeout;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sal|O!", &bucket, &indexes, &timeout, &options,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sal|O!", &bucket, &indexes, &timeout, &options,
                                          pcbc_watch_query_indexes_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
@@ -489,7 +489,7 @@ PHP_METHOD(QueryIndexManager, watchIndexes)
         lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_POST);
         lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_JSON, strlen(PCBC_CONTENT_TYPE_JSON));
         lcb_cmdhttp_body(cmd, payload, payload_len);
-        pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, &ctx, httpcb_watchIndexes, NULL TSRMLS_CC);
+        pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, &ctx, httpcb_watchIndexes, NULL);
     }
     efree(payload);
 }
@@ -500,7 +500,7 @@ PHP_METHOD(QueryIndexManager, buildDeferredIndexes)
     zval *prop, val;
     zend_string *bucket;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &bucket);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &bucket);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -519,7 +519,7 @@ PHP_METHOD(QueryIndexManager, buildDeferredIndexes)
                            (int)ZSTR_LEN(bucket), ZSTR_VAL(bucket), (int)ZSTR_LEN(bucket), ZSTR_VAL(bucket));
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_JSON, strlen(PCBC_CONTENT_TYPE_JSON));
     lcb_cmdhttp_body(cmd, payload, payload_len);
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(payload);
 }
 
@@ -688,45 +688,45 @@ zend_function_entry query_index_methods[] = {
 PHP_METHOD(CreateQueryIndexOptions, condition)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_create_query_index_options_ce, getThis(), ZEND_STRL("condition"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_create_query_index_options_ce, getThis(), ZEND_STRL("condition"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(CreateQueryIndexOptions, ignoreIfExists)
 {
     zend_bool val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &val) == FAILURE) {
         RETURN_NULL();
     }
 
     zend_update_property_bool(pcbc_create_query_index_options_ce, getThis(), ZEND_STRL("ignore_if_exists"),
-                              val TSRMLS_CC);
+                              val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(CreateQueryIndexOptions, deferred)
 {
     zend_bool val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_create_query_index_options_ce, getThis(), ZEND_STRL("deferred"), val TSRMLS_CC);
+    zend_update_property_bool(pcbc_create_query_index_options_ce, getThis(), ZEND_STRL("deferred"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(CreateQueryIndexOptions, numReplicas)
 {
     zend_long val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_create_query_index_options_ce, getThis(), ZEND_STRL("num_replicas"), val TSRMLS_CC);
+    zend_update_property_long(pcbc_create_query_index_options_ce, getThis(), ZEND_STRL("num_replicas"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -763,48 +763,48 @@ zend_function_entry create_query_index_options_methods[] = {
 PHP_METHOD(CreateQueryPrimaryIndexOptions, indexName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
     zend_update_property_str(pcbc_create_query_primary_index_options_ce, getThis(), ZEND_STRL("index_name"),
-                             val TSRMLS_CC);
+                             val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(CreateQueryPrimaryIndexOptions, ignoreIfExists)
 {
     zend_bool val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &val) == FAILURE) {
         RETURN_NULL();
     }
 
     zend_update_property_bool(pcbc_create_query_primary_index_options_ce, getThis(), ZEND_STRL("ignore_if_exists"),
-                              val TSRMLS_CC);
+                              val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(CreateQueryPrimaryIndexOptions, deferred)
 {
     zend_bool val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &val) == FAILURE) {
         RETURN_NULL();
     }
 
     zend_update_property_bool(pcbc_create_query_primary_index_options_ce, getThis(), ZEND_STRL("deferred"),
-                              val TSRMLS_CC);
+                              val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(CreateQueryPrimaryIndexOptions, numReplicas)
 {
     zend_long val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &val) == FAILURE) {
         RETURN_NULL();
     }
 
     zend_update_property_long(pcbc_create_query_primary_index_options_ce, getThis(), ZEND_STRL("num_replicas"),
-                              val TSRMLS_CC);
+                              val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -841,12 +841,12 @@ zend_function_entry create_query_primary_index_options_methods[] = {
 PHP_METHOD(DropQueryIndexOptions, ignoreIfNotExists)
 {
     zend_bool val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &val) == FAILURE) {
         RETURN_NULL();
     }
 
     zend_update_property_bool(pcbc_drop_query_index_options_ce, getThis(), ZEND_STRL("ignore_if_not_exists"),
-                              val TSRMLS_CC);
+                              val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -865,24 +865,24 @@ zend_function_entry drop_query_index_options_methods[] = {
 PHP_METHOD(DropQueryPrimaryIndexOptions, indexName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
     zend_update_property_str(pcbc_drop_query_primary_index_options_ce, getThis(), ZEND_STRL("index_name"),
-                             val TSRMLS_CC);
+                             val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(DropQueryPrimaryIndexOptions, ignoreIfNotExists)
 {
     zend_bool val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &val) == FAILURE) {
         RETURN_NULL();
     }
 
     zend_update_property_bool(pcbc_drop_query_primary_index_options_ce, getThis(), ZEND_STRL("ignore_if_not_exists"),
-                              val TSRMLS_CC);
+                              val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -907,12 +907,12 @@ zend_function_entry drop_query_primary_index_options_methods[] = {
 PHP_METHOD(WatchQueryIndexesOptions, watchPrimary)
 {
     zend_bool val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &val) == FAILURE) {
         RETURN_NULL();
     }
 
     zend_update_property_bool(pcbc_watch_query_indexes_options_ce, getThis(), ZEND_STRL("watch_primary"),
-                              val TSRMLS_CC);
+                              val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -933,55 +933,55 @@ PHP_MINIT_FUNCTION(QueryIndexManager)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "QueryIndexManager", query_index_manager_methods);
-    pcbc_query_index_manager_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_index_manager_ce, ZEND_STRL("cluster"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_query_index_manager_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_query_index_manager_ce, ZEND_STRL("cluster"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "QueryIndex", query_index_methods);
-    pcbc_query_index_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("is_primary"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("type"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("state"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("keyspace"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("index_key"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("condition"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_query_index_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("is_primary"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("type"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("state"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("keyspace"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("index_key"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_index_ce, ZEND_STRL("condition"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "CreateQueryIndexOptions", create_query_index_options_methods);
-    pcbc_create_query_index_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_create_query_index_options_ce, ZEND_STRL("condition"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_create_query_index_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_create_query_index_options_ce, ZEND_STRL("condition"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_create_query_index_options_ce, ZEND_STRL("ignore_if_exists"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_create_query_index_options_ce, ZEND_STRL("num_replicas"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_create_query_index_options_ce, ZEND_STRL("deferred"), ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_create_query_index_options_ce, ZEND_STRL("deferred"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "CreateQueryPrimaryIndexOptions", create_query_primary_index_options_methods);
-    pcbc_create_query_primary_index_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_create_query_primary_index_options_ce = zend_register_internal_class(&ce);
     zend_declare_property_null(pcbc_create_query_primary_index_options_ce, ZEND_STRL("index_name"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_create_query_primary_index_options_ce, ZEND_STRL("ignore_if_exists"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_create_query_primary_index_options_ce, ZEND_STRL("num_replicas"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_create_query_primary_index_options_ce, ZEND_STRL("deferred"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "DropQueryIndexOptions", drop_query_index_options_methods);
-    pcbc_drop_query_index_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_drop_query_index_options_ce = zend_register_internal_class(&ce);
     zend_declare_property_null(pcbc_drop_query_index_options_ce, ZEND_STRL("ignore_if_not_exists"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "DropQueryPrimaryIndexOptions", drop_query_primary_index_options_methods);
-    pcbc_drop_query_primary_index_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_drop_query_primary_index_options_ce = zend_register_internal_class(&ce);
     zend_declare_property_null(pcbc_drop_query_primary_index_options_ce, ZEND_STRL("index_name"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_drop_query_primary_index_options_ce, ZEND_STRL("ignore_if_not_exists"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "WatchQueryIndexesOptions", watch_query_indexes_options_methods);
-    pcbc_watch_query_indexes_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_watch_query_indexes_options_ce = zend_register_internal_class(&ce);
     zend_declare_property_null(pcbc_watch_query_indexes_options_ce, ZEND_STRL("watch_primary"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/managers/search_index_manager.c
+++ b/src/couchbase/managers/search_index_manager.c
@@ -29,35 +29,35 @@ static void parse_index_entry(zval *return_value, zval *response)
     zval *val;
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("name"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("name"), val TSRMLS_CC);
+        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("name"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("uuid"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("uuid"), val TSRMLS_CC);
+        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("uuid"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("type"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("type"), val TSRMLS_CC);
+        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("type"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("params"));
     if (val) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("params"), val TSRMLS_CC);
+        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("params"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("sourceName"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("source_name"), val TSRMLS_CC);
+        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("source_name"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("sourceUUID"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("source_uuid"), val TSRMLS_CC);
+        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("source_uuid"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("sourceType"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("source_type"), val TSRMLS_CC);
+        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("source_type"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("sourceParams"));
     if (val) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("source_params"), val TSRMLS_CC);
+        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("source_params"), val);
     }
 }
 
@@ -100,7 +100,7 @@ PHP_METHOD(SearchIndexManager, getAllIndexes)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_GET);
     lcb_cmdhttp_path(cmd, path, strlen(path));
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getAllIndexes, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getAllIndexes, NULL);
 }
 
 static void httpcb_getIndex(void *ctx, zval *return_value, zval *response)
@@ -119,7 +119,7 @@ PHP_METHOD(SearchIndexManager, getIndex)
     char *path;
     zend_string *name;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -133,7 +133,7 @@ PHP_METHOD(SearchIndexManager, getIndex)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_GET);
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getIndex, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getIndex, NULL);
     efree(path);
 }
 
@@ -145,7 +145,7 @@ PHP_METHOD(SearchIndexManager, dropIndex)
     char *path;
     zend_string *name;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -159,7 +159,7 @@ PHP_METHOD(SearchIndexManager, dropIndex)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_DELETE);
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
 }
 
@@ -172,7 +172,7 @@ PHP_METHOD(SearchIndexManager, upsertIndex)
     smart_str buf = {0};
     int last_error;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "O", &index, pcbc_search_index_ce);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O", &index, pcbc_search_index_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -200,7 +200,7 @@ PHP_METHOD(SearchIndexManager, upsertIndex)
         smart_str_0(&buf);
         lcb_cmdhttp_body(cmd, ZSTR_VAL(buf.s), ZSTR_LEN(buf.s));
     }
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
     smart_str_free(&buf);
 }
@@ -223,7 +223,7 @@ PHP_METHOD(SearchIndexManager, getIndexedDocumentsCount)
     char *path;
     zend_string *name;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -237,7 +237,7 @@ PHP_METHOD(SearchIndexManager, getIndexedDocumentsCount)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_GET);
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getIndexedDocumentsCount, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getIndexedDocumentsCount, NULL);
     efree(path);
 }
 
@@ -249,7 +249,7 @@ PHP_METHOD(SearchIndexManager, pauseIngest)
     char *path;
     zend_string *name;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -263,7 +263,7 @@ PHP_METHOD(SearchIndexManager, pauseIngest)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_POST);
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
 }
 
@@ -275,7 +275,7 @@ PHP_METHOD(SearchIndexManager, resumeIngest)
     char *path;
     zend_string *name;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -289,7 +289,7 @@ PHP_METHOD(SearchIndexManager, resumeIngest)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_POST);
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
 }
 
@@ -301,7 +301,7 @@ PHP_METHOD(SearchIndexManager, allowQuerying)
     char *path;
     zend_string *name;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -315,7 +315,7 @@ PHP_METHOD(SearchIndexManager, allowQuerying)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_POST);
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
 }
 
@@ -327,7 +327,7 @@ PHP_METHOD(SearchIndexManager, disallowQuerying)
     char *path;
     zend_string *name;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -341,7 +341,7 @@ PHP_METHOD(SearchIndexManager, disallowQuerying)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_POST);
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
 }
 
@@ -353,7 +353,7 @@ PHP_METHOD(SearchIndexManager, freezePlan)
     char *path;
     zend_string *name;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -367,7 +367,7 @@ PHP_METHOD(SearchIndexManager, freezePlan)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_POST);
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
 }
 
@@ -379,7 +379,7 @@ PHP_METHOD(SearchIndexManager, unfreezePlan)
     char *path;
     zend_string *name;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -393,7 +393,7 @@ PHP_METHOD(SearchIndexManager, unfreezePlan)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_POST);
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
 }
 
@@ -413,7 +413,7 @@ PHP_METHOD(SearchIndexManager, analyzeDocument)
     smart_str buf = {0};
     int last_error;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sz", &name, &doc);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sz", &name, &doc);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -437,7 +437,7 @@ PHP_METHOD(SearchIndexManager, analyzeDocument)
         smart_str_0(&buf);
         lcb_cmdhttp_body(cmd, ZSTR_VAL(buf.s), ZSTR_LEN(buf.s));
     }
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_analyzeDocument, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_analyzeDocument, NULL);
     efree(path);
     smart_str_free(&buf);
 }
@@ -599,88 +599,88 @@ PHP_METHOD(SearchIndex, sourceParams)
 PHP_METHOD(SearchIndex, setType)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("type"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("type"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(SearchIndex, setUuid)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("uuid"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("uuid"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(SearchIndex, setName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(SearchIndex, setParams)
 {
     zval *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "a", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "a", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_search_index_ce, getThis(), ZEND_STRL("params"), val TSRMLS_CC);
+    zend_update_property(pcbc_search_index_ce, getThis(), ZEND_STRL("params"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(SearchIndex, setSourceType)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("source_type"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("source_type"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(SearchIndex, setSourceUuid)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("source_uuid"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("source_uuid"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(SearchIndex, setSourceName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("source_name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("source_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(SearchIndex, setSourceParams)
 {
     zval *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "a", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "a", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_search_index_ce, getThis(), ZEND_STRL("source_params"), val TSRMLS_CC);
+    zend_update_property(pcbc_search_index_ce, getThis(), ZEND_STRL("source_params"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -814,19 +814,19 @@ PHP_MINIT_FUNCTION(SearchIndexManager)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchIndexManager", search_index_manager_methods);
-    pcbc_search_index_manager_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_search_index_manager_ce = zend_register_internal_class(&ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchIndex", search_index_methods);
-    pcbc_search_index_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_search_index_ce TSRMLS_CC, 1, pcbc_json_serializable_ce);
-    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("type"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("uuid"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("params"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("source_type"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("source_uuid"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("source_name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("source_params"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_search_index_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_search_index_ce, 1, pcbc_json_serializable_ce);
+    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("type"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("uuid"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("params"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("source_type"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("source_uuid"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("source_name"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_index_ce, ZEND_STRL("source_params"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/managers/search_index_manager.c
+++ b/src/couchbase/managers/search_index_manager.c
@@ -29,35 +29,35 @@ static void parse_index_entry(zval *return_value, zval *response)
     zval *val;
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("name"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("name"), val);
+        pcbc_update_property(pcbc_search_index_ce, return_value, ("name"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("uuid"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("uuid"), val);
+        pcbc_update_property(pcbc_search_index_ce, return_value, ("uuid"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("type"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("type"), val);
+        pcbc_update_property(pcbc_search_index_ce, return_value, ("type"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("params"));
     if (val) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("params"), val);
+        pcbc_update_property(pcbc_search_index_ce, return_value, ("params"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("sourceName"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("source_name"), val);
+        pcbc_update_property(pcbc_search_index_ce, return_value, ("source_name"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("sourceUUID"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("source_uuid"), val);
+        pcbc_update_property(pcbc_search_index_ce, return_value, ("source_uuid"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("sourceType"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("source_type"), val);
+        pcbc_update_property(pcbc_search_index_ce, return_value, ("source_type"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("sourceParams"));
     if (val) {
-        zend_update_property(pcbc_search_index_ce, return_value, ZEND_STRL("source_params"), val);
+        pcbc_update_property(pcbc_search_index_ce, return_value, ("source_params"), val);
     }
 }
 
@@ -92,7 +92,7 @@ PHP_METHOD(SearchIndexManager, getAllIndexes)
     if (zend_parse_parameters_none_throw() == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_search_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_search_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -123,7 +123,7 @@ PHP_METHOD(SearchIndexManager, getIndex)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_search_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_search_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     path_len = spprintf(&path, 0, "/api/index/%.*s", (int)ZSTR_LEN(name), ZSTR_VAL(name));
@@ -149,7 +149,7 @@ PHP_METHOD(SearchIndexManager, dropIndex)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_search_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_search_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     path_len = spprintf(&path, 0, "/api/index/%.*s", (int)ZSTR_LEN(name), ZSTR_VAL(name));
@@ -176,10 +176,10 @@ PHP_METHOD(SearchIndexManager, upsertIndex)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_search_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_search_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
-    name = zend_read_property(pcbc_search_index_ce, index, ZEND_STRL("name"), 0, &val2);
+    name = pcbc_read_property(pcbc_search_index_ce, index, ("name"), 0, &val2);
     if (!name || Z_TYPE_P(name) != IS_STRING) {
         RETURN_NULL();
     }
@@ -227,7 +227,7 @@ PHP_METHOD(SearchIndexManager, getIndexedDocumentsCount)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_search_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_search_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     path_len = spprintf(&path, 0, "/api/index/%.*s/count", (int)ZSTR_LEN(name), ZSTR_VAL(name));
@@ -253,7 +253,7 @@ PHP_METHOD(SearchIndexManager, pauseIngest)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_search_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_search_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     path_len = spprintf(&path, 0, "/api/index/%.*s/ingestControl/pause", (int)ZSTR_LEN(name), ZSTR_VAL(name));
@@ -279,7 +279,7 @@ PHP_METHOD(SearchIndexManager, resumeIngest)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_search_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_search_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     path_len = spprintf(&path, 0, "/api/index/%.*s/ingestControl/resume", (int)ZSTR_LEN(name), ZSTR_VAL(name));
@@ -305,7 +305,7 @@ PHP_METHOD(SearchIndexManager, allowQuerying)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_search_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_search_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     path_len = spprintf(&path, 0, "/api/index/%.*s/queryControl/allow", (int)ZSTR_LEN(name), ZSTR_VAL(name));
@@ -331,7 +331,7 @@ PHP_METHOD(SearchIndexManager, disallowQuerying)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_search_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_search_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     path_len = spprintf(&path, 0, "/api/index/%.*s/queryControl/disallow", (int)ZSTR_LEN(name), ZSTR_VAL(name));
@@ -357,7 +357,7 @@ PHP_METHOD(SearchIndexManager, freezePlan)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_search_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_search_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     path_len = spprintf(&path, 0, "/api/index/%.*s/planFreezeControl/freeze", (int)ZSTR_LEN(name), ZSTR_VAL(name));
@@ -383,7 +383,7 @@ PHP_METHOD(SearchIndexManager, unfreezePlan)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_search_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_search_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     path_len = spprintf(&path, 0, "/api/index/%.*s/planFreezeControl/unfreeze", (int)ZSTR_LEN(name), ZSTR_VAL(name));
@@ -417,7 +417,7 @@ PHP_METHOD(SearchIndexManager, analyzeDocument)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_search_index_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_search_index_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     path_len = spprintf(&path, 0, "/api/index/%.*s/analyzeDoc", (int)ZSTR_LEN(name), ZSTR_VAL(name));
@@ -515,7 +515,7 @@ PHP_METHOD(SearchIndex, type)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("type"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("type"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -526,7 +526,7 @@ PHP_METHOD(SearchIndex, uuid)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("uuid"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("uuid"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -537,7 +537,7 @@ PHP_METHOD(SearchIndex, name)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -548,7 +548,7 @@ PHP_METHOD(SearchIndex, params)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("params"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("params"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -559,7 +559,7 @@ PHP_METHOD(SearchIndex, sourceType)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("source_type"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("source_type"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -570,7 +570,7 @@ PHP_METHOD(SearchIndex, sourceUuid)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("source_uuid"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("source_uuid"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -581,7 +581,7 @@ PHP_METHOD(SearchIndex, sourceName)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("source_name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("source_name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -592,7 +592,7 @@ PHP_METHOD(SearchIndex, sourceParams)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("source_params"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("source_params"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -603,7 +603,7 @@ PHP_METHOD(SearchIndex, setType)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("type"), val);
+    pcbc_update_property_str(pcbc_search_index_ce, getThis(), ("type"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -614,7 +614,7 @@ PHP_METHOD(SearchIndex, setUuid)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("uuid"), val);
+    pcbc_update_property_str(pcbc_search_index_ce, getThis(), ("uuid"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -625,7 +625,7 @@ PHP_METHOD(SearchIndex, setName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("name"), val);
+    pcbc_update_property_str(pcbc_search_index_ce, getThis(), ("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -636,7 +636,7 @@ PHP_METHOD(SearchIndex, setParams)
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_search_index_ce, getThis(), ZEND_STRL("params"), val);
+    pcbc_update_property(pcbc_search_index_ce, getThis(), ("params"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -647,7 +647,7 @@ PHP_METHOD(SearchIndex, setSourceType)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("source_type"), val);
+    pcbc_update_property_str(pcbc_search_index_ce, getThis(), ("source_type"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -658,7 +658,7 @@ PHP_METHOD(SearchIndex, setSourceUuid)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("source_uuid"), val);
+    pcbc_update_property_str(pcbc_search_index_ce, getThis(), ("source_uuid"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -669,7 +669,7 @@ PHP_METHOD(SearchIndex, setSourceName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_index_ce, getThis(), ZEND_STRL("source_name"), val);
+    pcbc_update_property_str(pcbc_search_index_ce, getThis(), ("source_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -680,7 +680,7 @@ PHP_METHOD(SearchIndex, setSourceParams)
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_search_index_ce, getThis(), ZEND_STRL("source_params"), val);
+    pcbc_update_property(pcbc_search_index_ce, getThis(), ("source_params"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -693,35 +693,35 @@ PHP_METHOD(SearchIndex, jsonSerialize)
     array_init(return_value);
 
     zval *prop, ret;
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("type"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("type"), 0, &ret);
     if (prop && Z_TYPE_P(prop) == IS_STRING) {
         add_assoc_zval(return_value, "type", prop);
     }
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("name"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("name"), 0, &ret);
     if (prop && Z_TYPE_P(prop) == IS_STRING) {
         add_assoc_zval(return_value, "name", prop);
     }
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("uuid"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("uuid"), 0, &ret);
     if (prop && Z_TYPE_P(prop) == IS_STRING) {
         add_assoc_zval(return_value, "uuid", prop);
     }
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("params"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("params"), 0, &ret);
     if (prop && Z_TYPE_P(prop) == IS_ARRAY) {
         add_assoc_zval(return_value, "params", prop);
     }
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("source_type"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("source_type"), 0, &ret);
     if (prop && Z_TYPE_P(prop) == IS_STRING) {
         add_assoc_zval(return_value, "sourceType", prop);
     }
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("source_name"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("source_name"), 0, &ret);
     if (prop && Z_TYPE_P(prop) == IS_STRING) {
         add_assoc_zval(return_value, "sourceName", prop);
     }
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("source_uuid"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("source_uuid"), 0, &ret);
     if (prop && Z_TYPE_P(prop) == IS_STRING) {
         add_assoc_zval(return_value, "sourceUUID", prop);
     }
-    prop = zend_read_property(pcbc_search_index_ce, getThis(), ZEND_STRL("source_params"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_index_ce, getThis(), ("source_params"), 0, &ret);
     if (prop && Z_TYPE_P(prop) == IS_ARRAY) {
         add_assoc_zval(return_value, "sourceParams", prop);
     }

--- a/src/couchbase/managers/user_manager.c
+++ b/src/couchbase/managers/user_manager.c
@@ -39,15 +39,15 @@ static void httpcb_getUser(void *ctx, zval *return_value, zval *response)
     object_init_ex(return_value, pcbc_user_and_metadata_ce);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("domain"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("domain"), val);
+        pcbc_update_property(pcbc_user_and_metadata_ce, return_value, ("domain"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("password_change_date"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("password_changed"), val);
+        pcbc_update_property(pcbc_user_and_metadata_ce, return_value, ("password_changed"), val);
     }
     zval external_groups;
     array_init(&external_groups);
-    zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("external_groups"),
+    pcbc_update_property(pcbc_user_and_metadata_ce, return_value, ("external_groups"),
                          &external_groups);
     zval_ptr_dtor(&external_groups);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("external_groups"));
@@ -62,19 +62,19 @@ static void httpcb_getUser(void *ctx, zval *return_value, zval *response)
 
     zval user;
     object_init_ex(&user, pcbc_user_ce);
-    zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("user"), &user);
+    pcbc_update_property(pcbc_user_and_metadata_ce, return_value, ("user"), &user);
     zval_ptr_dtor(&user);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("id"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_user_ce, &user, ZEND_STRL("username"), val);
+        pcbc_update_property(pcbc_user_ce, &user, ("username"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("name"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_user_ce, &user, ZEND_STRL("display_name"), val);
+        pcbc_update_property(pcbc_user_ce, &user, ("display_name"), val);
     }
     zval groups;
     array_init(&groups);
-    zend_update_property(pcbc_user_ce, &user, ZEND_STRL("groups"), &groups);
+    pcbc_update_property(pcbc_user_ce, &user, ("groups"), &groups);
     zval_ptr_dtor(&groups);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("groups"));
     if (val && Z_TYPE_P(val) == IS_ARRAY) {
@@ -87,12 +87,12 @@ static void httpcb_getUser(void *ctx, zval *return_value, zval *response)
     }
     zval user_roles;
     array_init(&user_roles);
-    zend_update_property(pcbc_user_ce, &user, ZEND_STRL("roles"), &user_roles);
+    pcbc_update_property(pcbc_user_ce, &user, ("roles"), &user_roles);
     zval_ptr_dtor(&user_roles);
 
     zval roles;
     array_init(&roles);
-    zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("effective_roles"), &roles);
+    pcbc_update_property(pcbc_user_and_metadata_ce, return_value, ("effective_roles"), &roles);
     zval_ptr_dtor(&roles);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("roles"));
     if (val && Z_TYPE_P(val) == IS_ARRAY) {
@@ -103,19 +103,19 @@ static void httpcb_getUser(void *ctx, zval *return_value, zval *response)
             object_init_ex(&role, pcbc_role_ce);
             val = zend_symtable_str_find(Z_ARRVAL_P(ent), ZEND_STRL("role"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("name"), val);
+                pcbc_update_property(pcbc_role_ce, &role, ("name"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(ent), ZEND_STRL("bucket_name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("bucket"), val);
+                pcbc_update_property(pcbc_role_ce, &role, ("bucket"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(ent), ZEND_STRL("scope_name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("scope"), val);
+                pcbc_update_property(pcbc_role_ce, &role, ("scope"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(ent), ZEND_STRL("collection_name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("collection"), val);
+                pcbc_update_property(pcbc_role_ce, &role, ("collection"), val);
             }
             int is_user_role = 0;
             zval origins;
@@ -129,11 +129,11 @@ static void httpcb_getUser(void *ctx, zval *return_value, zval *response)
                     object_init_ex(&origin, pcbc_origin_ce);
                     val = zend_symtable_str_find(Z_ARRVAL_P(e), ZEND_STRL("name"));
                     if (val && Z_TYPE_P(val) == IS_STRING) {
-                        zend_update_property(pcbc_origin_ce, &origin, ZEND_STRL("name"), val);
+                        pcbc_update_property(pcbc_origin_ce, &origin, ("name"), val);
                     }
                     val = zend_symtable_str_find(Z_ARRVAL_P(e), ZEND_STRL("type"));
                     if (val && Z_TYPE_P(val) == IS_STRING) {
-                        zend_update_property(pcbc_origin_ce, &origin, ZEND_STRL("type"), val);
+                        pcbc_update_property(pcbc_origin_ce, &origin, ("type"), val);
                         if (zend_binary_strcmp("user", 4, Z_STRVAL_P(val), Z_STRLEN_P(val)) == 0) {
                             is_user_role = 1;
                         }
@@ -149,9 +149,9 @@ static void httpcb_getUser(void *ctx, zval *return_value, zval *response)
             }
             zval role_and_origins;
             object_init_ex(&role_and_origins, pcbc_role_and_origins_ce);
-            zend_update_property(pcbc_role_and_origins_ce, &role_and_origins, ZEND_STRL("role"), &role);
+            pcbc_update_property(pcbc_role_and_origins_ce, &role_and_origins, ("role"), &role);
             zval_ptr_dtor(&role);
-            zend_update_property(pcbc_role_and_origins_ce, &role_and_origins, ZEND_STRL("origins"), &origins);
+            pcbc_update_property(pcbc_role_and_origins_ce, &role_and_origins, ("origins"), &origins);
             zval_ptr_dtor(&origins);
             add_next_index_zval(&roles, &role_and_origins);
         }
@@ -171,13 +171,13 @@ PHP_METHOD(UserManager, getUser)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_user_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_user_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     smart_str path = {0};
     if (options) {
         zval dval, *domain;
-        domain = zend_read_property(pcbc_get_user_options_ce, options, ZEND_STRL("domain_name"), 0, &dval);
+        domain = pcbc_read_property(pcbc_get_user_options_ce, options, ("domain_name"), 0, &dval);
         if (domain && Z_TYPE_P(domain) == IS_STRING) {
             smart_str_append_printf(&path, "/settings/rbac/users/%.*s", (int)Z_STRLEN_P(domain), Z_STRVAL_P(domain));
         }
@@ -226,11 +226,11 @@ PHP_METHOD(UserManager, getAllUsers)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_user_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_user_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
     if (options) {
         zval dval, *domain;
-        domain = zend_read_property(pcbc_get_all_users_options_ce, options, ZEND_STRL("domain_name"), 0, &dval);
+        domain = pcbc_read_property(pcbc_get_all_users_options_ce, options, ("domain_name"), 0, &dval);
         if (domain && Z_TYPE_P(domain) == IS_STRING) {
             path_len = spprintf(&path, 0, "/settings/rbac/users/%.*s", (int)Z_STRLEN_P(domain), Z_STRVAL_P(domain));
             need_to_free_path = 1;
@@ -259,9 +259,9 @@ PHP_METHOD(UserManager, upsertUser)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_user_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_user_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
-    username = zend_read_property(pcbc_user_ce, user, ZEND_STRL("username"), 0, &val);
+    username = pcbc_read_property(pcbc_user_ce, user, ("username"), 0, &val);
     if (!username || Z_TYPE_P(username) != IS_STRING) {
         RETURN_NULL();
     }
@@ -269,7 +269,7 @@ PHP_METHOD(UserManager, upsertUser)
     smart_str path = {0};
     if (options) {
         zval dval, *domain;
-        domain = zend_read_property(pcbc_upsert_user_options_ce, options, ZEND_STRL("domain_name"), 0, &dval);
+        domain = pcbc_read_property(pcbc_upsert_user_options_ce, options, ("domain_name"), 0, &dval);
         if (domain && Z_TYPE_P(domain) == IS_STRING) {
             smart_str_append_printf(&path, "/settings/rbac/users/%.*s", (int)Z_STRLEN_P(domain), Z_STRVAL_P(domain));
         }
@@ -288,16 +288,16 @@ PHP_METHOD(UserManager, upsertUser)
 
     zval payload;
     array_init(&payload);
-    prop = zend_read_property(pcbc_user_ce, user, ZEND_STRL("display_name"), 0, &val);
+    prop = pcbc_read_property(pcbc_user_ce, user, ("display_name"), 0, &val);
     if (prop && Z_TYPE_P(prop) == IS_STRING) {
         add_assoc_zval(&payload, "name", prop);
     }
-    prop = zend_read_property(pcbc_user_ce, user, ZEND_STRL("password"), 0, &val);
+    prop = pcbc_read_property(pcbc_user_ce, user, ("password"), 0, &val);
     if (prop && Z_TYPE_P(prop) == IS_STRING) {
         add_assoc_zval(&payload, "password", prop);
     }
     smart_str buf = {0};
-    prop = zend_read_property(pcbc_user_ce, user, ZEND_STRL("groups"), 0, &val);
+    prop = pcbc_read_property(pcbc_user_ce, user, ("groups"), 0, &val);
     if (prop && Z_TYPE_P(prop) == IS_ARRAY && zend_array_count(Z_ARRVAL_P(prop)) > 0) {
         add_assoc_zval(&payload, "groups", prop);
         zval *entry;
@@ -313,24 +313,24 @@ PHP_METHOD(UserManager, upsertUser)
         add_assoc_stringl(&payload, "groups", ZSTR_VAL(buf.s), ZSTR_LEN(buf.s));
         smart_str_free(&buf);
     }
-    prop = zend_read_property(pcbc_user_ce, user, ZEND_STRL("roles"), 0, &val);
+    prop = pcbc_read_property(pcbc_user_ce, user, ("roles"), 0, &val);
     if (prop && Z_TYPE_P(prop) == IS_ARRAY && zend_array_count(Z_ARRVAL_P(prop)) > 0) {
         zval *entry;
         ZEND_HASH_FOREACH_VAL(HASH_OF(prop), entry)
         {
             zval zv;
-            prop = zend_read_property(pcbc_role_ce, entry, ZEND_STRL("name"), 0, &zv);
+            prop = pcbc_read_property(pcbc_role_ce, entry, ("name"), 0, &zv);
             if (!prop || Z_TYPE_P(prop) != IS_STRING) {
                 continue;
             }
             smart_str_append_printf(&buf, "%.*s", (int)Z_STRLEN_P(prop), Z_STRVAL_P(prop));
-            prop = zend_read_property(pcbc_role_ce, entry, ZEND_STRL("bucket"), 0, &zv);
+            prop = pcbc_read_property(pcbc_role_ce, entry, ("bucket"), 0, &zv);
             if (prop && Z_TYPE_P(prop) == IS_STRING) {
                 smart_str_append_printf(&buf, "[%.*s", (int)Z_STRLEN_P(prop), Z_STRVAL_P(prop));
-                prop = zend_read_property(pcbc_role_ce, entry, ZEND_STRL("scope"), 0, &zv);
+                prop = pcbc_read_property(pcbc_role_ce, entry, ("scope"), 0, &zv);
                 if (prop && Z_TYPE_P(prop) == IS_STRING) {
                     smart_str_append_printf(&buf, ":%.*s", (int)Z_STRLEN_P(prop), Z_STRVAL_P(prop));
-                    prop = zend_read_property(pcbc_role_ce, entry, ZEND_STRL("collection"), 0, &zv);
+                    prop = pcbc_read_property(pcbc_role_ce, entry, ("collection"), 0, &zv);
                     if (prop && Z_TYPE_P(prop) == IS_STRING) {
                         smart_str_append_printf(&buf, ":%.*s", (int)Z_STRLEN_P(prop), Z_STRVAL_P(prop));
                     }
@@ -371,13 +371,13 @@ PHP_METHOD(UserManager, dropUser)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_user_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_user_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     smart_str path = {0};
     if (options) {
         zval dval, *domain;
-        domain = zend_read_property(pcbc_drop_user_options_ce, options, ZEND_STRL("domain_name"), 0, &dval);
+        domain = pcbc_read_property(pcbc_drop_user_options_ce, options, ("domain_name"), 0, &dval);
         if (domain && Z_TYPE_P(domain) == IS_STRING) {
             smart_str_append_printf(&path, "/settings/rbac/users/%.*s", (int)Z_STRLEN_P(domain), Z_STRVAL_P(domain));
         }
@@ -411,33 +411,33 @@ static void httpcb_getRoles(void *ctx, zval *return_value, zval *response)
         zval *val;
         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("role"));
         if (val && Z_TYPE_P(val) == IS_STRING) {
-            zend_update_property(pcbc_role_ce, &role, ZEND_STRL("name"), val);
+            pcbc_update_property(pcbc_role_ce, &role, ("name"), val);
         }
         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("bucket_name"));
         if (val && Z_TYPE_P(val) == IS_STRING) {
-            zend_update_property(pcbc_role_ce, &role, ZEND_STRL("bucket"), val);
+            pcbc_update_property(pcbc_role_ce, &role, ("bucket"), val);
         }
         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("scope_name"));
         if (val && Z_TYPE_P(val) == IS_STRING) {
-            zend_update_property(pcbc_role_ce, &role, ZEND_STRL("scope"), val);
+            pcbc_update_property(pcbc_role_ce, &role, ("scope"), val);
         }
         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("collection_name"));
         if (val && Z_TYPE_P(val) == IS_STRING) {
-            zend_update_property(pcbc_role_ce, &role, ZEND_STRL("collection"), val);
+            pcbc_update_property(pcbc_role_ce, &role, ("collection"), val);
         }
 
         zval role_and_desc;
         object_init_ex(&role_and_desc, pcbc_role_and_description_ce);
-        zend_update_property(pcbc_role_and_description_ce, &role_and_desc, ZEND_STRL("role"), &role);
+        pcbc_update_property(pcbc_role_and_description_ce, &role_and_desc, ("role"), &role);
         zval_ptr_dtor(&role);
         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("name"));
         if (val && Z_TYPE_P(val) == IS_STRING) {
-            zend_update_property(pcbc_role_and_description_ce, &role_and_desc, ZEND_STRL("display_name"),
+            pcbc_update_property(pcbc_role_and_description_ce, &role_and_desc, ("display_name"),
                                  val);
         }
         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("desc"));
         if (val && Z_TYPE_P(val) == IS_STRING) {
-            zend_update_property(pcbc_role_and_description_ce, &role_and_desc, ZEND_STRL("description"), val);
+            pcbc_update_property(pcbc_role_and_description_ce, &role_and_desc, ("description"), val);
         }
 
         add_next_index_zval(return_value, &role_and_desc);
@@ -454,7 +454,7 @@ PHP_METHOD(UserManager, getRoles)
     if (zend_parse_parameters_none_throw() == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_user_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_user_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -474,20 +474,20 @@ static void httpcb_getGroup(void *ctx, zval *return_value, zval *response)
     zval *val;
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("id"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_group_ce, return_value, ZEND_STRL("name"), val);
+        pcbc_update_property(pcbc_group_ce, return_value, ("name"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("ldap_group_ref"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_group_ce, return_value, ZEND_STRL("ldap_group_reference"), val);
+        pcbc_update_property(pcbc_group_ce, return_value, ("ldap_group_reference"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("description"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_group_ce, return_value, ZEND_STRL("description"), val);
+        pcbc_update_property(pcbc_group_ce, return_value, ("description"), val);
     }
 
     zval roles;
     array_init(&roles);
-    zend_update_property(pcbc_group_ce, return_value, ZEND_STRL("roles"), &roles);
+    pcbc_update_property(pcbc_group_ce, return_value, ("roles"), &roles);
     zval_ptr_dtor(&roles);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("roles"));
     if (val && Z_TYPE_P(val) == IS_ARRAY) {
@@ -498,19 +498,19 @@ static void httpcb_getGroup(void *ctx, zval *return_value, zval *response)
             object_init_ex(&role, pcbc_role_ce);
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("role"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("name"), val);
+                pcbc_update_property(pcbc_role_ce, &role, ("name"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("bucket_name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("bucket"), val);
+                pcbc_update_property(pcbc_role_ce, &role, ("bucket"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("scope_name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("scope"), val);
+                pcbc_update_property(pcbc_role_ce, &role, ("scope"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("collection_name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("collection"), val);
+                pcbc_update_property(pcbc_role_ce, &role, ("collection"), val);
             }
 
             add_next_index_zval(&roles, &role);
@@ -531,7 +531,7 @@ PHP_METHOD(UserManager, getGroup)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_user_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_user_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -569,7 +569,7 @@ PHP_METHOD(UserManager, getAllGroups)
     if (zend_parse_parameters_none_throw() == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_user_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_user_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -590,14 +590,14 @@ PHP_METHOD(UserManager, upsertGroup)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_user_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_user_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
-    roles = zend_read_property(pcbc_group_ce, group, ZEND_STRL("roles"), 0, &val1);
+    roles = pcbc_read_property(pcbc_group_ce, group, ("roles"), 0, &val1);
     if (!roles || Z_TYPE_P(roles) != IS_ARRAY) {
         RETURN_NULL();
     }
-    name = zend_read_property(pcbc_group_ce, group, ZEND_STRL("name"), 0, &val2);
+    name = pcbc_read_property(pcbc_group_ce, group, ("name"), 0, &val2);
     if (!name || Z_TYPE_P(name) != IS_STRING) {
         RETURN_NULL();
     }
@@ -611,7 +611,7 @@ PHP_METHOD(UserManager, upsertGroup)
 
     zval *entry;
     smart_str buf = {0};
-    prop = zend_read_property(pcbc_group_ce, group, ZEND_STRL("description"), 0, &val2);
+    prop = pcbc_read_property(pcbc_group_ce, group, ("description"), 0, &val2);
     if (prop && Z_TYPE_P(prop) == IS_STRING) {
         smart_str_appends(&buf, "description=");
         zend_string *str = php_url_encode(Z_STRVAL_P(prop), Z_STRLEN_P(prop));
@@ -623,12 +623,12 @@ PHP_METHOD(UserManager, upsertGroup)
     ZEND_HASH_FOREACH_VAL(HASH_OF(roles), entry)
     {
         zval zv;
-        prop = zend_read_property(pcbc_role_ce, entry, ZEND_STRL("name"), 0, &zv);
+        prop = pcbc_read_property(pcbc_role_ce, entry, ("name"), 0, &zv);
         if (!prop || Z_TYPE_P(prop) != IS_STRING) {
             continue;
         }
         smart_str_append_printf(&buf, "%.*s", (int)Z_STRLEN_P(prop), Z_STRVAL_P(prop));
-        prop = zend_read_property(pcbc_role_ce, entry, ZEND_STRL("bucket"), 0, &zv);
+        prop = pcbc_read_property(pcbc_role_ce, entry, ("bucket"), 0, &zv);
         if (prop && Z_TYPE_P(prop) == IS_STRING) {
             smart_str_append_printf(&buf, "[%.*s]", (int)Z_STRLEN_P(prop), Z_STRVAL_P(prop));
         }
@@ -655,7 +655,7 @@ PHP_METHOD(UserManager, dropGroup)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    prop = zend_read_property(pcbc_user_manager_ce, getThis(), ZEND_STRL("cluster"), 0, &val);
+    prop = pcbc_read_property(pcbc_user_manager_ce, getThis(), ("cluster"), 0, &val);
     cluster = Z_CLUSTER_OBJ_P(prop);
 
     path_len = spprintf(&path, 0, "/settings/rbac/groups/%.*s", (int)ZSTR_LEN(name), ZSTR_VAL(name));
@@ -728,7 +728,7 @@ PHP_METHOD(Role, name)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_role_ce, getThis(), ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_role_ce, getThis(), ("name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -739,7 +739,7 @@ PHP_METHOD(Role, bucket)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_role_ce, getThis(), ZEND_STRL("bucket"), 0, &rv);
+    prop = pcbc_read_property(pcbc_role_ce, getThis(), ("bucket"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -750,7 +750,7 @@ PHP_METHOD(Role, scope)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_role_ce, getThis(), ZEND_STRL("scope"), 0, &rv);
+    prop = pcbc_read_property(pcbc_role_ce, getThis(), ("scope"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -761,7 +761,7 @@ PHP_METHOD(Role, collection)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_role_ce, getThis(), ZEND_STRL("collection"), 0, &rv);
+    prop = pcbc_read_property(pcbc_role_ce, getThis(), ("collection"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -772,7 +772,7 @@ PHP_METHOD(Role, setName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_role_ce, getThis(), ZEND_STRL("name"), val);
+    pcbc_update_property_str(pcbc_role_ce, getThis(), ("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -783,7 +783,7 @@ PHP_METHOD(Role, setBucket)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_role_ce, getThis(), ZEND_STRL("bucket"), val);
+    pcbc_update_property_str(pcbc_role_ce, getThis(), ("bucket"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -794,7 +794,7 @@ PHP_METHOD(Role, setScope)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_role_ce, getThis(), ZEND_STRL("scope"), val);
+    pcbc_update_property_str(pcbc_role_ce, getThis(), ("scope"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -805,7 +805,7 @@ PHP_METHOD(Role, setCollection)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_role_ce, getThis(), ZEND_STRL("collection"), val);
+    pcbc_update_property_str(pcbc_role_ce, getThis(), ("collection"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -858,7 +858,7 @@ PHP_METHOD(RoleAndDescription, role)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_role_and_description_ce, getThis(), ZEND_STRL("role"), 0, &rv);
+    prop = pcbc_read_property(pcbc_role_and_description_ce, getThis(), ("role"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -869,7 +869,7 @@ PHP_METHOD(RoleAndDescription, displayName)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_role_and_description_ce, getThis(), ZEND_STRL("display_name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_role_and_description_ce, getThis(), ("display_name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -880,7 +880,7 @@ PHP_METHOD(RoleAndDescription, description)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_role_and_description_ce, getThis(), ZEND_STRL("description"), 0, &rv);
+    prop = pcbc_read_property(pcbc_role_and_description_ce, getThis(), ("description"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -909,7 +909,7 @@ PHP_METHOD(Origin, name)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_origin_ce, getThis(), ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_origin_ce, getThis(), ("name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -920,7 +920,7 @@ PHP_METHOD(Origin, type)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_origin_ce, getThis(), ZEND_STRL("type"), 0, &rv);
+    prop = pcbc_read_property(pcbc_origin_ce, getThis(), ("type"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -945,7 +945,7 @@ PHP_METHOD(RoleAndOrigins, role)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_role_and_origins_ce, getThis(), ZEND_STRL("role"), 0, &rv);
+    prop = pcbc_read_property(pcbc_role_and_origins_ce, getThis(), ("role"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -956,7 +956,7 @@ PHP_METHOD(RoleAndOrigins, origins)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_role_and_origins_ce, getThis(), ZEND_STRL("origins"), 0, &rv);
+    prop = pcbc_read_property(pcbc_role_and_origins_ce, getThis(), ("origins"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -981,7 +981,7 @@ PHP_METHOD(User, username)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_user_ce, getThis(), ZEND_STRL("username"), 0, &rv);
+    prop = pcbc_read_property(pcbc_user_ce, getThis(), ("username"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -992,7 +992,7 @@ PHP_METHOD(User, displayName)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_user_ce, getThis(), ZEND_STRL("display_name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_user_ce, getThis(), ("display_name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1003,7 +1003,7 @@ PHP_METHOD(User, groups)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_user_ce, getThis(), ZEND_STRL("groups"), 0, &rv);
+    prop = pcbc_read_property(pcbc_user_ce, getThis(), ("groups"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1014,7 +1014,7 @@ PHP_METHOD(User, roles)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_user_ce, getThis(), ZEND_STRL("roles"), 0, &rv);
+    prop = pcbc_read_property(pcbc_user_ce, getThis(), ("roles"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1025,7 +1025,7 @@ PHP_METHOD(User, setUsername)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_user_ce, getThis(), ZEND_STRL("username"), val);
+    pcbc_update_property_str(pcbc_user_ce, getThis(), ("username"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1036,7 +1036,7 @@ PHP_METHOD(User, setPassword)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_user_ce, getThis(), ZEND_STRL("password"), val);
+    pcbc_update_property_str(pcbc_user_ce, getThis(), ("password"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1047,7 +1047,7 @@ PHP_METHOD(User, setDisplayName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_user_ce, getThis(), ZEND_STRL("display_name"), val);
+    pcbc_update_property_str(pcbc_user_ce, getThis(), ("display_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1058,7 +1058,7 @@ PHP_METHOD(User, setGroups)
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_user_ce, getThis(), ZEND_STRL("groups"), val);
+    pcbc_update_property(pcbc_user_ce, getThis(), ("groups"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1069,7 +1069,7 @@ PHP_METHOD(User, setRoles)
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_user_ce, getThis(), ZEND_STRL("roles"), val);
+    pcbc_update_property(pcbc_user_ce, getThis(), ("roles"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1127,7 +1127,7 @@ PHP_METHOD(UserAndMetadata, domain)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_user_and_metadata_ce, getThis(), ZEND_STRL("domain"), 0, &rv);
+    prop = pcbc_read_property(pcbc_user_and_metadata_ce, getThis(), ("domain"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1138,7 +1138,7 @@ PHP_METHOD(UserAndMetadata, passwordChanged)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_user_and_metadata_ce, getThis(), ZEND_STRL("password_changed"), 0, &rv);
+    prop = pcbc_read_property(pcbc_user_and_metadata_ce, getThis(), ("password_changed"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1149,7 +1149,7 @@ PHP_METHOD(UserAndMetadata, externalGroups)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_user_and_metadata_ce, getThis(), ZEND_STRL("external_groups"), 0, &rv);
+    prop = pcbc_read_property(pcbc_user_and_metadata_ce, getThis(), ("external_groups"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1160,7 +1160,7 @@ PHP_METHOD(UserAndMetadata, effectiveRoles)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_user_and_metadata_ce, getThis(), ZEND_STRL("effective_roles"), 0, &rv);
+    prop = pcbc_read_property(pcbc_user_and_metadata_ce, getThis(), ("effective_roles"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1171,7 +1171,7 @@ PHP_METHOD(UserAndMetadata, user)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_user_and_metadata_ce, getThis(), ZEND_STRL("user"), 0, &rv);
+    prop = pcbc_read_property(pcbc_user_and_metadata_ce, getThis(), ("user"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1208,7 +1208,7 @@ PHP_METHOD(Group, name)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_group_ce, getThis(), ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_group_ce, getThis(), ("name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1219,7 +1219,7 @@ PHP_METHOD(Group, description)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_group_ce, getThis(), ZEND_STRL("description"), 0, &rv);
+    prop = pcbc_read_property(pcbc_group_ce, getThis(), ("description"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1230,7 +1230,7 @@ PHP_METHOD(Group, ldapGroupReference)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_group_ce, getThis(), ZEND_STRL("ldap_group_reference"), 0, &rv);
+    prop = pcbc_read_property(pcbc_group_ce, getThis(), ("ldap_group_reference"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1241,7 +1241,7 @@ PHP_METHOD(Group, roles)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_group_ce, getThis(), ZEND_STRL("roles"), 0, &rv);
+    prop = pcbc_read_property(pcbc_group_ce, getThis(), ("roles"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1252,7 +1252,7 @@ PHP_METHOD(Group, setName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_group_ce, getThis(), ZEND_STRL("name"), val);
+    pcbc_update_property_str(pcbc_group_ce, getThis(), ("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1263,7 +1263,7 @@ PHP_METHOD(Group, setDescription)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_group_ce, getThis(), ZEND_STRL("description"), val);
+    pcbc_update_property_str(pcbc_group_ce, getThis(), ("description"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1274,7 +1274,7 @@ PHP_METHOD(Group, setRoles)
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_group_ce, getThis(), ZEND_STRL("roles"), val);
+    pcbc_update_property(pcbc_group_ce, getThis(), ("roles"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1322,7 +1322,7 @@ PHP_METHOD(GetUserOptions, domainName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_get_user_options_ce, getThis(), ZEND_STRL("domain_name"), val);
+    pcbc_update_property_str(pcbc_get_user_options_ce, getThis(), ("domain_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1344,7 +1344,7 @@ PHP_METHOD(UpsertUserOptions, domainName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_upsert_user_options_ce, getThis(), ZEND_STRL("domain_name"), val);
+    pcbc_update_property_str(pcbc_upsert_user_options_ce, getThis(), ("domain_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1366,7 +1366,7 @@ PHP_METHOD(DropUserOptions, domainName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_drop_user_options_ce, getThis(), ZEND_STRL("domain_name"), val);
+    pcbc_update_property_str(pcbc_drop_user_options_ce, getThis(), ("domain_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1388,7 +1388,7 @@ PHP_METHOD(GetAllUsersOptions, domainName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_get_all_users_options_ce, getThis(), ZEND_STRL("domain_name"), val);
+    pcbc_update_property_str(pcbc_get_all_users_options_ce, getThis(), ("domain_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 

--- a/src/couchbase/managers/user_manager.c
+++ b/src/couchbase/managers/user_manager.c
@@ -39,16 +39,16 @@ static void httpcb_getUser(void *ctx, zval *return_value, zval *response)
     object_init_ex(return_value, pcbc_user_and_metadata_ce);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("domain"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("domain"), val TSRMLS_CC);
+        zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("domain"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("password_change_date"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("password_changed"), val TSRMLS_CC);
+        zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("password_changed"), val);
     }
     zval external_groups;
     array_init(&external_groups);
     zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("external_groups"),
-                         &external_groups TSRMLS_CC);
+                         &external_groups);
     zval_ptr_dtor(&external_groups);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("external_groups"));
     if (val && Z_TYPE_P(val) == IS_ARRAY) {
@@ -62,19 +62,19 @@ static void httpcb_getUser(void *ctx, zval *return_value, zval *response)
 
     zval user;
     object_init_ex(&user, pcbc_user_ce);
-    zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("user"), &user TSRMLS_CC);
+    zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("user"), &user);
     zval_ptr_dtor(&user);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("id"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_user_ce, &user, ZEND_STRL("username"), val TSRMLS_CC);
+        zend_update_property(pcbc_user_ce, &user, ZEND_STRL("username"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("name"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_user_ce, &user, ZEND_STRL("display_name"), val TSRMLS_CC);
+        zend_update_property(pcbc_user_ce, &user, ZEND_STRL("display_name"), val);
     }
     zval groups;
     array_init(&groups);
-    zend_update_property(pcbc_user_ce, &user, ZEND_STRL("groups"), &groups TSRMLS_CC);
+    zend_update_property(pcbc_user_ce, &user, ZEND_STRL("groups"), &groups);
     zval_ptr_dtor(&groups);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("groups"));
     if (val && Z_TYPE_P(val) == IS_ARRAY) {
@@ -87,12 +87,12 @@ static void httpcb_getUser(void *ctx, zval *return_value, zval *response)
     }
     zval user_roles;
     array_init(&user_roles);
-    zend_update_property(pcbc_user_ce, &user, ZEND_STRL("roles"), &user_roles TSRMLS_CC);
+    zend_update_property(pcbc_user_ce, &user, ZEND_STRL("roles"), &user_roles);
     zval_ptr_dtor(&user_roles);
 
     zval roles;
     array_init(&roles);
-    zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("effective_roles"), &roles TSRMLS_CC);
+    zend_update_property(pcbc_user_and_metadata_ce, return_value, ZEND_STRL("effective_roles"), &roles);
     zval_ptr_dtor(&roles);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("roles"));
     if (val && Z_TYPE_P(val) == IS_ARRAY) {
@@ -103,19 +103,19 @@ static void httpcb_getUser(void *ctx, zval *return_value, zval *response)
             object_init_ex(&role, pcbc_role_ce);
             val = zend_symtable_str_find(Z_ARRVAL_P(ent), ZEND_STRL("role"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("name"), val TSRMLS_CC);
+                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("name"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(ent), ZEND_STRL("bucket_name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("bucket"), val TSRMLS_CC);
+                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("bucket"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(ent), ZEND_STRL("scope_name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("scope"), val TSRMLS_CC);
+                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("scope"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(ent), ZEND_STRL("collection_name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("collection"), val TSRMLS_CC);
+                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("collection"), val);
             }
             int is_user_role = 0;
             zval origins;
@@ -129,11 +129,11 @@ static void httpcb_getUser(void *ctx, zval *return_value, zval *response)
                     object_init_ex(&origin, pcbc_origin_ce);
                     val = zend_symtable_str_find(Z_ARRVAL_P(e), ZEND_STRL("name"));
                     if (val && Z_TYPE_P(val) == IS_STRING) {
-                        zend_update_property(pcbc_origin_ce, &origin, ZEND_STRL("name"), val TSRMLS_CC);
+                        zend_update_property(pcbc_origin_ce, &origin, ZEND_STRL("name"), val);
                     }
                     val = zend_symtable_str_find(Z_ARRVAL_P(e), ZEND_STRL("type"));
                     if (val && Z_TYPE_P(val) == IS_STRING) {
-                        zend_update_property(pcbc_origin_ce, &origin, ZEND_STRL("type"), val TSRMLS_CC);
+                        zend_update_property(pcbc_origin_ce, &origin, ZEND_STRL("type"), val);
                         if (zend_binary_strcmp("user", 4, Z_STRVAL_P(val), Z_STRLEN_P(val)) == 0) {
                             is_user_role = 1;
                         }
@@ -149,9 +149,9 @@ static void httpcb_getUser(void *ctx, zval *return_value, zval *response)
             }
             zval role_and_origins;
             object_init_ex(&role_and_origins, pcbc_role_and_origins_ce);
-            zend_update_property(pcbc_role_and_origins_ce, &role_and_origins, ZEND_STRL("role"), &role TSRMLS_CC);
+            zend_update_property(pcbc_role_and_origins_ce, &role_and_origins, ZEND_STRL("role"), &role);
             zval_ptr_dtor(&role);
-            zend_update_property(pcbc_role_and_origins_ce, &role_and_origins, ZEND_STRL("origins"), &origins TSRMLS_CC);
+            zend_update_property(pcbc_role_and_origins_ce, &role_and_origins, ZEND_STRL("origins"), &origins);
             zval_ptr_dtor(&origins);
             add_next_index_zval(&roles, &role_and_origins);
         }
@@ -167,7 +167,7 @@ PHP_METHOD(UserManager, getUser)
     zend_string *username;
 
     int rv =
-        zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|O!", &username, &options, pcbc_get_user_options_ce);
+        zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|O!", &username, &options, pcbc_get_user_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -192,7 +192,7 @@ PHP_METHOD(UserManager, getUser)
     lcb_cmdhttp_create(&cmd, LCB_HTTP_TYPE_MANAGEMENT);
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_GET);
     lcb_cmdhttp_path(cmd, ZSTR_VAL(path.s), ZSTR_LEN(path.s));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getUser, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getUser, NULL);
     smart_str_free(&path);
 }
 
@@ -222,7 +222,7 @@ PHP_METHOD(UserManager, getAllUsers)
     size_t path_len = strlen(path);
     int need_to_free_path = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "|O!", &options, pcbc_get_all_users_options_ce);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|O!", &options, pcbc_get_all_users_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -241,7 +241,7 @@ PHP_METHOD(UserManager, getAllUsers)
     lcb_cmdhttp_create(&cmd, LCB_HTTP_TYPE_MANAGEMENT);
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_GET);
     lcb_cmdhttp_path(cmd, path, path_len);
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getAllUsers, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getAllUsers, NULL);
     if (need_to_free_path) {
         efree(path);
     }
@@ -254,7 +254,7 @@ PHP_METHOD(UserManager, upsertUser)
     zval *options = NULL;
     zval *user;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "O|O!", &user, pcbc_user_ce, &options,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O|O!", &user, pcbc_user_ce, &options,
                                          pcbc_upsert_user_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
@@ -345,7 +345,7 @@ PHP_METHOD(UserManager, upsertUser)
         smart_str_free(&buf);
     }
     rv = php_url_encode_hash_ex(HASH_OF(&payload), &buf, NULL, 0, NULL, 0, NULL, 0, NULL, NULL,
-                                PHP_QUERY_RFC1738 TSRMLS_CC);
+                                PHP_QUERY_RFC1738);
     zval_dtor(&payload);
     if (rv == FAILURE) {
         smart_str_free(&buf);
@@ -354,7 +354,7 @@ PHP_METHOD(UserManager, upsertUser)
     }
     smart_str_0(&buf);
     lcb_cmdhttp_body(cmd, ZSTR_VAL(buf.s), ZSTR_LEN(buf.s));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     smart_str_free(&path);
     smart_str_free(&buf);
 }
@@ -367,7 +367,7 @@ PHP_METHOD(UserManager, dropUser)
     zend_string *username;
 
     int rv =
-        zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|O!", &username, &options, pcbc_drop_user_options_ce);
+        zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|O!", &username, &options, pcbc_drop_user_options_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -392,7 +392,7 @@ PHP_METHOD(UserManager, dropUser)
     lcb_cmdhttp_create(&cmd, LCB_HTTP_TYPE_MANAGEMENT);
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_DELETE);
     lcb_cmdhttp_path(cmd, ZSTR_VAL(path.s), ZSTR_LEN(path.s));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     smart_str_free(&path);
 }
 
@@ -411,33 +411,33 @@ static void httpcb_getRoles(void *ctx, zval *return_value, zval *response)
         zval *val;
         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("role"));
         if (val && Z_TYPE_P(val) == IS_STRING) {
-            zend_update_property(pcbc_role_ce, &role, ZEND_STRL("name"), val TSRMLS_CC);
+            zend_update_property(pcbc_role_ce, &role, ZEND_STRL("name"), val);
         }
         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("bucket_name"));
         if (val && Z_TYPE_P(val) == IS_STRING) {
-            zend_update_property(pcbc_role_ce, &role, ZEND_STRL("bucket"), val TSRMLS_CC);
+            zend_update_property(pcbc_role_ce, &role, ZEND_STRL("bucket"), val);
         }
         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("scope_name"));
         if (val && Z_TYPE_P(val) == IS_STRING) {
-            zend_update_property(pcbc_role_ce, &role, ZEND_STRL("scope"), val TSRMLS_CC);
+            zend_update_property(pcbc_role_ce, &role, ZEND_STRL("scope"), val);
         }
         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("collection_name"));
         if (val && Z_TYPE_P(val) == IS_STRING) {
-            zend_update_property(pcbc_role_ce, &role, ZEND_STRL("collection"), val TSRMLS_CC);
+            zend_update_property(pcbc_role_ce, &role, ZEND_STRL("collection"), val);
         }
 
         zval role_and_desc;
         object_init_ex(&role_and_desc, pcbc_role_and_description_ce);
-        zend_update_property(pcbc_role_and_description_ce, &role_and_desc, ZEND_STRL("role"), &role TSRMLS_CC);
+        zend_update_property(pcbc_role_and_description_ce, &role_and_desc, ZEND_STRL("role"), &role);
         zval_ptr_dtor(&role);
         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("name"));
         if (val && Z_TYPE_P(val) == IS_STRING) {
             zend_update_property(pcbc_role_and_description_ce, &role_and_desc, ZEND_STRL("display_name"),
-                                 val TSRMLS_CC);
+                                 val);
         }
         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("desc"));
         if (val && Z_TYPE_P(val) == IS_STRING) {
-            zend_update_property(pcbc_role_and_description_ce, &role_and_desc, ZEND_STRL("description"), val TSRMLS_CC);
+            zend_update_property(pcbc_role_and_description_ce, &role_and_desc, ZEND_STRL("description"), val);
         }
 
         add_next_index_zval(return_value, &role_and_desc);
@@ -461,7 +461,7 @@ PHP_METHOD(UserManager, getRoles)
     lcb_cmdhttp_create(&cmd, LCB_HTTP_TYPE_MANAGEMENT);
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_GET);
     lcb_cmdhttp_path(cmd, path, strlen(path));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getRoles, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getRoles, NULL);
 }
 
 static void httpcb_getGroup(void *ctx, zval *return_value, zval *response)
@@ -474,20 +474,20 @@ static void httpcb_getGroup(void *ctx, zval *return_value, zval *response)
     zval *val;
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("id"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_group_ce, return_value, ZEND_STRL("name"), val TSRMLS_CC);
+        zend_update_property(pcbc_group_ce, return_value, ZEND_STRL("name"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("ldap_group_ref"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_group_ce, return_value, ZEND_STRL("ldap_group_reference"), val TSRMLS_CC);
+        zend_update_property(pcbc_group_ce, return_value, ZEND_STRL("ldap_group_reference"), val);
     }
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("description"));
     if (val && Z_TYPE_P(val) == IS_STRING) {
-        zend_update_property(pcbc_group_ce, return_value, ZEND_STRL("description"), val TSRMLS_CC);
+        zend_update_property(pcbc_group_ce, return_value, ZEND_STRL("description"), val);
     }
 
     zval roles;
     array_init(&roles);
-    zend_update_property(pcbc_group_ce, return_value, ZEND_STRL("roles"), &roles TSRMLS_CC);
+    zend_update_property(pcbc_group_ce, return_value, ZEND_STRL("roles"), &roles);
     zval_ptr_dtor(&roles);
     val = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("roles"));
     if (val && Z_TYPE_P(val) == IS_ARRAY) {
@@ -498,19 +498,19 @@ static void httpcb_getGroup(void *ctx, zval *return_value, zval *response)
             object_init_ex(&role, pcbc_role_ce);
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("role"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("name"), val TSRMLS_CC);
+                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("name"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("bucket_name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("bucket"), val TSRMLS_CC);
+                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("bucket"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("scope_name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("scope"), val TSRMLS_CC);
+                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("scope"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("collection_name"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("collection"), val TSRMLS_CC);
+                zend_update_property(pcbc_role_ce, &role, ZEND_STRL("collection"), val);
             }
 
             add_next_index_zval(&roles, &role);
@@ -527,7 +527,7 @@ PHP_METHOD(UserManager, getGroup)
     int rv, path_len;
     zend_string *name;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -539,7 +539,7 @@ PHP_METHOD(UserManager, getGroup)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_GET);
     path_len = spprintf(&path, 0, "/settings/rbac/groups/%.*s", (int)ZSTR_LEN(name), ZSTR_VAL(name));
     lcb_cmdhttp_path(cmd, path, path_len);
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getGroup, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getGroup, NULL);
     efree(path);
 }
 
@@ -576,7 +576,7 @@ PHP_METHOD(UserManager, getAllGroups)
     lcb_cmdhttp_create(&cmd, LCB_HTTP_TYPE_MANAGEMENT);
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_GET);
     lcb_cmdhttp_path(cmd, path, strlen(path));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getAllGroups, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, httpcb_getAllGroups, NULL);
 }
 
 PHP_METHOD(UserManager, upsertGroup)
@@ -586,7 +586,7 @@ PHP_METHOD(UserManager, upsertGroup)
     int rv, path_len;
     char *path = NULL;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "O", &group, pcbc_group_ce);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O", &group, pcbc_group_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -638,7 +638,7 @@ PHP_METHOD(UserManager, upsertGroup)
     smart_str_0(&buf);
     lcb_cmdhttp_body(cmd, ZSTR_VAL(buf.s), ZSTR_LEN(buf.s));
 
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
     smart_str_free(&buf);
 }
@@ -651,7 +651,7 @@ PHP_METHOD(UserManager, dropGroup)
     char *path;
     zend_string *name;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -665,7 +665,7 @@ PHP_METHOD(UserManager, dropGroup)
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_DELETE);
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, cluster->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
 }
 
@@ -768,44 +768,44 @@ PHP_METHOD(Role, collection)
 PHP_METHOD(Role, setName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_role_ce, getThis(), ZEND_STRL("name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_role_ce, getThis(), ZEND_STRL("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(Role, setBucket)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_role_ce, getThis(), ZEND_STRL("bucket"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_role_ce, getThis(), ZEND_STRL("bucket"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(Role, setScope)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_role_ce, getThis(), ZEND_STRL("scope"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_role_ce, getThis(), ZEND_STRL("scope"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(Role, setCollection)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_role_ce, getThis(), ZEND_STRL("collection"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_role_ce, getThis(), ZEND_STRL("collection"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1021,55 +1021,55 @@ PHP_METHOD(User, roles)
 PHP_METHOD(User, setUsername)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_user_ce, getThis(), ZEND_STRL("username"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_user_ce, getThis(), ZEND_STRL("username"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(User, setPassword)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_user_ce, getThis(), ZEND_STRL("password"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_user_ce, getThis(), ZEND_STRL("password"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(User, setDisplayName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_user_ce, getThis(), ZEND_STRL("display_name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_user_ce, getThis(), ZEND_STRL("display_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(User, setGroups)
 {
     zval *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "a", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "a", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_user_ce, getThis(), ZEND_STRL("groups"), val TSRMLS_CC);
+    zend_update_property(pcbc_user_ce, getThis(), ZEND_STRL("groups"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(User, setRoles)
 {
     zval *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "a", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "a", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_user_ce, getThis(), ZEND_STRL("roles"), val TSRMLS_CC);
+    zend_update_property(pcbc_user_ce, getThis(), ZEND_STRL("roles"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1248,33 +1248,33 @@ PHP_METHOD(Group, roles)
 PHP_METHOD(Group, setName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_group_ce, getThis(), ZEND_STRL("name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_group_ce, getThis(), ZEND_STRL("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(Group, setDescription)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_group_ce, getThis(), ZEND_STRL("description"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_group_ce, getThis(), ZEND_STRL("description"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(Group, setRoles)
 {
     zval *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "a", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "a", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_group_ce, getThis(), ZEND_STRL("roles"), val TSRMLS_CC);
+    zend_update_property(pcbc_group_ce, getThis(), ZEND_STRL("roles"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1318,11 +1318,11 @@ zend_function_entry group_methods[] = {
 PHP_METHOD(GetUserOptions, domainName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_get_user_options_ce, getThis(), ZEND_STRL("domain_name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_get_user_options_ce, getThis(), ZEND_STRL("domain_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1340,11 +1340,11 @@ zend_function_entry get_user_options_methods[] = {
 PHP_METHOD(UpsertUserOptions, domainName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_upsert_user_options_ce, getThis(), ZEND_STRL("domain_name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_upsert_user_options_ce, getThis(), ZEND_STRL("domain_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1362,11 +1362,11 @@ zend_function_entry upsert_user_options_methods[] = {
 PHP_METHOD(DropUserOptions, domainName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_drop_user_options_ce, getThis(), ZEND_STRL("domain_name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_drop_user_options_ce, getThis(), ZEND_STRL("domain_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1384,11 +1384,11 @@ zend_function_entry drop_user_options_methods[] = {
 PHP_METHOD(GetAllUsersOptions, domainName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_get_all_users_options_ce, getThis(), ZEND_STRL("domain_name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_get_all_users_options_ce, getThis(), ZEND_STRL("domain_name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -1408,70 +1408,70 @@ PHP_MINIT_FUNCTION(UserManager)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "UserManager", user_manager_methods);
-    pcbc_user_manager_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_user_manager_ce, ZEND_STRL("cluster"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_user_manager_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_user_manager_ce, ZEND_STRL("cluster"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "Role", role_methods);
-    pcbc_role_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_role_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_role_ce, ZEND_STRL("bucket"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_role_ce, ZEND_STRL("scope"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_role_ce, ZEND_STRL("collection"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_role_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_role_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_role_ce, ZEND_STRL("bucket"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_role_ce, ZEND_STRL("scope"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_role_ce, ZEND_STRL("collection"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "RoleAndDescription", role_and_description_methods);
-    pcbc_role_and_description_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_role_and_description_ce, ZEND_STRL("role"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_role_and_description_ce, ZEND_STRL("display_name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_role_and_description_ce, ZEND_STRL("description"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_role_and_description_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_role_and_description_ce, ZEND_STRL("role"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_role_and_description_ce, ZEND_STRL("display_name"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_role_and_description_ce, ZEND_STRL("description"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "Origin", origin_methods);
-    pcbc_origin_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_origin_ce, ZEND_STRL("type"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_origin_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_origin_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_origin_ce, ZEND_STRL("type"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_origin_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "RoleAndOrigins", role_and_origins_methods);
-    pcbc_role_and_origins_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_role_and_origins_ce, ZEND_STRL("role"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_role_and_origins_ce, ZEND_STRL("origins"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_role_and_origins_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_role_and_origins_ce, ZEND_STRL("role"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_role_and_origins_ce, ZEND_STRL("origins"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "User", user_methods);
-    pcbc_user_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_user_ce, ZEND_STRL("username"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_user_ce, ZEND_STRL("password"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_user_ce, ZEND_STRL("display_name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_user_ce, ZEND_STRL("groups"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_user_ce, ZEND_STRL("roles"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_user_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_user_ce, ZEND_STRL("username"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_user_ce, ZEND_STRL("password"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_user_ce, ZEND_STRL("display_name"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_user_ce, ZEND_STRL("groups"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_user_ce, ZEND_STRL("roles"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "UserAndMetadata", user_and_metadata_methods);
-    pcbc_user_and_metadata_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_user_and_metadata_ce, ZEND_STRL("domain"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_user_and_metadata_ce, ZEND_STRL("user"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_user_and_metadata_ce, ZEND_STRL("effective_roles"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_user_and_metadata_ce, ZEND_STRL("password_changed"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_user_and_metadata_ce, ZEND_STRL("external_groups"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_user_and_metadata_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_user_and_metadata_ce, ZEND_STRL("domain"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_user_and_metadata_ce, ZEND_STRL("user"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_user_and_metadata_ce, ZEND_STRL("effective_roles"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_user_and_metadata_ce, ZEND_STRL("password_changed"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_user_and_metadata_ce, ZEND_STRL("external_groups"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "Group", group_methods);
-    pcbc_group_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_group_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_group_ce, ZEND_STRL("description"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_group_ce, ZEND_STRL("roles"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_group_ce, ZEND_STRL("ldap_group_reference"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_group_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_group_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_group_ce, ZEND_STRL("description"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_group_ce, ZEND_STRL("roles"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_group_ce, ZEND_STRL("ldap_group_reference"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GetAllUsersOptions", get_all_users_options_methods);
-    pcbc_get_all_users_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_all_users_options_ce, ZEND_STRL("domain_name"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_get_all_users_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_get_all_users_options_ce, ZEND_STRL("domain_name"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GetUserOptions", get_user_options_methods);
-    pcbc_get_user_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_user_options_ce, ZEND_STRL("domain_name"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_get_user_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_get_user_options_ce, ZEND_STRL("domain_name"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "DropUserOptions", drop_user_options_methods);
-    pcbc_drop_user_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_drop_user_options_ce, ZEND_STRL("domain_name"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_drop_user_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_drop_user_options_ce, ZEND_STRL("domain_name"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "UpsertUserOptions", upsert_user_options_methods);
-    pcbc_upsert_user_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_upsert_user_options_ce, ZEND_STRL("domain_name"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_upsert_user_options_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_upsert_user_options_ce, ZEND_STRL("domain_name"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/managers/user_manager.c
+++ b/src/couchbase/managers/user_manager.c
@@ -344,7 +344,7 @@ PHP_METHOD(UserManager, upsertUser)
         add_assoc_stringl(&payload, "roles", ZSTR_VAL(buf.s), ZSTR_LEN(buf.s));
         smart_str_free(&buf);
     }
-    rv = php_url_encode_hash_ex(HASH_OF(&payload), &buf, NULL, 0, NULL, 0, NULL, 0, NULL, NULL,
+    php_url_encode_hash_ex(HASH_OF(&payload), &buf, NULL, 0, NULL, 0, NULL, 0, NULL, NULL,
                                 PHP_QUERY_RFC1738);
     zval_dtor(&payload);
     if (rv == FAILURE) {

--- a/src/couchbase/managers/view_index_manager.c
+++ b/src/couchbase/managers/view_index_manager.c
@@ -27,7 +27,7 @@ static void httpcb_getDesignDocument(void *ctx, zval *return_value, zval *respon
     zval view_prop;
     object_init_ex(return_value, pcbc_design_document_ce);
     array_init(&view_prop);
-    zend_update_property(pcbc_design_document_ce, return_value, ZEND_STRL("views"), &view_prop);
+    pcbc_update_property(pcbc_design_document_ce, return_value, ("views"), &view_prop);
     zval_delref_p(&view_prop);
 
     zval *views = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("views"));
@@ -38,14 +38,14 @@ static void httpcb_getDesignDocument(void *ctx, zval *return_value, zval *respon
         {
             zval view, *val;
             object_init_ex(&view, pcbc_view_ce);
-            zend_update_property_str(pcbc_view_ce, &view, ZEND_STRL("name"), string_key);
+            pcbc_update_property_str(pcbc_view_ce, &view, ("name"), string_key);
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("map"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_view_ce, &view, ZEND_STRL("map"), val);
+                pcbc_update_property(pcbc_view_ce, &view, ("map"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("reduce"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_view_ce, &view, ZEND_STRL("reduce"), val);
+                pcbc_update_property(pcbc_view_ce, &view, ("reduce"), val);
             }
             add_assoc_zval_ex(&view_prop, ZSTR_VAL(string_key), ZSTR_LEN(string_key), &view);
         }
@@ -66,7 +66,7 @@ PHP_METHOD(ViewIndexManager, getDesignDocument)
         return;
     }
 
-    prop = zend_read_property(pcbc_view_index_manager_ce, getThis(), ZEND_STRL("bucket"), 0, &val);
+    prop = pcbc_read_property(pcbc_view_index_manager_ce, getThis(), ("bucket"), 0, &val);
     bucket = Z_BUCKET_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -77,7 +77,7 @@ PHP_METHOD(ViewIndexManager, getDesignDocument)
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
     pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, httpcb_getDesignDocument, NULL);
     efree(path);
-    zend_update_property_str(pcbc_design_document_ce, return_value, ZEND_STRL("name"), name);
+    pcbc_update_property_str(pcbc_design_document_ce, return_value, ("name"), name);
 }
 
 static void parse_ddoc_entry(zval *return_value, zval *response)
@@ -85,7 +85,7 @@ static void parse_ddoc_entry(zval *return_value, zval *response)
     zval view_prop;
     object_init_ex(return_value, pcbc_design_document_ce);
     array_init(&view_prop);
-    zend_update_property(pcbc_design_document_ce, return_value, ZEND_STRL("views"), &view_prop);
+    pcbc_update_property(pcbc_design_document_ce, return_value, ("views"), &view_prop);
     zval_delref_p(&view_prop);
     zval *doc = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("doc"));
     if (doc && Z_TYPE_P(doc) == IS_ARRAY) {
@@ -95,7 +95,7 @@ static void parse_ddoc_entry(zval *return_value, zval *response)
                 zval *val;
                 val = zend_symtable_str_find(Z_ARRVAL_P(meta), ZEND_STRL("id"));
                 if (val && Z_TYPE_P(val) == IS_STRING) {
-                    zend_update_property(pcbc_design_document_ce, return_value, ZEND_STRL("name"), val);
+                    pcbc_update_property(pcbc_design_document_ce, return_value, ("name"), val);
                 }
             }
         }
@@ -110,14 +110,14 @@ static void parse_ddoc_entry(zval *return_value, zval *response)
                     {
                         zval view, *val;
                         object_init_ex(&view, pcbc_view_ce);
-                        zend_update_property_str(pcbc_view_ce, &view, ZEND_STRL("name"), string_key);
+                        pcbc_update_property_str(pcbc_view_ce, &view, ("name"), string_key);
                         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("map"));
                         if (val && Z_TYPE_P(val) == IS_STRING) {
-                            zend_update_property(pcbc_view_ce, &view, ZEND_STRL("map"), val);
+                            pcbc_update_property(pcbc_view_ce, &view, ("map"), val);
                         }
                         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("reduce"));
                         if (val && Z_TYPE_P(val) == IS_STRING) {
-                            zend_update_property(pcbc_view_ce, &view, ZEND_STRL("reduce"), val);
+                            pcbc_update_property(pcbc_view_ce, &view, ("reduce"), val);
                         }
                         add_assoc_zval_ex(&view_prop, ZSTR_VAL(string_key), ZSTR_LEN(string_key), &view);
                     }
@@ -156,7 +156,7 @@ PHP_METHOD(ViewIndexManager, getAllDesignDocuments)
         RETURN_NULL();
     }
 
-    prop = zend_read_property(pcbc_view_index_manager_ce, getThis(), ZEND_STRL("bucket"), 0, &val);
+    prop = pcbc_read_property(pcbc_view_index_manager_ce, getThis(), ("bucket"), 0, &val);
     bucket = Z_BUCKET_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -183,13 +183,13 @@ PHP_METHOD(ViewIndexManager, upsertDesignDocument)
         return;
     }
 
-    prop = zend_read_property(pcbc_view_index_manager_ce, getThis(), ZEND_STRL("bucket"), 0, &val);
+    prop = pcbc_read_property(pcbc_view_index_manager_ce, getThis(), ("bucket"), 0, &val);
     bucket = Z_BUCKET_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
     lcb_cmdhttp_create(&cmd, LCB_HTTP_TYPE_VIEW);
     lcb_cmdhttp_method(cmd, LCB_HTTP_METHOD_PUT);
-    prop = zend_read_property(pcbc_design_document_ce, document, ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_design_document_ce, document, ("name"), 0, &rv);
     path_len = spprintf(&path, 0, "/%.*s", (int)Z_STRLEN_P(prop), Z_STRVAL_P(prop));
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_JSON, strlen(PCBC_CONTENT_TYPE_JSON));
@@ -222,7 +222,7 @@ PHP_METHOD(ViewIndexManager, dropDesignDocument)
         return;
     }
 
-    prop = zend_read_property(pcbc_view_index_manager_ce, getThis(), ZEND_STRL("bucket"), 0, &val);
+    prop = pcbc_read_property(pcbc_view_index_manager_ce, getThis(), ("bucket"), 0, &val);
     bucket = Z_BUCKET_OBJ_P(prop);
 
     lcb_CMDHTTP *cmd;
@@ -277,7 +277,7 @@ PHP_METHOD(DesignDocument, jsonSerialize)
     zval_delref_p(&views);
 
     zval *prop, ret;
-    prop = zend_read_property(pcbc_design_document_ce, getThis(), ZEND_STRL("views"), 0, &ret);
+    prop = pcbc_read_property(pcbc_design_document_ce, getThis(), ("views"), 0, &ret);
     if (prop && Z_TYPE_P(prop) == IS_ARRAY) {
         zend_string *string_key = NULL;
         zval *entry;
@@ -285,11 +285,11 @@ PHP_METHOD(DesignDocument, jsonSerialize)
         {
             zval view, *val, ret;
             array_init(&view);
-            val = zend_read_property(pcbc_view_ce, entry, ZEND_STRL("map"), 0, &ret);
+            val = pcbc_read_property(pcbc_view_ce, entry, ("map"), 0, &ret);
             if (val && Z_TYPE_P(val)) {
                 add_assoc_zval(&view, "map", val);
             }
-            val = zend_read_property(pcbc_view_ce, entry, ZEND_STRL("reduce"), 0, &ret);
+            val = pcbc_read_property(pcbc_view_ce, entry, ("reduce"), 0, &ret);
             if (val && Z_TYPE_P(val)) {
                 add_assoc_zval(&view, "reduce", val);
             }
@@ -324,7 +324,7 @@ PHP_METHOD(DesignDocument, name)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_design_document_ce, getThis(), ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_design_document_ce, getThis(), ("name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -335,7 +335,7 @@ PHP_METHOD(DesignDocument, views)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_design_document_ce, getThis(), ZEND_STRL("views"), 0, &rv);
+    prop = pcbc_read_property(pcbc_design_document_ce, getThis(), ("views"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -346,7 +346,7 @@ PHP_METHOD(DesignDocument, setName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_design_document_ce, getThis(), ZEND_STRL("name"), val);
+    pcbc_update_property_str(pcbc_design_document_ce, getThis(), ("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -357,7 +357,7 @@ PHP_METHOD(DesignDocument, setViews)
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_design_document_ce, getThis(), ZEND_STRL("views"), val);
+    pcbc_update_property(pcbc_design_document_ce, getThis(), ("views"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -400,7 +400,7 @@ PHP_METHOD(View, name)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_view_ce, getThis(), ZEND_STRL("name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_view_ce, getThis(), ("name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -411,7 +411,7 @@ PHP_METHOD(View, map)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_view_ce, getThis(), ZEND_STRL("map"), 0, &rv);
+    prop = pcbc_read_property(pcbc_view_ce, getThis(), ("map"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -422,7 +422,7 @@ PHP_METHOD(View, reduce)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_view_ce, getThis(), ZEND_STRL("reduce"), 0, &rv);
+    prop = pcbc_read_property(pcbc_view_ce, getThis(), ("reduce"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -433,7 +433,7 @@ PHP_METHOD(View, setName)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_view_ce, getThis(), ZEND_STRL("name"), val);
+    pcbc_update_property_str(pcbc_view_ce, getThis(), ("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -444,7 +444,7 @@ PHP_METHOD(View, setMap)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_view_ce, getThis(), ZEND_STRL("map"), val);
+    pcbc_update_property_str(pcbc_view_ce, getThis(), ("map"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -455,7 +455,7 @@ PHP_METHOD(View, setReduce)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_view_ce, getThis(), ZEND_STRL("reduce"), val);
+    pcbc_update_property_str(pcbc_view_ce, getThis(), ("reduce"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 

--- a/src/couchbase/managers/view_index_manager.c
+++ b/src/couchbase/managers/view_index_manager.c
@@ -27,7 +27,7 @@ static void httpcb_getDesignDocument(void *ctx, zval *return_value, zval *respon
     zval view_prop;
     object_init_ex(return_value, pcbc_design_document_ce);
     array_init(&view_prop);
-    zend_update_property(pcbc_design_document_ce, return_value, ZEND_STRL("views"), &view_prop TSRMLS_CC);
+    zend_update_property(pcbc_design_document_ce, return_value, ZEND_STRL("views"), &view_prop);
     zval_delref_p(&view_prop);
 
     zval *views = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("views"));
@@ -38,14 +38,14 @@ static void httpcb_getDesignDocument(void *ctx, zval *return_value, zval *respon
         {
             zval view, *val;
             object_init_ex(&view, pcbc_view_ce);
-            zend_update_property_str(pcbc_view_ce, &view, ZEND_STRL("name"), string_key TSRMLS_CC);
+            zend_update_property_str(pcbc_view_ce, &view, ZEND_STRL("name"), string_key);
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("map"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_view_ce, &view, ZEND_STRL("map"), val TSRMLS_CC);
+                zend_update_property(pcbc_view_ce, &view, ZEND_STRL("map"), val);
             }
             val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("reduce"));
             if (val && Z_TYPE_P(val) == IS_STRING) {
-                zend_update_property(pcbc_view_ce, &view, ZEND_STRL("reduce"), val TSRMLS_CC);
+                zend_update_property(pcbc_view_ce, &view, ZEND_STRL("reduce"), val);
             }
             add_assoc_zval_ex(&view_prop, ZSTR_VAL(string_key), ZSTR_LEN(string_key), &view);
         }
@@ -61,7 +61,7 @@ PHP_METHOD(ViewIndexManager, getDesignDocument)
     char *path;
     int rv, path_len;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         return;
     }
@@ -75,9 +75,9 @@ PHP_METHOD(ViewIndexManager, getDesignDocument)
     path_len = spprintf(&path, 0, "/%.*s", (int)ZSTR_LEN(name), ZSTR_VAL(name));
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, httpcb_getDesignDocument, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, httpcb_getDesignDocument, NULL);
     efree(path);
-    zend_update_property_str(pcbc_design_document_ce, return_value, ZEND_STRL("name"), name TSRMLS_CC);
+    zend_update_property_str(pcbc_design_document_ce, return_value, ZEND_STRL("name"), name);
 }
 
 static void parse_ddoc_entry(zval *return_value, zval *response)
@@ -85,7 +85,7 @@ static void parse_ddoc_entry(zval *return_value, zval *response)
     zval view_prop;
     object_init_ex(return_value, pcbc_design_document_ce);
     array_init(&view_prop);
-    zend_update_property(pcbc_design_document_ce, return_value, ZEND_STRL("views"), &view_prop TSRMLS_CC);
+    zend_update_property(pcbc_design_document_ce, return_value, ZEND_STRL("views"), &view_prop);
     zval_delref_p(&view_prop);
     zval *doc = zend_symtable_str_find(Z_ARRVAL_P(response), ZEND_STRL("doc"));
     if (doc && Z_TYPE_P(doc) == IS_ARRAY) {
@@ -95,7 +95,7 @@ static void parse_ddoc_entry(zval *return_value, zval *response)
                 zval *val;
                 val = zend_symtable_str_find(Z_ARRVAL_P(meta), ZEND_STRL("id"));
                 if (val && Z_TYPE_P(val) == IS_STRING) {
-                    zend_update_property(pcbc_design_document_ce, return_value, ZEND_STRL("name"), val TSRMLS_CC);
+                    zend_update_property(pcbc_design_document_ce, return_value, ZEND_STRL("name"), val);
                 }
             }
         }
@@ -110,14 +110,14 @@ static void parse_ddoc_entry(zval *return_value, zval *response)
                     {
                         zval view, *val;
                         object_init_ex(&view, pcbc_view_ce);
-                        zend_update_property_str(pcbc_view_ce, &view, ZEND_STRL("name"), string_key TSRMLS_CC);
+                        zend_update_property_str(pcbc_view_ce, &view, ZEND_STRL("name"), string_key);
                         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("map"));
                         if (val && Z_TYPE_P(val) == IS_STRING) {
-                            zend_update_property(pcbc_view_ce, &view, ZEND_STRL("map"), val TSRMLS_CC);
+                            zend_update_property(pcbc_view_ce, &view, ZEND_STRL("map"), val);
                         }
                         val = zend_symtable_str_find(Z_ARRVAL_P(entry), ZEND_STRL("reduce"));
                         if (val && Z_TYPE_P(val) == IS_STRING) {
-                            zend_update_property(pcbc_view_ce, &view, ZEND_STRL("reduce"), val TSRMLS_CC);
+                            zend_update_property(pcbc_view_ce, &view, ZEND_STRL("reduce"), val);
                         }
                         add_assoc_zval_ex(&view_prop, ZSTR_VAL(string_key), ZSTR_LEN(string_key), &view);
                     }
@@ -165,7 +165,7 @@ PHP_METHOD(ViewIndexManager, getAllDesignDocuments)
     path_len = spprintf(&path, 0, "/pools/default/buckets/%s/ddocs", bucket->conn->bucketname);
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, httpcb_getAllDesignDocuments, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, httpcb_getAllDesignDocuments, NULL);
     efree(path);
 }
 
@@ -179,7 +179,7 @@ PHP_METHOD(ViewIndexManager, upsertDesignDocument)
     smart_str buf = {0};
     int last_error;
 
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "O", &document, pcbc_design_document_ce) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O", &document, pcbc_design_document_ce) == FAILURE) {
         return;
     }
 
@@ -204,7 +204,7 @@ PHP_METHOD(ViewIndexManager, upsertDesignDocument)
         smart_str_0(&buf);
         lcb_cmdhttp_body(cmd, ZSTR_VAL(buf.s), ZSTR_LEN(buf.s));
     }
-    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
     smart_str_free(&buf);
 }
@@ -217,7 +217,7 @@ PHP_METHOD(ViewIndexManager, dropDesignDocument)
     zend_string *name;
     int rv, path_len;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &name);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S", &name);
     if (rv == FAILURE) {
         return;
     }
@@ -231,7 +231,7 @@ PHP_METHOD(ViewIndexManager, dropDesignDocument)
     path_len = spprintf(&path, 0, "/%*s", (int)ZSTR_LEN(name), ZSTR_VAL(name));
     lcb_cmdhttp_path(cmd, path, path_len);
     lcb_cmdhttp_content_type(cmd, PCBC_CONTENT_TYPE_FORM, strlen(PCBC_CONTENT_TYPE_FORM));
-    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, NULL, NULL TSRMLS_CC);
+    pcbc_http_request(return_value, bucket->conn->lcb, cmd, 1, NULL, NULL, NULL);
     efree(path);
 }
 
@@ -342,22 +342,22 @@ PHP_METHOD(DesignDocument, views)
 PHP_METHOD(DesignDocument, setName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_design_document_ce, getThis(), ZEND_STRL("name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_design_document_ce, getThis(), ZEND_STRL("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(DesignDocument, setViews)
 {
     zval *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "a", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "a", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property(pcbc_design_document_ce, getThis(), ZEND_STRL("views"), val TSRMLS_CC);
+    zend_update_property(pcbc_design_document_ce, getThis(), ZEND_STRL("views"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -429,33 +429,33 @@ PHP_METHOD(View, reduce)
 PHP_METHOD(View, setName)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_view_ce, getThis(), ZEND_STRL("name"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_view_ce, getThis(), ZEND_STRL("name"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(View, setMap)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_view_ce, getThis(), ZEND_STRL("map"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_view_ce, getThis(), ZEND_STRL("map"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(View, setReduce)
 {
     zend_string *val;
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &val) == FAILURE) {
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &val) == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_view_ce, getThis(), ZEND_STRL("reduce"), val TSRMLS_CC);
+    zend_update_property_str(pcbc_view_ce, getThis(), ZEND_STRL("reduce"), val);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -476,20 +476,20 @@ PHP_MINIT_FUNCTION(ViewIndexManager)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ViewIndexManager", view_index_manager_methods);
-    pcbc_view_index_manager_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_index_manager_ce, ZEND_STRL("bucket"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_view_index_manager_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_view_index_manager_ce, ZEND_STRL("bucket"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "DesignDocument", design_document_methods);
-    pcbc_design_document_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_design_document_ce TSRMLS_CC, 1, pcbc_json_serializable_ce);
-    zend_declare_property_null(pcbc_design_document_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_design_document_ce, ZEND_STRL("views"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_design_document_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_design_document_ce, 1, pcbc_json_serializable_ce);
+    zend_declare_property_null(pcbc_design_document_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_design_document_ce, ZEND_STRL("views"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "View", view_methods);
-    pcbc_view_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_ce, ZEND_STRL("map"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_ce, ZEND_STRL("reduce"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_view_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_view_ce, ZEND_STRL("name"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_ce, ZEND_STRL("map"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_ce, ZEND_STRL("reduce"), ZEND_ACC_PRIVATE);
     return SUCCESS;
 }
 

--- a/src/couchbase/mutate_spec.c
+++ b/src/couchbase/mutate_spec.c
@@ -172,88 +172,88 @@ PHP_MINIT_FUNCTION(MutateInSpec)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateInSpec", pcbc_mutate_in_spec_methods);
-    pcbc_mutate_in_spec_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_mutate_in_spec_ce = zend_register_internal_interface(&ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateInsertSpec", pcbc_mutate_insert_spec_methods);
-    pcbc_mutate_insert_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutate_insert_spec_ce TSRMLS_CC, 1, pcbc_mutate_in_spec_ce);
-    zend_declare_property_null(pcbc_mutate_insert_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_insert_spec_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_insert_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_insert_spec_ce, ZEND_STRL("create_path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_insert_spec_ce, ZEND_STRL("expand_macros"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutate_insert_spec_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_mutate_insert_spec_ce, 1, pcbc_mutate_in_spec_ce);
+    zend_declare_property_null(pcbc_mutate_insert_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_insert_spec_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_insert_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_insert_spec_ce, ZEND_STRL("create_path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_insert_spec_ce, ZEND_STRL("expand_macros"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateUpsertSpec", pcbc_mutate_upsert_spec_methods);
-    pcbc_mutate_upsert_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutate_upsert_spec_ce TSRMLS_CC, 1, pcbc_mutate_in_spec_ce);
-    zend_declare_property_null(pcbc_mutate_upsert_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_upsert_spec_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_upsert_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_upsert_spec_ce, ZEND_STRL("create_path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_upsert_spec_ce, ZEND_STRL("expand_macros"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutate_upsert_spec_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_mutate_upsert_spec_ce, 1, pcbc_mutate_in_spec_ce);
+    zend_declare_property_null(pcbc_mutate_upsert_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_upsert_spec_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_upsert_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_upsert_spec_ce, ZEND_STRL("create_path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_upsert_spec_ce, ZEND_STRL("expand_macros"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateReplaceSpec", pcbc_mutate_replace_spec_methods);
-    pcbc_mutate_replace_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutate_replace_spec_ce TSRMLS_CC, 1, pcbc_mutate_in_spec_ce);
-    zend_declare_property_null(pcbc_mutate_replace_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_replace_spec_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_replace_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_replace_spec_ce, ZEND_STRL("expand_macros"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutate_replace_spec_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_mutate_replace_spec_ce, 1, pcbc_mutate_in_spec_ce);
+    zend_declare_property_null(pcbc_mutate_replace_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_replace_spec_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_replace_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_replace_spec_ce, ZEND_STRL("expand_macros"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateRemoveSpec", pcbc_mutate_remove_spec_methods);
-    pcbc_mutate_remove_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutate_remove_spec_ce TSRMLS_CC, 1, pcbc_mutate_in_spec_ce);
-    zend_declare_property_null(pcbc_mutate_remove_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_remove_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutate_remove_spec_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_mutate_remove_spec_ce, 1, pcbc_mutate_in_spec_ce);
+    zend_declare_property_null(pcbc_mutate_remove_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_remove_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateArrayAppendSpec", pcbc_mutate_array_append_spec_methods);
-    pcbc_mutate_array_append_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutate_array_append_spec_ce TSRMLS_CC, 1, pcbc_mutate_in_spec_ce);
-    zend_declare_property_null(pcbc_mutate_array_append_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_array_append_spec_ce, ZEND_STRL("values"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_array_append_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_array_append_spec_ce, ZEND_STRL("create_path"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutate_array_append_spec_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_mutate_array_append_spec_ce, 1, pcbc_mutate_in_spec_ce);
+    zend_declare_property_null(pcbc_mutate_array_append_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_array_append_spec_ce, ZEND_STRL("values"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_array_append_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_array_append_spec_ce, ZEND_STRL("create_path"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_mutate_array_append_spec_ce, ZEND_STRL("expand_macros"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateArrayPrependSpec", pcbc_mutate_array_prepend_spec_methods);
-    pcbc_mutate_array_prepend_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutate_array_prepend_spec_ce TSRMLS_CC, 1, pcbc_mutate_in_spec_ce);
-    zend_declare_property_null(pcbc_mutate_array_prepend_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_array_prepend_spec_ce, ZEND_STRL("values"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_array_prepend_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_array_prepend_spec_ce, ZEND_STRL("create_path"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutate_array_prepend_spec_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_mutate_array_prepend_spec_ce, 1, pcbc_mutate_in_spec_ce);
+    zend_declare_property_null(pcbc_mutate_array_prepend_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_array_prepend_spec_ce, ZEND_STRL("values"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_array_prepend_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_array_prepend_spec_ce, ZEND_STRL("create_path"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_mutate_array_prepend_spec_ce, ZEND_STRL("expand_macros"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateArrayInsertSpec", pcbc_mutate_array_insert_spec_methods);
-    pcbc_mutate_array_insert_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutate_array_insert_spec_ce TSRMLS_CC, 1, pcbc_mutate_in_spec_ce);
-    zend_declare_property_null(pcbc_mutate_array_insert_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_array_insert_spec_ce, ZEND_STRL("values"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_array_insert_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_array_insert_spec_ce, ZEND_STRL("create_path"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutate_array_insert_spec_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_mutate_array_insert_spec_ce, 1, pcbc_mutate_in_spec_ce);
+    zend_declare_property_null(pcbc_mutate_array_insert_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_array_insert_spec_ce, ZEND_STRL("values"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_array_insert_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_array_insert_spec_ce, ZEND_STRL("create_path"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_mutate_array_insert_spec_ce, ZEND_STRL("expand_macros"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateArrayAddUniqueSpec", pcbc_mutate_array_add_unique_spec_methods);
-    pcbc_mutate_array_add_unique_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutate_array_add_unique_spec_ce TSRMLS_CC, 1, pcbc_mutate_in_spec_ce);
-    zend_declare_property_null(pcbc_mutate_array_add_unique_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_array_add_unique_spec_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_array_add_unique_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutate_array_add_unique_spec_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_mutate_array_add_unique_spec_ce, 1, pcbc_mutate_in_spec_ce);
+    zend_declare_property_null(pcbc_mutate_array_add_unique_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_array_add_unique_spec_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_array_add_unique_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_mutate_array_add_unique_spec_ce, ZEND_STRL("create_path"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_mutate_array_add_unique_spec_ce, ZEND_STRL("expand_macros"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateCounterSpec", pcbc_mutate_counter_spec_methods);
-    pcbc_mutate_counter_spec_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutate_counter_spec_ce TSRMLS_CC, 1, pcbc_mutate_in_spec_ce);
-    zend_declare_property_null(pcbc_mutate_counter_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_counter_spec_ce, ZEND_STRL("delta"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_counter_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_counter_spec_ce, ZEND_STRL("create_path"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutate_counter_spec_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_mutate_counter_spec_ce, 1, pcbc_mutate_in_spec_ce);
+    zend_declare_property_null(pcbc_mutate_counter_spec_ce, ZEND_STRL("path"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_counter_spec_ce, ZEND_STRL("delta"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_counter_spec_ce, ZEND_STRL("is_xattr"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_counter_spec_ce, ZEND_STRL("create_path"), ZEND_ACC_PRIVATE);
     return SUCCESS;
 }
 
@@ -263,16 +263,16 @@ PHP_METHOD(MutateInsertSpec, __construct)
     zval *value;
     zend_bool is_xattr = 0, create_path = 0, expand_macros = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sz|bbb", &path, &value, &is_xattr, &create_path,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sz|bbb", &path, &value, &is_xattr, &create_path,
                                          &expand_macros);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("path"), path TSRMLS_CC);
-    zend_update_property_bool(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr TSRMLS_CC);
-    zend_update_property_bool(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("create_path"), create_path TSRMLS_CC);
+    zend_update_property_str(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("path"), path);
+    zend_update_property_bool(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
+    zend_update_property_bool(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("create_path"), create_path);
     zend_update_property_bool(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("expand_macros"),
-                              expand_macros TSRMLS_CC);
+                              expand_macros);
     {
         smart_str buf = {0};
         int last_error;
@@ -283,7 +283,7 @@ PHP_METHOD(MutateInsertSpec, __construct)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        zend_update_property_str(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("value"), buf.s TSRMLS_CC);
+        zend_update_property_str(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("value"), buf.s);
         smart_str_free(&buf);
     }
 }
@@ -294,16 +294,16 @@ PHP_METHOD(MutateUpsertSpec, __construct)
     zval *value;
     zend_bool is_xattr = 0, create_path = 0, expand_macros = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sz|bbb", &path, &value, &is_xattr, &create_path,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sz|bbb", &path, &value, &is_xattr, &create_path,
                                          &expand_macros);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("path"), path TSRMLS_CC);
-    zend_update_property_bool(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr TSRMLS_CC);
-    zend_update_property_bool(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("create_path"), create_path TSRMLS_CC);
+    zend_update_property_str(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("path"), path);
+    zend_update_property_bool(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
+    zend_update_property_bool(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("create_path"), create_path);
     zend_update_property_bool(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("expand_macros"),
-                              expand_macros TSRMLS_CC);
+                              expand_macros);
     {
         smart_str buf = {0};
         int last_error;
@@ -314,7 +314,7 @@ PHP_METHOD(MutateUpsertSpec, __construct)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        zend_update_property_str(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("value"), buf.s TSRMLS_CC);
+        zend_update_property_str(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("value"), buf.s);
         smart_str_free(&buf);
     }
 }
@@ -325,13 +325,13 @@ PHP_METHOD(MutateReplaceSpec, __construct)
     zval *value;
     zend_bool is_xattr = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sz|b", &path, &value, &is_xattr);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sz|b", &path, &value, &is_xattr);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_replace_spec_ce, getThis(), ZEND_STRL("path"), path TSRMLS_CC);
-    zend_update_property_bool(pcbc_mutate_replace_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr TSRMLS_CC);
-    zend_update_property_bool(pcbc_mutate_replace_spec_ce, getThis(), ZEND_STRL("expand_macros"), is_xattr TSRMLS_CC);
+    zend_update_property_str(pcbc_mutate_replace_spec_ce, getThis(), ZEND_STRL("path"), path);
+    zend_update_property_bool(pcbc_mutate_replace_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
+    zend_update_property_bool(pcbc_mutate_replace_spec_ce, getThis(), ZEND_STRL("expand_macros"), is_xattr);
     {
         smart_str buf = {0};
         int last_error;
@@ -342,7 +342,7 @@ PHP_METHOD(MutateReplaceSpec, __construct)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        zend_update_property_str(pcbc_mutate_replace_spec_ce, getThis(), ZEND_STRL("value"), buf.s TSRMLS_CC);
+        zend_update_property_str(pcbc_mutate_replace_spec_ce, getThis(), ZEND_STRL("value"), buf.s);
         smart_str_free(&buf);
     }
 }
@@ -352,12 +352,12 @@ PHP_METHOD(MutateRemoveSpec, __construct)
     zend_string *path;
     zend_bool is_xattr = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|b", &path, &is_xattr);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|b", &path, &is_xattr);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_remove_spec_ce, getThis(), ZEND_STRL("path"), path TSRMLS_CC);
-    zend_update_property_bool(pcbc_mutate_remove_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr TSRMLS_CC);
+    zend_update_property_str(pcbc_mutate_remove_spec_ce, getThis(), ZEND_STRL("path"), path);
+    zend_update_property_bool(pcbc_mutate_remove_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
 }
 
 PHP_METHOD(MutateArrayAppendSpec, __construct)
@@ -366,17 +366,17 @@ PHP_METHOD(MutateArrayAppendSpec, __construct)
     zval *value;
     zend_bool is_xattr = 0, create_path = 0, expand_macros = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sa|bbb", &path, &value, &is_xattr, &create_path,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sa|bbb", &path, &value, &is_xattr, &create_path,
                                          &expand_macros);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_array_append_spec_ce, getThis(), ZEND_STRL("path"), path TSRMLS_CC);
-    zend_update_property_bool(pcbc_mutate_array_append_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr TSRMLS_CC);
+    zend_update_property_str(pcbc_mutate_array_append_spec_ce, getThis(), ZEND_STRL("path"), path);
+    zend_update_property_bool(pcbc_mutate_array_append_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
     zend_update_property_bool(pcbc_mutate_array_append_spec_ce, getThis(), ZEND_STRL("create_path"),
-                              create_path TSRMLS_CC);
+                              create_path);
     zend_update_property_bool(pcbc_mutate_array_append_spec_ce, getThis(), ZEND_STRL("expand_macros"),
-                              expand_macros TSRMLS_CC);
+                              expand_macros);
     {
         smart_str buf = {0};
         int last_error;
@@ -388,7 +388,7 @@ PHP_METHOD(MutateArrayAppendSpec, __construct)
         }
         smart_str_0(&buf);
         zend_update_property_stringl(pcbc_mutate_array_append_spec_ce, getThis(), ZEND_STRL("value"),
-                                     ZSTR_VAL(buf.s) + 1, ZSTR_LEN(buf.s) - 2 TSRMLS_CC);
+                                     ZSTR_VAL(buf.s) + 1, ZSTR_LEN(buf.s) - 2);
         smart_str_free(&buf);
     }
 }
@@ -399,17 +399,17 @@ PHP_METHOD(MutateArrayPrependSpec, __construct)
     zval *value;
     zend_bool is_xattr = 0, create_path = 0, expand_macros = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sa|bbb", &path, &value, &is_xattr, &create_path,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sa|bbb", &path, &value, &is_xattr, &create_path,
                                          &expand_macros);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_array_prepend_spec_ce, getThis(), ZEND_STRL("path"), path TSRMLS_CC);
-    zend_update_property_bool(pcbc_mutate_array_prepend_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr TSRMLS_CC);
+    zend_update_property_str(pcbc_mutate_array_prepend_spec_ce, getThis(), ZEND_STRL("path"), path);
+    zend_update_property_bool(pcbc_mutate_array_prepend_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
     zend_update_property_bool(pcbc_mutate_array_prepend_spec_ce, getThis(), ZEND_STRL("create_path"),
-                              create_path TSRMLS_CC);
+                              create_path);
     zend_update_property_bool(pcbc_mutate_array_prepend_spec_ce, getThis(), ZEND_STRL("expand_macros"),
-                              expand_macros TSRMLS_CC);
+                              expand_macros);
     {
         smart_str buf = {0};
         int last_error;
@@ -421,7 +421,7 @@ PHP_METHOD(MutateArrayPrependSpec, __construct)
         }
         smart_str_0(&buf);
         zend_update_property_stringl(pcbc_mutate_array_prepend_spec_ce, getThis(), ZEND_STRL("value"),
-                                     ZSTR_VAL(buf.s) + 1, ZSTR_LEN(buf.s) - 2 TSRMLS_CC);
+                                     ZSTR_VAL(buf.s) + 1, ZSTR_LEN(buf.s) - 2);
         smart_str_free(&buf);
     }
 }
@@ -432,17 +432,17 @@ PHP_METHOD(MutateArrayInsertSpec, __construct)
     zval *value;
     zend_bool is_xattr = 0, create_path = 0, expand_macros = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sa|bbb", &path, &value, &is_xattr, &create_path,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sa|bbb", &path, &value, &is_xattr, &create_path,
                                          &expand_macros);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_array_insert_spec_ce, getThis(), ZEND_STRL("path"), path TSRMLS_CC);
-    zend_update_property_bool(pcbc_mutate_array_insert_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr TSRMLS_CC);
+    zend_update_property_str(pcbc_mutate_array_insert_spec_ce, getThis(), ZEND_STRL("path"), path);
+    zend_update_property_bool(pcbc_mutate_array_insert_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
     zend_update_property_bool(pcbc_mutate_array_insert_spec_ce, getThis(), ZEND_STRL("create_path"),
-                              create_path TSRMLS_CC);
+                              create_path);
     zend_update_property_bool(pcbc_mutate_array_insert_spec_ce, getThis(), ZEND_STRL("expand_macros"),
-                              expand_macros TSRMLS_CC);
+                              expand_macros);
     {
         smart_str buf = {0};
         int last_error;
@@ -454,7 +454,7 @@ PHP_METHOD(MutateArrayInsertSpec, __construct)
         }
         smart_str_0(&buf);
         zend_update_property_stringl(pcbc_mutate_array_insert_spec_ce, getThis(), ZEND_STRL("value"),
-                                     ZSTR_VAL(buf.s) + 1, ZSTR_LEN(buf.s) - 2 TSRMLS_CC);
+                                     ZSTR_VAL(buf.s) + 1, ZSTR_LEN(buf.s) - 2);
         smart_str_free(&buf);
     }
 }
@@ -465,18 +465,18 @@ PHP_METHOD(MutateArrayAddUniqueSpec, __construct)
     zval *value;
     zend_bool is_xattr = 0, create_path = 0, expand_macros = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sz|bbb", &path, &value, &is_xattr, &create_path,
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sz|bbb", &path, &value, &is_xattr, &create_path,
                                          &expand_macros);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_array_add_unique_spec_ce, getThis(), ZEND_STRL("path"), path TSRMLS_CC);
+    zend_update_property_str(pcbc_mutate_array_add_unique_spec_ce, getThis(), ZEND_STRL("path"), path);
     zend_update_property_bool(pcbc_mutate_array_add_unique_spec_ce, getThis(), ZEND_STRL("is_xattr"),
-                              is_xattr TSRMLS_CC);
+                              is_xattr);
     zend_update_property_bool(pcbc_mutate_array_add_unique_spec_ce, getThis(), ZEND_STRL("create_path"),
-                              create_path TSRMLS_CC);
+                              create_path);
     zend_update_property_bool(pcbc_mutate_array_add_unique_spec_ce, getThis(), ZEND_STRL("expand_macros"),
-                              expand_macros TSRMLS_CC);
+                              expand_macros);
     {
         smart_str buf = {0};
         int last_error;
@@ -487,7 +487,7 @@ PHP_METHOD(MutateArrayAddUniqueSpec, __construct)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        zend_update_property_str(pcbc_mutate_array_add_unique_spec_ce, getThis(), ZEND_STRL("value"), buf.s TSRMLS_CC);
+        zend_update_property_str(pcbc_mutate_array_add_unique_spec_ce, getThis(), ZEND_STRL("value"), buf.s);
         smart_str_free(&buf);
     }
 }
@@ -498,14 +498,14 @@ PHP_METHOD(MutateCounterSpec, __construct)
     zend_long delta;
     zend_bool is_xattr = 0, create_path = 0;
 
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sl|bb", &path, &delta, &is_xattr, &create_path);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sl|bb", &path, &delta, &is_xattr, &create_path);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_counter_spec_ce, getThis(), ZEND_STRL("path"), path TSRMLS_CC);
-    zend_update_property_long(pcbc_mutate_counter_spec_ce, getThis(), ZEND_STRL("delta"), delta TSRMLS_CC);
-    zend_update_property_bool(pcbc_mutate_counter_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr TSRMLS_CC);
-    zend_update_property_bool(pcbc_mutate_counter_spec_ce, getThis(), ZEND_STRL("create_path"), create_path TSRMLS_CC);
+    zend_update_property_str(pcbc_mutate_counter_spec_ce, getThis(), ZEND_STRL("path"), path);
+    zend_update_property_long(pcbc_mutate_counter_spec_ce, getThis(), ZEND_STRL("delta"), delta);
+    zend_update_property_bool(pcbc_mutate_counter_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
+    zend_update_property_bool(pcbc_mutate_counter_spec_ce, getThis(), ZEND_STRL("create_path"), create_path);
 }
 
 /*

--- a/src/couchbase/mutate_spec.c
+++ b/src/couchbase/mutate_spec.c
@@ -268,10 +268,10 @@ PHP_METHOD(MutateInsertSpec, __construct)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("path"), path);
-    zend_update_property_bool(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
-    zend_update_property_bool(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("create_path"), create_path);
-    zend_update_property_bool(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("expand_macros"),
+    pcbc_update_property_str(pcbc_mutate_insert_spec_ce, getThis(), ("path"), path);
+    pcbc_update_property_bool(pcbc_mutate_insert_spec_ce, getThis(), ("is_xattr"), is_xattr);
+    pcbc_update_property_bool(pcbc_mutate_insert_spec_ce, getThis(), ("create_path"), create_path);
+    pcbc_update_property_bool(pcbc_mutate_insert_spec_ce, getThis(), ("expand_macros"),
                               expand_macros);
     {
         smart_str buf = {0};
@@ -283,7 +283,7 @@ PHP_METHOD(MutateInsertSpec, __construct)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        zend_update_property_str(pcbc_mutate_insert_spec_ce, getThis(), ZEND_STRL("value"), buf.s);
+        pcbc_update_property_str(pcbc_mutate_insert_spec_ce, getThis(), ("value"), buf.s);
         smart_str_free(&buf);
     }
 }
@@ -299,10 +299,10 @@ PHP_METHOD(MutateUpsertSpec, __construct)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("path"), path);
-    zend_update_property_bool(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
-    zend_update_property_bool(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("create_path"), create_path);
-    zend_update_property_bool(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("expand_macros"),
+    pcbc_update_property_str(pcbc_mutate_upsert_spec_ce, getThis(), ("path"), path);
+    pcbc_update_property_bool(pcbc_mutate_upsert_spec_ce, getThis(), ("is_xattr"), is_xattr);
+    pcbc_update_property_bool(pcbc_mutate_upsert_spec_ce, getThis(), ("create_path"), create_path);
+    pcbc_update_property_bool(pcbc_mutate_upsert_spec_ce, getThis(), ("expand_macros"),
                               expand_macros);
     {
         smart_str buf = {0};
@@ -314,7 +314,7 @@ PHP_METHOD(MutateUpsertSpec, __construct)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        zend_update_property_str(pcbc_mutate_upsert_spec_ce, getThis(), ZEND_STRL("value"), buf.s);
+        pcbc_update_property_str(pcbc_mutate_upsert_spec_ce, getThis(), ("value"), buf.s);
         smart_str_free(&buf);
     }
 }
@@ -329,9 +329,9 @@ PHP_METHOD(MutateReplaceSpec, __construct)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_replace_spec_ce, getThis(), ZEND_STRL("path"), path);
-    zend_update_property_bool(pcbc_mutate_replace_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
-    zend_update_property_bool(pcbc_mutate_replace_spec_ce, getThis(), ZEND_STRL("expand_macros"), is_xattr);
+    pcbc_update_property_str(pcbc_mutate_replace_spec_ce, getThis(), ("path"), path);
+    pcbc_update_property_bool(pcbc_mutate_replace_spec_ce, getThis(), ("is_xattr"), is_xattr);
+    pcbc_update_property_bool(pcbc_mutate_replace_spec_ce, getThis(), ("expand_macros"), is_xattr);
     {
         smart_str buf = {0};
         int last_error;
@@ -342,7 +342,7 @@ PHP_METHOD(MutateReplaceSpec, __construct)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        zend_update_property_str(pcbc_mutate_replace_spec_ce, getThis(), ZEND_STRL("value"), buf.s);
+        pcbc_update_property_str(pcbc_mutate_replace_spec_ce, getThis(), ("value"), buf.s);
         smart_str_free(&buf);
     }
 }
@@ -356,8 +356,8 @@ PHP_METHOD(MutateRemoveSpec, __construct)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_remove_spec_ce, getThis(), ZEND_STRL("path"), path);
-    zend_update_property_bool(pcbc_mutate_remove_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
+    pcbc_update_property_str(pcbc_mutate_remove_spec_ce, getThis(), ("path"), path);
+    pcbc_update_property_bool(pcbc_mutate_remove_spec_ce, getThis(), ("is_xattr"), is_xattr);
 }
 
 PHP_METHOD(MutateArrayAppendSpec, __construct)
@@ -371,11 +371,11 @@ PHP_METHOD(MutateArrayAppendSpec, __construct)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_array_append_spec_ce, getThis(), ZEND_STRL("path"), path);
-    zend_update_property_bool(pcbc_mutate_array_append_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
-    zend_update_property_bool(pcbc_mutate_array_append_spec_ce, getThis(), ZEND_STRL("create_path"),
+    pcbc_update_property_str(pcbc_mutate_array_append_spec_ce, getThis(), ("path"), path);
+    pcbc_update_property_bool(pcbc_mutate_array_append_spec_ce, getThis(), ("is_xattr"), is_xattr);
+    pcbc_update_property_bool(pcbc_mutate_array_append_spec_ce, getThis(), ("create_path"),
                               create_path);
-    zend_update_property_bool(pcbc_mutate_array_append_spec_ce, getThis(), ZEND_STRL("expand_macros"),
+    pcbc_update_property_bool(pcbc_mutate_array_append_spec_ce, getThis(), ("expand_macros"),
                               expand_macros);
     {
         smart_str buf = {0};
@@ -387,7 +387,7 @@ PHP_METHOD(MutateArrayAppendSpec, __construct)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        zend_update_property_stringl(pcbc_mutate_array_append_spec_ce, getThis(), ZEND_STRL("value"),
+        pcbc_update_property_stringl(pcbc_mutate_array_append_spec_ce, getThis(), ("value"),
                                      ZSTR_VAL(buf.s) + 1, ZSTR_LEN(buf.s) - 2);
         smart_str_free(&buf);
     }
@@ -404,11 +404,11 @@ PHP_METHOD(MutateArrayPrependSpec, __construct)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_array_prepend_spec_ce, getThis(), ZEND_STRL("path"), path);
-    zend_update_property_bool(pcbc_mutate_array_prepend_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
-    zend_update_property_bool(pcbc_mutate_array_prepend_spec_ce, getThis(), ZEND_STRL("create_path"),
+    pcbc_update_property_str(pcbc_mutate_array_prepend_spec_ce, getThis(), ("path"), path);
+    pcbc_update_property_bool(pcbc_mutate_array_prepend_spec_ce, getThis(), ("is_xattr"), is_xattr);
+    pcbc_update_property_bool(pcbc_mutate_array_prepend_spec_ce, getThis(), ("create_path"),
                               create_path);
-    zend_update_property_bool(pcbc_mutate_array_prepend_spec_ce, getThis(), ZEND_STRL("expand_macros"),
+    pcbc_update_property_bool(pcbc_mutate_array_prepend_spec_ce, getThis(), ("expand_macros"),
                               expand_macros);
     {
         smart_str buf = {0};
@@ -420,7 +420,7 @@ PHP_METHOD(MutateArrayPrependSpec, __construct)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        zend_update_property_stringl(pcbc_mutate_array_prepend_spec_ce, getThis(), ZEND_STRL("value"),
+        pcbc_update_property_stringl(pcbc_mutate_array_prepend_spec_ce, getThis(), ("value"),
                                      ZSTR_VAL(buf.s) + 1, ZSTR_LEN(buf.s) - 2);
         smart_str_free(&buf);
     }
@@ -437,11 +437,11 @@ PHP_METHOD(MutateArrayInsertSpec, __construct)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_array_insert_spec_ce, getThis(), ZEND_STRL("path"), path);
-    zend_update_property_bool(pcbc_mutate_array_insert_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
-    zend_update_property_bool(pcbc_mutate_array_insert_spec_ce, getThis(), ZEND_STRL("create_path"),
+    pcbc_update_property_str(pcbc_mutate_array_insert_spec_ce, getThis(), ("path"), path);
+    pcbc_update_property_bool(pcbc_mutate_array_insert_spec_ce, getThis(), ("is_xattr"), is_xattr);
+    pcbc_update_property_bool(pcbc_mutate_array_insert_spec_ce, getThis(), ("create_path"),
                               create_path);
-    zend_update_property_bool(pcbc_mutate_array_insert_spec_ce, getThis(), ZEND_STRL("expand_macros"),
+    pcbc_update_property_bool(pcbc_mutate_array_insert_spec_ce, getThis(), ("expand_macros"),
                               expand_macros);
     {
         smart_str buf = {0};
@@ -453,7 +453,7 @@ PHP_METHOD(MutateArrayInsertSpec, __construct)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        zend_update_property_stringl(pcbc_mutate_array_insert_spec_ce, getThis(), ZEND_STRL("value"),
+        pcbc_update_property_stringl(pcbc_mutate_array_insert_spec_ce, getThis(), ("value"),
                                      ZSTR_VAL(buf.s) + 1, ZSTR_LEN(buf.s) - 2);
         smart_str_free(&buf);
     }
@@ -470,12 +470,12 @@ PHP_METHOD(MutateArrayAddUniqueSpec, __construct)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_array_add_unique_spec_ce, getThis(), ZEND_STRL("path"), path);
-    zend_update_property_bool(pcbc_mutate_array_add_unique_spec_ce, getThis(), ZEND_STRL("is_xattr"),
+    pcbc_update_property_str(pcbc_mutate_array_add_unique_spec_ce, getThis(), ("path"), path);
+    pcbc_update_property_bool(pcbc_mutate_array_add_unique_spec_ce, getThis(), ("is_xattr"),
                               is_xattr);
-    zend_update_property_bool(pcbc_mutate_array_add_unique_spec_ce, getThis(), ZEND_STRL("create_path"),
+    pcbc_update_property_bool(pcbc_mutate_array_add_unique_spec_ce, getThis(), ("create_path"),
                               create_path);
-    zend_update_property_bool(pcbc_mutate_array_add_unique_spec_ce, getThis(), ZEND_STRL("expand_macros"),
+    pcbc_update_property_bool(pcbc_mutate_array_add_unique_spec_ce, getThis(), ("expand_macros"),
                               expand_macros);
     {
         smart_str buf = {0};
@@ -487,7 +487,7 @@ PHP_METHOD(MutateArrayAddUniqueSpec, __construct)
             RETURN_NULL();
         }
         smart_str_0(&buf);
-        zend_update_property_str(pcbc_mutate_array_add_unique_spec_ce, getThis(), ZEND_STRL("value"), buf.s);
+        pcbc_update_property_str(pcbc_mutate_array_add_unique_spec_ce, getThis(), ("value"), buf.s);
         smart_str_free(&buf);
     }
 }
@@ -502,10 +502,10 @@ PHP_METHOD(MutateCounterSpec, __construct)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_mutate_counter_spec_ce, getThis(), ZEND_STRL("path"), path);
-    zend_update_property_long(pcbc_mutate_counter_spec_ce, getThis(), ZEND_STRL("delta"), delta);
-    zend_update_property_bool(pcbc_mutate_counter_spec_ce, getThis(), ZEND_STRL("is_xattr"), is_xattr);
-    zend_update_property_bool(pcbc_mutate_counter_spec_ce, getThis(), ZEND_STRL("create_path"), create_path);
+    pcbc_update_property_str(pcbc_mutate_counter_spec_ce, getThis(), ("path"), path);
+    pcbc_update_property_long(pcbc_mutate_counter_spec_ce, getThis(), ("delta"), delta);
+    pcbc_update_property_bool(pcbc_mutate_counter_spec_ce, getThis(), ("is_xattr"), is_xattr);
+    pcbc_update_property_bool(pcbc_mutate_counter_spec_ce, getThis(), ("create_path"), create_path);
 }
 
 /*

--- a/src/couchbase/mutation_state.c
+++ b/src/couchbase/mutation_state.c
@@ -28,7 +28,7 @@ PHP_METHOD(MutationState, add)
     zval *source;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "O", &source, pcbc_mutation_result_ce);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O", &source, pcbc_mutation_result_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -36,7 +36,7 @@ PHP_METHOD(MutationState, add)
     zval fname;
     zval retval;
     PCBC_STRING(fname, "mutationToken");
-    rv = call_user_function_ex(EG(function_table), source, &fname, &retval, 0, NULL, 1, NULL TSRMLS_CC);
+    rv = call_user_function_ex(EG(function_table), source, &fname, &retval, 0, NULL, 1, NULL);
     if (rv == FAILURE || EG(exception) || Z_ISUNDEF(retval)) {
         RETURN_NULL();
     }
@@ -46,7 +46,7 @@ PHP_METHOD(MutationState, add)
     if (Z_TYPE_P(tokens) == IS_NULL) {
         array_init(&rv1);
         tokens = &rv1;
-        zend_update_property(pcbc_mutation_state_ce, getThis(), ZEND_STRL("tokens"), tokens TSRMLS_CC);
+        zend_update_property(pcbc_mutation_state_ce, getThis(), ZEND_STRL("tokens"), tokens);
         Z_DELREF_P(tokens);
     }
     add_next_index_zval(tokens, &retval);
@@ -54,7 +54,7 @@ PHP_METHOD(MutationState, add)
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
-void pcbc_mutation_state_export_for_n1ql(zval *mutation_state, zval *scan_vectors TSRMLS_DC)
+void pcbc_mutation_state_export_for_n1ql(zval *mutation_state, zval *scan_vectors)
 {
     array_init(scan_vectors);
 
@@ -68,7 +68,7 @@ void pcbc_mutation_state_export_for_n1ql(zval *mutation_state, zval *scan_vector
         {
             zval bucket;
             PCBC_STRING(fname, "bucketName");
-            call_user_function_ex(EG(function_table), token, &fname, &bucket, 0, NULL, 1, NULL TSRMLS_CC);
+            call_user_function_ex(EG(function_table), token, &fname, &bucket, 0, NULL, 1, NULL);
 
             zval new_group;
             zval *bucket_group = zend_symtable_str_find(Z_ARRVAL_P(scan_vectors), Z_STRVAL(bucket), Z_STRLEN(bucket));
@@ -85,7 +85,7 @@ void pcbc_mutation_state_export_for_n1ql(zval *mutation_state, zval *scan_vector
 
             zval seqno;
             PCBC_STRING(fname, "sequenceNumber");
-            call_user_function_ex(EG(function_table), token, &fname, &seqno, 0, NULL, 1, NULL TSRMLS_CC);
+            call_user_function_ex(EG(function_table), token, &fname, &seqno, 0, NULL, 1, NULL);
             decoded = php_base64_decode_str(Z_STR(seqno));
             if (decoded) {
                 if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
@@ -100,7 +100,7 @@ void pcbc_mutation_state_export_for_n1ql(zval *mutation_state, zval *scan_vector
 
             zval vb_uuid;
             PCBC_STRING(fname, "partitionUuid");
-            call_user_function_ex(EG(function_table), token, &fname, &vb_uuid, 0, NULL, 1, NULL TSRMLS_CC);
+            call_user_function_ex(EG(function_table), token, &fname, &vb_uuid, 0, NULL, 1, NULL);
             decoded = php_base64_decode_str(Z_STR(vb_uuid));
             if (decoded) {
                 if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
@@ -114,16 +114,16 @@ void pcbc_mutation_state_export_for_n1ql(zval *mutation_state, zval *scan_vector
 
             zval vb_id;
             PCBC_STRING(fname, "partitionId");
-            call_user_function_ex(EG(function_table), token, &fname, &vb_id, 0, NULL, 1, NULL TSRMLS_CC);
+            call_user_function_ex(EG(function_table), token, &fname, &vb_id, 0, NULL, 1, NULL);
 
             snprintf(buf, 21, "%d", (int)Z_LVAL(vb_id));
-            zend_hash_str_update(Z_ARRVAL_P(bucket_group), buf, strlen(buf), &pair TSRMLS_CC);
+            zend_hash_str_update(Z_ARRVAL_P(bucket_group), buf, strlen(buf), &pair);
         }
         ZEND_HASH_FOREACH_END();
     }
 }
 
-void pcbc_mutation_state_export_for_search(zval *mutation_state, zval *scan_vectors TSRMLS_DC)
+void pcbc_mutation_state_export_for_search(zval *mutation_state, zval *scan_vectors)
 {
     array_init(scan_vectors);
 
@@ -141,11 +141,11 @@ void pcbc_mutation_state_export_for_search(zval *mutation_state, zval *scan_vect
 
             zval vb_id;
             PCBC_STRING(fname, "partitionId");
-            call_user_function_ex(EG(function_table), token, &fname, &vb_id, 0, NULL, 1, NULL TSRMLS_CC);
+            call_user_function_ex(EG(function_table), token, &fname, &vb_id, 0, NULL, 1, NULL);
 
             zval vb_uuid;
             PCBC_STRING(fname, "partitionUuid");
-            call_user_function_ex(EG(function_table), token, &fname, &vb_uuid, 0, NULL, 1, NULL TSRMLS_CC);
+            call_user_function_ex(EG(function_table), token, &fname, &vb_uuid, 0, NULL, 1, NULL);
             decoded = php_base64_decode_str(Z_STR(vb_uuid));
             if (decoded) {
                 if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
@@ -158,7 +158,7 @@ void pcbc_mutation_state_export_for_search(zval *mutation_state, zval *scan_vect
 
             zval seqno;
             PCBC_STRING(fname, "sequenceNumber");
-            call_user_function_ex(EG(function_table), token, &fname, &seqno, 0, NULL, 1, NULL TSRMLS_CC);
+            call_user_function_ex(EG(function_table), token, &fname, &seqno, 0, NULL, 1, NULL);
             decoded = php_base64_decode_str(Z_STR(seqno));
             if (decoded) {
                 if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
@@ -195,8 +195,8 @@ PHP_MINIT_FUNCTION(MutationState)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutationState", mutation_state_methods);
-    pcbc_mutation_state_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutation_state_ce, ZEND_STRL("tokens"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutation_state_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_mutation_state_ce, ZEND_STRL("tokens"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/mutation_state.c
+++ b/src/couchbase/mutation_state.c
@@ -36,7 +36,7 @@ PHP_METHOD(MutationState, add)
     zval fname;
     zval retval;
     PCBC_STRING(fname, "mutationToken");
-    rv = call_user_function_ex(EG(function_table), source, &fname, &retval, 0, NULL, 1, NULL);
+    rv = call_user_function(EG(function_table), source, &fname, &retval, 0, NULL);
     if (rv == FAILURE || EG(exception) || Z_ISUNDEF(retval)) {
         RETURN_NULL();
     }
@@ -68,7 +68,7 @@ void pcbc_mutation_state_export_for_n1ql(zval *mutation_state, zval *scan_vector
         {
             zval bucket;
             PCBC_STRING(fname, "bucketName");
-            call_user_function_ex(EG(function_table), token, &fname, &bucket, 0, NULL, 1, NULL);
+            call_user_function(EG(function_table), token, &fname, &bucket, 0, NULL);
 
             zval new_group;
             zval *bucket_group = zend_symtable_str_find(Z_ARRVAL_P(scan_vectors), Z_STRVAL(bucket), Z_STRLEN(bucket));
@@ -85,7 +85,7 @@ void pcbc_mutation_state_export_for_n1ql(zval *mutation_state, zval *scan_vector
 
             zval seqno;
             PCBC_STRING(fname, "sequenceNumber");
-            call_user_function_ex(EG(function_table), token, &fname, &seqno, 0, NULL, 1, NULL);
+            call_user_function(EG(function_table), token, &fname, &seqno, 0, NULL);
             decoded = php_base64_decode_str(Z_STR(seqno));
             if (decoded) {
                 if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
@@ -100,7 +100,7 @@ void pcbc_mutation_state_export_for_n1ql(zval *mutation_state, zval *scan_vector
 
             zval vb_uuid;
             PCBC_STRING(fname, "partitionUuid");
-            call_user_function_ex(EG(function_table), token, &fname, &vb_uuid, 0, NULL, 1, NULL);
+            call_user_function(EG(function_table), token, &fname, &vb_uuid, 0, NULL);
             decoded = php_base64_decode_str(Z_STR(vb_uuid));
             if (decoded) {
                 if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
@@ -114,7 +114,7 @@ void pcbc_mutation_state_export_for_n1ql(zval *mutation_state, zval *scan_vector
 
             zval vb_id;
             PCBC_STRING(fname, "partitionId");
-            call_user_function_ex(EG(function_table), token, &fname, &vb_id, 0, NULL, 1, NULL);
+            call_user_function(EG(function_table), token, &fname, &vb_id, 0, NULL);
 
             snprintf(buf, 21, "%d", (int)Z_LVAL(vb_id));
             zend_hash_str_update(Z_ARRVAL_P(bucket_group), buf, strlen(buf), &pair);
@@ -141,11 +141,11 @@ void pcbc_mutation_state_export_for_search(zval *mutation_state, zval *scan_vect
 
             zval vb_id;
             PCBC_STRING(fname, "partitionId");
-            call_user_function_ex(EG(function_table), token, &fname, &vb_id, 0, NULL, 1, NULL);
+            call_user_function(EG(function_table), token, &fname, &vb_id, 0, NULL);
 
             zval vb_uuid;
             PCBC_STRING(fname, "partitionUuid");
-            call_user_function_ex(EG(function_table), token, &fname, &vb_uuid, 0, NULL, 1, NULL);
+            call_user_function(EG(function_table), token, &fname, &vb_uuid, 0, NULL);
             decoded = php_base64_decode_str(Z_STR(vb_uuid));
             if (decoded) {
                 if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {
@@ -158,7 +158,7 @@ void pcbc_mutation_state_export_for_search(zval *mutation_state, zval *scan_vect
 
             zval seqno;
             PCBC_STRING(fname, "sequenceNumber");
-            call_user_function_ex(EG(function_table), token, &fname, &seqno, 0, NULL, 1, NULL);
+            call_user_function(EG(function_table), token, &fname, &seqno, 0, NULL);
             decoded = php_base64_decode_str(Z_STR(seqno));
             if (decoded) {
                 if (ZSTR_LEN(decoded) == sizeof(uint64_t)) {

--- a/src/couchbase/mutation_state.c
+++ b/src/couchbase/mutation_state.c
@@ -42,11 +42,11 @@ PHP_METHOD(MutationState, add)
     }
 
     zval *tokens, rv1;
-    tokens = zend_read_property(pcbc_mutation_state_ce, getThis(), ZEND_STRL("tokens"), 0, &rv1);
+    tokens = pcbc_read_property(pcbc_mutation_state_ce, getThis(), ("tokens"), 0, &rv1);
     if (Z_TYPE_P(tokens) == IS_NULL) {
         array_init(&rv1);
         tokens = &rv1;
-        zend_update_property(pcbc_mutation_state_ce, getThis(), ZEND_STRL("tokens"), tokens);
+        pcbc_update_property(pcbc_mutation_state_ce, getThis(), ("tokens"), tokens);
         Z_DELREF_P(tokens);
     }
     add_next_index_zval(tokens, &retval);
@@ -60,7 +60,7 @@ void pcbc_mutation_state_export_for_n1ql(zval *mutation_state, zval *scan_vector
 
     zval *tokens, rv1;
     zval fname;
-    tokens = zend_read_property(pcbc_mutation_state_ce, mutation_state, ZEND_STRL("tokens"), 0, &rv1);
+    tokens = pcbc_read_property(pcbc_mutation_state_ce, mutation_state, ("tokens"), 0, &rv1);
     if (Z_TYPE_P(tokens) == IS_ARRAY) {
         HashTable *ht = HASH_OF(tokens);
         zval *token;
@@ -129,7 +129,7 @@ void pcbc_mutation_state_export_for_search(zval *mutation_state, zval *scan_vect
 
     zval *tokens, rv1;
     zval fname;
-    tokens = zend_read_property(pcbc_mutation_state_ce, mutation_state, ZEND_STRL("tokens"), 0, &rv1);
+    tokens = pcbc_read_property(pcbc_mutation_state_ce, mutation_state, ("tokens"), 0, &rv1);
     if (Z_TYPE_P(tokens) == IS_ARRAY) {
         HashTable *ht = HASH_OF(tokens);
         zval *token;

--- a/src/couchbase/password_authenticator.c
+++ b/src/couchbase/password_authenticator.c
@@ -41,7 +41,7 @@ PHP_METHOD(PasswordAuthenticator, __construct)
 }
 
 void pcbc_password_authenticator_init(zval *return_value, char *username, int username_len, char *password,
-                                      int password_len TSRMLS_DC)
+                                      int password_len)
 {
     pcbc_password_authenticator_t *obj;
 
@@ -60,7 +60,7 @@ PHP_METHOD(PasswordAuthenticator, username)
     size_t username_len;
     int rv;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &username, &username_len);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "s", &username, &username_len);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -83,7 +83,7 @@ PHP_METHOD(PasswordAuthenticator, password)
     size_t password_len;
     int rv;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &password, &password_len);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "s", &password, &password_len);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -100,7 +100,7 @@ PHP_METHOD(PasswordAuthenticator, password)
 }
 
 void pcbc_generate_password_lcb_auth(pcbc_password_authenticator_t *auth, lcb_AUTHENTICATOR **result,
-                                     lcb_INSTANCE_TYPE type, char **hash TSRMLS_DC)
+                                     lcb_INSTANCE_TYPE type, char **hash)
 {
     PHP_MD5_CTX md5;
     unsigned char digest[16];
@@ -141,7 +141,7 @@ zend_function_entry password_authenticator_methods[] = {
 
 zend_object_handlers password_authenticator_handlers;
 
-static void password_authenticator_free_object(zend_object *object TSRMLS_DC)
+static void password_authenticator_free_object(zend_object *object)
 {
     pcbc_password_authenticator_t *obj = Z_PASSWORD_AUTHENTICATOR_OBJ(object);
 
@@ -152,23 +152,23 @@ static void password_authenticator_free_object(zend_object *object TSRMLS_DC)
         efree(obj->password);
     }
 
-    zend_object_std_dtor(&obj->std TSRMLS_CC);
+    zend_object_std_dtor(&obj->std);
 }
 
-static zend_object *authenticator_create_object(zend_class_entry *class_type TSRMLS_DC)
+static zend_object *authenticator_create_object(zend_class_entry *class_type)
 {
     pcbc_password_authenticator_t *obj = NULL;
 
     obj = PCBC_ALLOC_OBJECT_T(pcbc_password_authenticator_t, class_type);
 
-    zend_object_std_init(&obj->std, class_type TSRMLS_CC);
+    zend_object_std_init(&obj->std, class_type);
     object_properties_init(&obj->std, class_type);
 
     obj->std.handlers = &password_authenticator_handlers;
     return &obj->std;
 }
 
-static HashTable *pcbc_password_authenticator_get_debug_info(zval *object, int *is_temp TSRMLS_DC)
+static HashTable *pcbc_password_authenticator_get_debug_info(zval *object, int *is_temp)
 {
     pcbc_password_authenticator_t *obj = NULL;
     zval retval;
@@ -188,11 +188,11 @@ PHP_MINIT_FUNCTION(PasswordAuthenticator)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "PasswordAuthenticator", password_authenticator_methods);
-    pcbc_password_authenticator_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_password_authenticator_ce = zend_register_internal_class(&ce);
     pcbc_password_authenticator_ce->create_object = authenticator_create_object;
     PCBC_CE_DISABLE_SERIALIZATION(pcbc_password_authenticator_ce);
 
-    zend_class_implements(pcbc_password_authenticator_ce TSRMLS_CC, 1, pcbc_authenticator_ce);
+    zend_class_implements(pcbc_password_authenticator_ce, 1, pcbc_authenticator_ce);
 
     memcpy(&password_authenticator_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     password_authenticator_handlers.get_debug_info = pcbc_password_authenticator_get_debug_info;

--- a/src/couchbase/password_authenticator.c
+++ b/src/couchbase/password_authenticator.c
@@ -168,13 +168,19 @@ static zend_object *authenticator_create_object(zend_class_entry *class_type)
     return &obj->std;
 }
 
+
+#if PHP_VERSION_ID < 80000
 static HashTable *pcbc_password_authenticator_get_debug_info(zval *object, int *is_temp)
 {
-    pcbc_password_authenticator_t *obj = NULL;
+    pcbc_password_authenticator_t *obj = Z_PASSWORD_AUTHENTICATOR_OBJ_P(object);
+#else
+static HashTable *pcbc_password_authenticator_get_debug_info(zend_object *object, int *is_temp)
+{
+    pcbc_password_authenticator_t *obj = pcbc_password_authenticator_fetch_object(object);
+#endif
     zval retval;
 
     *is_temp = 1;
-    obj = Z_PASSWORD_AUTHENTICATOR_OBJ_P(object);
 
     array_init(&retval);
     if (obj->username) {

--- a/src/couchbase/result.c
+++ b/src/couchbase/result.c
@@ -788,7 +788,7 @@ PHP_METHOD(MutationTokenImpl, partitionId)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_mutation_token_impl_ce, getThis(), ZEND_STRL("partition_id"), 0, &rv);
+    prop = pcbc_read_property(pcbc_mutation_token_impl_ce, getThis(), ("partition_id"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -799,7 +799,7 @@ PHP_METHOD(MutationTokenImpl, partitionUuid)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_mutation_token_impl_ce, getThis(), ZEND_STRL("partition_uuid"), 0, &rv);
+    prop = pcbc_read_property(pcbc_mutation_token_impl_ce, getThis(), ("partition_uuid"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -810,7 +810,7 @@ PHP_METHOD(MutationTokenImpl, sequenceNumber)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_mutation_token_impl_ce, getThis(), ZEND_STRL("sequence_number"), 0, &rv);
+    prop = pcbc_read_property(pcbc_mutation_token_impl_ce, getThis(), ("sequence_number"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -821,7 +821,7 @@ PHP_METHOD(MutationTokenImpl, bucketName)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_mutation_token_impl_ce, getThis(), ZEND_STRL("bucket_name"), 0, &rv);
+    prop = pcbc_read_property(pcbc_mutation_token_impl_ce, getThis(), ("bucket_name"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -832,7 +832,7 @@ PHP_METHOD(ResultImpl, cas)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_result_impl_ce, getThis(), ZEND_STRL("cas"), 0, &rv);
+    prop = pcbc_read_property(pcbc_result_impl_ce, getThis(), ("cas"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -843,7 +843,7 @@ PHP_METHOD(GetResultImpl, cas)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_get_result_impl_ce, getThis(), ZEND_STRL("cas"), 0, &rv);
+    prop = pcbc_read_property(pcbc_get_result_impl_ce, getThis(), ("cas"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -854,7 +854,7 @@ PHP_METHOD(GetResultImpl, expiry)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_get_result_impl_ce, getThis(), ZEND_STRL("expiry"), 0, &rv);
+    prop = pcbc_read_property(pcbc_get_result_impl_ce, getThis(), ("expiry"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -865,7 +865,7 @@ PHP_METHOD(GetResultImpl, content)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_get_result_impl_ce, getThis(), ZEND_STRL("data"), 0, &rv);
+    prop = pcbc_read_property(pcbc_get_result_impl_ce, getThis(), ("data"), 0, &rv);
     PCBC_JSON_RESET_STATE;
     if (php_json_decode_ex(return_value, Z_STRVAL_P(prop), Z_STRLEN_P(prop), PHP_JSON_OBJECT_AS_ARRAY,
                            PHP_JSON_PARSER_DEFAULT_DEPTH)) {
@@ -880,7 +880,7 @@ PHP_METHOD(GetReplicaResultImpl, cas)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_get_replica_result_impl_ce, getThis(), ZEND_STRL("cas"), 0, &rv);
+    prop = pcbc_read_property(pcbc_get_replica_result_impl_ce, getThis(), ("cas"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -891,7 +891,7 @@ PHP_METHOD(GetReplicaResultImpl, expiry)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_get_replica_result_impl_ce, getThis(), ZEND_STRL("expiry"), 0, &rv);
+    prop = pcbc_read_property(pcbc_get_replica_result_impl_ce, getThis(), ("expiry"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -902,7 +902,7 @@ PHP_METHOD(GetReplicaResultImpl, content)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_get_replica_result_impl_ce, getThis(), ZEND_STRL("data"), 0, &rv);
+    prop = pcbc_read_property(pcbc_get_replica_result_impl_ce, getThis(), ("data"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -913,7 +913,7 @@ PHP_METHOD(GetReplicaResultImpl, isReplica)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_get_replica_result_impl_ce, getThis(), ZEND_STRL("is_replica"), 0, &rv);
+    prop = pcbc_read_property(pcbc_get_replica_result_impl_ce, getThis(), ("is_replica"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -924,7 +924,7 @@ PHP_METHOD(ExistsResultImpl, cas)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_exists_result_impl_ce, getThis(), ZEND_STRL("cas"), 0, &rv);
+    prop = pcbc_read_property(pcbc_exists_result_impl_ce, getThis(), ("cas"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -935,7 +935,7 @@ PHP_METHOD(ExistsResultImpl, expiry)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_exists_result_impl_ce, getThis(), ZEND_STRL("expiry"), 0, &rv);
+    prop = pcbc_read_property(pcbc_exists_result_impl_ce, getThis(), ("expiry"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -946,7 +946,7 @@ PHP_METHOD(ExistsResultImpl, exists)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_exists_result_impl_ce, getThis(), ZEND_STRL("is_found"), 0, &rv);
+    prop = pcbc_read_property(pcbc_exists_result_impl_ce, getThis(), ("is_found"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -957,7 +957,7 @@ PHP_METHOD(MutationResultImpl, cas)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_mutation_result_impl_ce, getThis(), ZEND_STRL("cas"), 0, &rv);
+    prop = pcbc_read_property(pcbc_mutation_result_impl_ce, getThis(), ("cas"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -968,7 +968,7 @@ PHP_METHOD(MutationResultImpl, expiry)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_mutation_result_impl_ce, getThis(), ZEND_STRL("expiry"), 0, &rv);
+    prop = pcbc_read_property(pcbc_mutation_result_impl_ce, getThis(), ("expiry"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -979,7 +979,7 @@ PHP_METHOD(MutationResultImpl, mutationToken)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_mutation_result_impl_ce, getThis(), ZEND_STRL("mutation_token"), 0, &rv);
+    prop = pcbc_read_property(pcbc_mutation_result_impl_ce, getThis(), ("mutation_token"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -990,7 +990,7 @@ PHP_METHOD(StoreResultImpl, cas)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_store_result_impl_ce, getThis(), ZEND_STRL("cas"), 0, &rv);
+    prop = pcbc_read_property(pcbc_store_result_impl_ce, getThis(), ("cas"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1001,7 +1001,7 @@ PHP_METHOD(StoreResultImpl, expiry)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_store_result_impl_ce, getThis(), ZEND_STRL("expiry"), 0, &rv);
+    prop = pcbc_read_property(pcbc_store_result_impl_ce, getThis(), ("expiry"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1012,7 +1012,7 @@ PHP_METHOD(StoreResultImpl, mutationToken)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_store_result_impl_ce, getThis(), ZEND_STRL("mutation_token"), 0, &rv);
+    prop = pcbc_read_property(pcbc_store_result_impl_ce, getThis(), ("mutation_token"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1023,7 +1023,7 @@ PHP_METHOD(CounterResultImpl, cas)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_counter_result_impl_ce, getThis(), ZEND_STRL("cas"), 0, &rv);
+    prop = pcbc_read_property(pcbc_counter_result_impl_ce, getThis(), ("cas"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1034,7 +1034,7 @@ PHP_METHOD(CounterResultImpl, expiry)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_counter_result_impl_ce, getThis(), ZEND_STRL("expiry"), 0, &rv);
+    prop = pcbc_read_property(pcbc_counter_result_impl_ce, getThis(), ("expiry"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1045,7 +1045,7 @@ PHP_METHOD(CounterResultImpl, mutationToken)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_counter_result_impl_ce, getThis(), ZEND_STRL("mutation_token"), 0, &rv);
+    prop = pcbc_read_property(pcbc_counter_result_impl_ce, getThis(), ("mutation_token"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1056,7 +1056,7 @@ PHP_METHOD(CounterResultImpl, content)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_counter_result_impl_ce, getThis(), ZEND_STRL("content"), 0, &rv);
+    prop = pcbc_read_property(pcbc_counter_result_impl_ce, getThis(), ("content"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1067,7 +1067,7 @@ PHP_METHOD(LookupInResultImpl, cas)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_lookup_in_result_impl_ce, getThis(), ZEND_STRL("cas"), 0, &rv);
+    prop = pcbc_read_property(pcbc_lookup_in_result_impl_ce, getThis(), ("cas"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1078,7 +1078,7 @@ PHP_METHOD(LookupInResultImpl, expiry)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_lookup_in_result_impl_ce, getThis(), ZEND_STRL("expiry"), 0, &rv);
+    prop = pcbc_read_property(pcbc_lookup_in_result_impl_ce, getThis(), ("expiry"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1090,11 +1090,11 @@ PHP_METHOD(LookupInResultImpl, content)
         RETURN_NULL();
     }
     zval *data, rv1, rv2;
-    data = zend_read_property(pcbc_lookup_in_result_impl_ce, getThis(), ZEND_STRL("data"), 0, &rv1);
+    data = pcbc_read_property(pcbc_lookup_in_result_impl_ce, getThis(), ("data"), 0, &rv1);
     if (idx < zend_hash_num_elements(Z_ARRVAL_P(data))) {
         zval *entry = zend_hash_index_find(Z_ARRVAL_P(data), idx);
         if (Z_OBJCE_P(entry) == pcbc_lookup_in_result_entry_ce) {
-            zval *value = zend_read_property(pcbc_lookup_in_result_entry_ce, entry, ZEND_STRL("value"), 0, &rv2);
+            zval *value = pcbc_read_property(pcbc_lookup_in_result_entry_ce, entry, ("value"), 0, &rv2);
             ZVAL_DEREF(value);
             ZVAL_COPY(return_value, value);
             return;
@@ -1113,11 +1113,11 @@ PHP_METHOD(LookupInResultImpl, exists)
     }
 
     zval *data, rv1, rv2;
-    data = zend_read_property(pcbc_lookup_in_result_impl_ce, getThis(), ZEND_STRL("data"), 0, &rv1);
+    data = pcbc_read_property(pcbc_lookup_in_result_impl_ce, getThis(), ("data"), 0, &rv1);
     if (idx < zend_hash_num_elements(Z_ARRVAL_P(data))) {
         zval *entry = zend_hash_index_find(Z_ARRVAL_P(data), idx);
         if (Z_OBJCE_P(entry) == pcbc_lookup_in_result_entry_ce) {
-            zval *code = zend_read_property(pcbc_lookup_in_result_entry_ce, entry, ZEND_STRL("code"), 0, &rv2);
+            zval *code = pcbc_read_property(pcbc_lookup_in_result_entry_ce, entry, ("code"), 0, &rv2);
             if (Z_LVAL_P(code) == 0) {
                 RETURN_TRUE;
             }
@@ -1135,11 +1135,11 @@ PHP_METHOD(LookupInResultImpl, status)
     }
 
     zval *data, rv1, rv2;
-    data = zend_read_property(pcbc_lookup_in_result_impl_ce, getThis(), ZEND_STRL("data"), 0, &rv1);
+    data = pcbc_read_property(pcbc_lookup_in_result_impl_ce, getThis(), ("data"), 0, &rv1);
     if (idx < zend_hash_num_elements(Z_ARRVAL_P(data))) {
         zval *entry = zend_hash_index_find(Z_ARRVAL_P(data), idx);
         if (Z_OBJCE_P(entry) == pcbc_lookup_in_result_entry_ce) {
-            zval *code = zend_read_property(pcbc_lookup_in_result_entry_ce, entry, ZEND_STRL("code"), 0, &rv2);
+            zval *code = pcbc_read_property(pcbc_lookup_in_result_entry_ce, entry, ("code"), 0, &rv2);
             ZVAL_DEREF(code);
             ZVAL_COPY(return_value, code);
             return;
@@ -1155,7 +1155,7 @@ PHP_METHOD(MutateInResultImpl, mutationToken)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_mutate_in_result_impl_ce, getThis(), ZEND_STRL("mutation_token"), 0, &rv);
+    prop = pcbc_read_property(pcbc_mutate_in_result_impl_ce, getThis(), ("mutation_token"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1166,7 +1166,7 @@ PHP_METHOD(MutateInResultImpl, cas)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_mutate_in_result_impl_ce, getThis(), ZEND_STRL("cas"), 0, &rv);
+    prop = pcbc_read_property(pcbc_mutate_in_result_impl_ce, getThis(), ("cas"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1177,7 +1177,7 @@ PHP_METHOD(MutateInResultImpl, expiry)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_mutate_in_result_impl_ce, getThis(), ZEND_STRL("expiry"), 0, &rv);
+    prop = pcbc_read_property(pcbc_mutate_in_result_impl_ce, getThis(), ("expiry"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1189,11 +1189,11 @@ PHP_METHOD(MutateInResultImpl, content)
         RETURN_NULL();
     }
     zval *data, rv1, rv2;
-    data = zend_read_property(pcbc_mutate_in_result_impl_ce, getThis(), ZEND_STRL("data"), 0, &rv1);
+    data = pcbc_read_property(pcbc_mutate_in_result_impl_ce, getThis(), ("data"), 0, &rv1);
     if (idx < zend_hash_num_elements(Z_ARRVAL_P(data))) {
         zval *entry = zend_hash_index_find(Z_ARRVAL_P(data), idx);
         if (Z_OBJCE_P(entry) == pcbc_mutate_in_result_entry_ce) {
-            zval *value = zend_read_property(pcbc_mutate_in_result_entry_ce, entry, ZEND_STRL("value"), 0, &rv2);
+            zval *value = pcbc_read_property(pcbc_mutate_in_result_entry_ce, entry, ("value"), 0, &rv2);
             ZVAL_DEREF(value);
             ZVAL_COPY(return_value, value);
             return;
@@ -1212,11 +1212,11 @@ PHP_METHOD(MutateInResultImpl, status)
     }
 
     zval *data, rv1, rv2;
-    data = zend_read_property(pcbc_mutate_in_result_impl_ce, getThis(), ZEND_STRL("data"), 0, &rv1);
+    data = pcbc_read_property(pcbc_mutate_in_result_impl_ce, getThis(), ("data"), 0, &rv1);
     if (idx < zend_hash_num_elements(Z_ARRVAL_P(data))) {
         zval *entry = zend_hash_index_find(Z_ARRVAL_P(data), idx);
         if (Z_OBJCE_P(entry) == pcbc_mutate_in_result_entry_ce) {
-            zval *code = zend_read_property(pcbc_mutate_in_result_entry_ce, entry, ZEND_STRL("code"), 0, &rv2);
+            zval *code = pcbc_read_property(pcbc_mutate_in_result_entry_ce, entry, ("code"), 0, &rv2);
             ZVAL_DEREF(code);
             ZVAL_COPY(return_value, code);
             return;
@@ -1232,7 +1232,7 @@ PHP_METHOD(QueryResultImpl, metaData)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_result_impl_ce, getThis(), ZEND_STRL("meta"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_result_impl_ce, getThis(), ("meta"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1243,7 +1243,7 @@ PHP_METHOD(QueryResultImpl, rows)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_result_impl_ce, getThis(), ZEND_STRL("rows"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_result_impl_ce, getThis(), ("rows"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1254,7 +1254,7 @@ PHP_METHOD(QueryMetaDataImpl, status)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_meta_data_impl_ce, getThis(), ZEND_STRL("status"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_meta_data_impl_ce, getThis(), ("status"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1265,7 +1265,7 @@ PHP_METHOD(QueryMetaDataImpl, requestId)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_meta_data_impl_ce, getThis(), ZEND_STRL("request_id"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_meta_data_impl_ce, getThis(), ("request_id"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1276,7 +1276,7 @@ PHP_METHOD(QueryMetaDataImpl, clientContextId)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_meta_data_impl_ce, getThis(), ZEND_STRL("client_context_id"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_meta_data_impl_ce, getThis(), ("client_context_id"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1287,7 +1287,7 @@ PHP_METHOD(QueryMetaDataImpl, signature)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_meta_data_impl_ce, getThis(), ZEND_STRL("signature"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_meta_data_impl_ce, getThis(), ("signature"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1298,7 +1298,7 @@ PHP_METHOD(QueryMetaDataImpl, errors)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_meta_data_impl_ce, getThis(), ZEND_STRL("errors"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_meta_data_impl_ce, getThis(), ("errors"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1309,7 +1309,7 @@ PHP_METHOD(QueryMetaDataImpl, warnings)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_meta_data_impl_ce, getThis(), ZEND_STRL("warnings"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_meta_data_impl_ce, getThis(), ("warnings"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1320,7 +1320,7 @@ PHP_METHOD(QueryMetaDataImpl, metrics)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_meta_data_impl_ce, getThis(), ZEND_STRL("metrics"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_meta_data_impl_ce, getThis(), ("metrics"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1331,7 +1331,7 @@ PHP_METHOD(QueryMetaDataImpl, profile)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_query_meta_data_impl_ce, getThis(), ZEND_STRL("profile"), 0, &rv);
+    prop = pcbc_read_property(pcbc_query_meta_data_impl_ce, getThis(), ("profile"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1342,7 +1342,7 @@ PHP_METHOD(AnalyticsResultImpl, metaData)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_analytics_result_impl_ce, getThis(), ZEND_STRL("meta"), 0, &rv);
+    prop = pcbc_read_property(pcbc_analytics_result_impl_ce, getThis(), ("meta"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1353,7 +1353,7 @@ PHP_METHOD(AnalyticsResultImpl, rows)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_analytics_result_impl_ce, getThis(), ZEND_STRL("rows"), 0, &rv);
+    prop = pcbc_read_property(pcbc_analytics_result_impl_ce, getThis(), ("rows"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1364,7 +1364,7 @@ PHP_METHOD(SearchMetaDataImpl, successCount)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_meta_data_impl_ce, getThis(), ZEND_STRL("success_count"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_meta_data_impl_ce, getThis(), ("success_count"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1375,7 +1375,7 @@ PHP_METHOD(SearchMetaDataImpl, errorCount)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_meta_data_impl_ce, getThis(), ZEND_STRL("error_count"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_meta_data_impl_ce, getThis(), ("error_count"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1386,7 +1386,7 @@ PHP_METHOD(SearchMetaDataImpl, took)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_meta_data_impl_ce, getThis(), ZEND_STRL("took"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_meta_data_impl_ce, getThis(), ("took"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1397,7 +1397,7 @@ PHP_METHOD(SearchMetaDataImpl, totalHits)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_meta_data_impl_ce, getThis(), ZEND_STRL("total_hits"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_meta_data_impl_ce, getThis(), ("total_hits"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1408,7 +1408,7 @@ PHP_METHOD(SearchMetaDataImpl, maxScore)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_meta_data_impl_ce, getThis(), ZEND_STRL("max_score"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_meta_data_impl_ce, getThis(), ("max_score"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1419,7 +1419,7 @@ PHP_METHOD(SearchMetaDataImpl, metrics)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_meta_data_impl_ce, getThis(), ZEND_STRL("metrics"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_meta_data_impl_ce, getThis(), ("metrics"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1430,7 +1430,7 @@ PHP_METHOD(SearchResultImpl, metaData)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_result_impl_ce, getThis(), ZEND_STRL("meta"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_result_impl_ce, getThis(), ("meta"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1441,7 +1441,7 @@ PHP_METHOD(SearchResultImpl, facets)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_result_impl_ce, getThis(), ZEND_STRL("facets"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_result_impl_ce, getThis(), ("facets"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1452,7 +1452,7 @@ PHP_METHOD(SearchResultImpl, rows)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_search_result_impl_ce, getThis(), ZEND_STRL("rows"), 0, &rv);
+    prop = pcbc_read_property(pcbc_search_result_impl_ce, getThis(), ("rows"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1463,7 +1463,7 @@ PHP_METHOD(ViewMetaDataImpl, totalRows)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_view_meta_data_impl_ce, getThis(), ZEND_STRL("total_rows"), 0, &rv);
+    prop = pcbc_read_property(pcbc_view_meta_data_impl_ce, getThis(), ("total_rows"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1474,7 +1474,7 @@ PHP_METHOD(ViewMetaDataImpl, debug)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_view_meta_data_impl_ce, getThis(), ZEND_STRL("debug"), 0, &rv);
+    prop = pcbc_read_property(pcbc_view_meta_data_impl_ce, getThis(), ("debug"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1485,7 +1485,7 @@ PHP_METHOD(ViewResultImpl, rows)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_view_result_impl_ce, getThis(), ZEND_STRL("rows"), 0, &rv);
+    prop = pcbc_read_property(pcbc_view_result_impl_ce, getThis(), ("rows"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1496,7 +1496,7 @@ PHP_METHOD(ViewResultImpl, metaData)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_view_result_impl_ce, getThis(), ZEND_STRL("meta"), 0, &rv);
+    prop = pcbc_read_property(pcbc_view_result_impl_ce, getThis(), ("meta"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1507,7 +1507,7 @@ PHP_METHOD(ViewRow, id)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_view_result_entry_ce, getThis(), ZEND_STRL("id"), 0, &rv);
+    prop = pcbc_read_property(pcbc_view_result_entry_ce, getThis(), ("id"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1518,7 +1518,7 @@ PHP_METHOD(ViewRow, key)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_view_result_entry_ce, getThis(), ZEND_STRL("key"), 0, &rv);
+    prop = pcbc_read_property(pcbc_view_result_entry_ce, getThis(), ("key"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1529,7 +1529,7 @@ PHP_METHOD(ViewRow, value)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_view_result_entry_ce, getThis(), ZEND_STRL("value"), 0, &rv);
+    prop = pcbc_read_property(pcbc_view_result_entry_ce, getThis(), ("value"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 
@@ -1540,7 +1540,7 @@ PHP_METHOD(ViewRow, document)
     }
 
     zval *prop, rv;
-    prop = zend_read_property(pcbc_view_result_entry_ce, getThis(), ZEND_STRL("document"), 0, &rv);
+    prop = pcbc_read_property(pcbc_view_result_entry_ce, getThis(), ("document"), 0, &rv);
     ZVAL_COPY(return_value, prop);
 }
 

--- a/src/couchbase/result.c
+++ b/src/couchbase/result.c
@@ -534,249 +534,249 @@ PHP_MINIT_FUNCTION(Result)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutationToken", pcbc_mutation_token_methods);
-    pcbc_mutation_token_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_mutation_token_ce = zend_register_internal_interface(&ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutationTokenImpl", pcbc_mutation_token_impl_methods);
-    pcbc_mutation_token_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutation_token_impl_ce TSRMLS_CC, 1, pcbc_mutation_token_ce);
-    zend_declare_property_null(pcbc_mutation_token_impl_ce, ZEND_STRL("partition_id"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutation_token_impl_ce, ZEND_STRL("partition_uuid"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutation_token_impl_ce, ZEND_STRL("sequence_number"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutation_token_impl_ce, ZEND_STRL("bucket_name"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutation_token_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_mutation_token_impl_ce, 1, pcbc_mutation_token_ce);
+    zend_declare_property_null(pcbc_mutation_token_impl_ce, ZEND_STRL("partition_id"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutation_token_impl_ce, ZEND_STRL("partition_uuid"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutation_token_impl_ce, ZEND_STRL("sequence_number"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutation_token_impl_ce, ZEND_STRL("bucket_name"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "QueryMetaData", pcbc_query_meta_data_methods);
-    pcbc_query_meta_data_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_query_meta_data_ce = zend_register_internal_interface(&ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "QueryMetaDataImpl", pcbc_query_meta_data_impl_methods);
-    pcbc_query_meta_data_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_query_meta_data_impl_ce TSRMLS_CC, 1, pcbc_query_meta_data_ce);
-    zend_declare_property_null(pcbc_query_meta_data_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_meta_data_impl_ce, ZEND_STRL("request_id"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_query_meta_data_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_query_meta_data_impl_ce, 1, pcbc_query_meta_data_ce);
+    zend_declare_property_null(pcbc_query_meta_data_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_meta_data_impl_ce, ZEND_STRL("request_id"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_query_meta_data_impl_ce, ZEND_STRL("client_context_id"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_meta_data_impl_ce, ZEND_STRL("signature"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_meta_data_impl_ce, ZEND_STRL("errors"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_meta_data_impl_ce, ZEND_STRL("warnings"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_meta_data_impl_ce, ZEND_STRL("metrics"), ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_meta_data_impl_ce, ZEND_STRL("signature"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_meta_data_impl_ce, ZEND_STRL("errors"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_meta_data_impl_ce, ZEND_STRL("warnings"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_meta_data_impl_ce, ZEND_STRL("metrics"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchMetaData", pcbc_search_meta_data_methods);
-    pcbc_search_meta_data_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_search_meta_data_ce = zend_register_internal_interface(&ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchMetaDataImpl", pcbc_search_meta_data_impl_methods);
-    pcbc_search_meta_data_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_search_meta_data_impl_ce TSRMLS_CC, 1, pcbc_search_meta_data_ce);
-    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("success_count"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("error_count"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("took"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("total_hits"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("max_score"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("metrics"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_search_meta_data_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_search_meta_data_impl_ce, 1, pcbc_search_meta_data_ce);
+    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("success_count"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("error_count"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("took"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("total_hits"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("max_score"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("metrics"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_meta_data_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ViewMetaData", pcbc_view_meta_data_methods);
-    pcbc_view_meta_data_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_view_meta_data_ce = zend_register_internal_interface(&ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ViewMetaDataImpl", pcbc_view_meta_data_impl_methods);
-    pcbc_view_meta_data_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_view_meta_data_impl_ce TSRMLS_CC, 1, pcbc_view_meta_data_ce);
-    zend_declare_property_null(pcbc_view_meta_data_impl_ce, ZEND_STRL("total_rows"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_meta_data_impl_ce, ZEND_STRL("debug"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_view_meta_data_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_view_meta_data_impl_ce, 1, pcbc_view_meta_data_ce);
+    zend_declare_property_null(pcbc_view_meta_data_impl_ce, ZEND_STRL("total_rows"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_meta_data_impl_ce, ZEND_STRL("debug"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "Result", pcbc_result_methods);
-    pcbc_result_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_result_ce = zend_register_internal_interface(&ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ResultImpl", pcbc_result_impl_methods);
-    pcbc_result_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_result_impl_ce TSRMLS_CC, 1, pcbc_result_ce);
-    zend_declare_property_null(pcbc_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_result_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_result_impl_ce, 1, pcbc_result_ce);
+    zend_declare_property_null(pcbc_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GetResult", pcbc_get_result_methods);
-    pcbc_get_result_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_get_result_ce TSRMLS_CC, 1, pcbc_result_ce);
+    pcbc_get_result_ce = zend_register_internal_interface(&ce);
+    zend_class_implements(pcbc_get_result_ce, 1, pcbc_result_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GetResultImpl", pcbc_get_result_impl_methods);
-    pcbc_get_result_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_get_result_impl_ce TSRMLS_CC, 1, pcbc_get_result_ce);
-    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("data"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_get_result_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_get_result_impl_ce, 1, pcbc_get_result_ce);
+    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("data"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GetReplicaResult", pcbc_get_replica_result_methods);
-    pcbc_get_replica_result_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_get_replica_result_ce TSRMLS_CC, 1, pcbc_result_ce);
+    pcbc_get_replica_result_ce = zend_register_internal_interface(&ce);
+    zend_class_implements(pcbc_get_replica_result_ce, 1, pcbc_result_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GetReplicaResultImpl", pcbc_get_replica_result_impl_methods);
-    pcbc_get_replica_result_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_get_replica_result_impl_ce TSRMLS_CC, 1, pcbc_get_replica_result_ce);
-    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("data"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("is_replica"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_get_replica_result_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_get_replica_result_impl_ce, 1, pcbc_get_replica_result_ce);
+    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("data"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_get_replica_result_impl_ce, ZEND_STRL("is_replica"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ExistsResult", pcbc_exists_result_methods);
-    pcbc_exists_result_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_exists_result_ce TSRMLS_CC, 1, pcbc_result_ce);
+    pcbc_exists_result_ce = zend_register_internal_interface(&ce);
+    zend_class_implements(pcbc_exists_result_ce, 1, pcbc_result_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ExistsResultImpl", pcbc_exists_result_impl_methods);
-    pcbc_exists_result_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_exists_result_impl_ce TSRMLS_CC, 1, pcbc_exists_result_ce);
-    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("is_found"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_exists_result_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_exists_result_impl_ce, 1, pcbc_exists_result_ce);
+    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_exists_result_impl_ce, ZEND_STRL("is_found"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutationResult", pcbc_mutation_result_methods);
-    pcbc_mutation_result_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutation_result_ce TSRMLS_CC, 1, pcbc_result_ce);
+    pcbc_mutation_result_ce = zend_register_internal_interface(&ce);
+    zend_class_implements(pcbc_mutation_result_ce, 1, pcbc_result_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutationResultImpl", pcbc_mutation_result_impl_methods);
-    pcbc_mutation_result_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutation_result_impl_ce TSRMLS_CC, 1, pcbc_mutation_result_ce);
-    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("mutation_token"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutation_result_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_mutation_result_impl_ce, 1, pcbc_mutation_result_ce);
+    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutation_result_impl_ce, ZEND_STRL("mutation_token"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "StoreResultImpl", pcbc_store_result_impl_methods);
-    pcbc_store_result_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_store_result_impl_ce TSRMLS_CC, 1, pcbc_mutation_result_ce);
-    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("mutation_token"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("is_stored"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("num_persisted"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("num_replicated"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_store_result_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_store_result_impl_ce, 1, pcbc_mutation_result_ce);
+    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("mutation_token"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("is_stored"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("num_persisted"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_store_result_impl_ce, ZEND_STRL("num_replicated"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "CounterResult", pcbc_counter_result_methods);
-    pcbc_counter_result_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_counter_result_ce TSRMLS_CC, 1, pcbc_mutation_result_ce);
+    pcbc_counter_result_ce = zend_register_internal_interface(&ce);
+    zend_class_implements(pcbc_counter_result_ce, 1, pcbc_mutation_result_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "CounterResultImpl", pcbc_counter_result_impl_methods);
-    pcbc_counter_result_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_counter_result_impl_ce TSRMLS_CC, 1, pcbc_counter_result_ce);
-    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("mutation_token"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("content"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_counter_result_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_counter_result_impl_ce, 1, pcbc_counter_result_ce);
+    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("mutation_token"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_counter_result_impl_ce, ZEND_STRL("content"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "LookupInResult", pcbc_lookup_in_result_methods);
-    pcbc_lookup_in_result_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_lookup_in_result_ce TSRMLS_CC, 1, pcbc_result_ce);
+    pcbc_lookup_in_result_ce = zend_register_internal_interface(&ce);
+    zend_class_implements(pcbc_lookup_in_result_ce, 1, pcbc_result_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "LookupInResultImpl", pcbc_lookup_in_result_impl_methods);
-    pcbc_lookup_in_result_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_lookup_in_result_impl_ce TSRMLS_CC, 1, pcbc_lookup_in_result_ce);
-    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("data"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_lookup_in_result_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_lookup_in_result_impl_ce, 1, pcbc_lookup_in_result_ce);
+    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_lookup_in_result_impl_ce, ZEND_STRL("data"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "LookupInResultEntry", pcbc_lookup_in_result_entry_methods);
-    pcbc_lookup_in_result_entry_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_lookup_in_result_entry_ce, ZEND_STRL("code"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_lookup_in_result_entry_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_lookup_in_result_entry_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_lookup_in_result_entry_ce, ZEND_STRL("code"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_lookup_in_result_entry_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateInResult", pcbc_mutate_in_result_methods);
-    pcbc_mutate_in_result_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutate_in_result_ce TSRMLS_CC, 1, pcbc_mutation_result_ce);
+    pcbc_mutate_in_result_ce = zend_register_internal_interface(&ce);
+    zend_class_implements(pcbc_mutate_in_result_ce, 1, pcbc_mutation_result_ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateInResultImpl", pcbc_mutate_in_result_impl_methods);
-    pcbc_mutate_in_result_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_mutate_in_result_impl_ce TSRMLS_CC, 1, pcbc_mutate_in_result_ce);
-    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("mutation_token"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("data"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutate_in_result_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_mutate_in_result_impl_ce, 1, pcbc_mutate_in_result_ce);
+    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("cas"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("expiry"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("err_ctx"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("err_ref"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("mutation_token"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_in_result_impl_ce, ZEND_STRL("data"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MutateInResultEntry", pcbc_mutate_in_result_entry_methods);
-    pcbc_mutate_in_result_entry_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_result_entry_ce, ZEND_STRL("code"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_mutate_in_result_entry_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_mutate_in_result_entry_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_mutate_in_result_entry_ce, ZEND_STRL("code"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_mutate_in_result_entry_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "QueryResult", pcbc_query_result_methods);
-    pcbc_query_result_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_query_result_ce = zend_register_internal_interface(&ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "QueryResultImpl", pcbc_query_result_impl_methods);
-    pcbc_query_result_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_query_result_impl_ce TSRMLS_CC, 1, pcbc_query_result_ce);
-    zend_declare_property_null(pcbc_query_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_result_impl_ce, ZEND_STRL("meta"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_result_impl_ce, ZEND_STRL("rows"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_query_result_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_query_result_impl_ce, 1, pcbc_query_result_ce);
+    zend_declare_property_null(pcbc_query_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_result_impl_ce, ZEND_STRL("meta"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_result_impl_ce, ZEND_STRL("rows"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "AnalyticsResult", pcbc_analytics_result_methods);
-    pcbc_analytics_result_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_analytics_result_ce = zend_register_internal_interface(&ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "AnalyticsResultImpl", pcbc_analytics_result_impl_methods);
-    pcbc_analytics_result_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_analytics_result_impl_ce TSRMLS_CC, 1, pcbc_analytics_result_ce);
-    zend_declare_property_null(pcbc_analytics_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_analytics_result_impl_ce, ZEND_STRL("meta"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_analytics_result_impl_ce, ZEND_STRL("rows"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_analytics_result_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_analytics_result_impl_ce, 1, pcbc_analytics_result_ce);
+    zend_declare_property_null(pcbc_analytics_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_analytics_result_impl_ce, ZEND_STRL("meta"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_analytics_result_impl_ce, ZEND_STRL("rows"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchResult", pcbc_search_result_methods);
-    pcbc_search_result_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_search_result_ce = zend_register_internal_interface(&ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchResultImpl", pcbc_search_result_impl_methods);
-    pcbc_search_result_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_search_result_impl_ce TSRMLS_CC, 1, pcbc_search_result_ce);
-    zend_declare_property_null(pcbc_search_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_result_impl_ce, ZEND_STRL("meta"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_result_impl_ce, ZEND_STRL("facets"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_result_impl_ce, ZEND_STRL("rows"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_search_result_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_search_result_impl_ce, 1, pcbc_search_result_ce);
+    zend_declare_property_null(pcbc_search_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_result_impl_ce, ZEND_STRL("meta"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_result_impl_ce, ZEND_STRL("facets"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_result_impl_ce, ZEND_STRL("rows"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ViewResult", pcbc_view_result_methods);
-    pcbc_view_result_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_view_result_ce = zend_register_internal_interface(&ce);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ViewResultImpl", pcbc_view_result_impl_methods);
-    pcbc_view_result_impl_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_view_result_impl_ce TSRMLS_CC, 1, pcbc_view_result_ce);
-    zend_declare_property_null(pcbc_view_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_result_impl_ce, ZEND_STRL("http_status"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_result_impl_ce, ZEND_STRL("body"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_result_impl_ce, ZEND_STRL("body_str"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_result_impl_ce, ZEND_STRL("meta"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_result_impl_ce, ZEND_STRL("rows"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_view_result_impl_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_view_result_impl_ce, 1, pcbc_view_result_ce);
+    zend_declare_property_null(pcbc_view_result_impl_ce, ZEND_STRL("status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_result_impl_ce, ZEND_STRL("http_status"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_result_impl_ce, ZEND_STRL("body"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_result_impl_ce, ZEND_STRL("body_str"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_result_impl_ce, ZEND_STRL("meta"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_result_impl_ce, ZEND_STRL("rows"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ViewRow", pcbc_view_result_entry_methods);
-    pcbc_view_result_entry_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_result_entry_ce, ZEND_STRL("id"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_result_entry_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_result_entry_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_view_result_entry_ce, ZEND_STRL("document"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_view_result_entry_ce = zend_register_internal_class(&ce);
+    zend_declare_property_null(pcbc_view_result_entry_ce, ZEND_STRL("id"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_result_entry_ce, ZEND_STRL("key"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_result_entry_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_view_result_entry_ce, ZEND_STRL("document"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }
@@ -868,7 +868,7 @@ PHP_METHOD(GetResultImpl, content)
     prop = zend_read_property(pcbc_get_result_impl_ce, getThis(), ZEND_STRL("data"), 0, &rv);
     PCBC_JSON_RESET_STATE;
     if (php_json_decode_ex(return_value, Z_STRVAL_P(prop), Z_STRLEN_P(prop), PHP_JSON_OBJECT_AS_ARRAY,
-                           PHP_JSON_PARSER_DEFAULT_DEPTH TSRMLS_CC)) {
+                           PHP_JSON_PARSER_DEFAULT_DEPTH)) {
         ZVAL_COPY(return_value, prop);
     }
 }

--- a/src/couchbase/search/boolean_field_query.c
+++ b/src/couchbase/search/boolean_field_query.c
@@ -29,7 +29,7 @@ PHP_METHOD(BooleanFieldSearchQuery, __construct)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_boolean_field_search_query_ce, getThis(), ZEND_STRL("value"), value);
+    pcbc_update_property_bool(pcbc_boolean_field_search_query_ce, getThis(), ("value"), value);
 }
 
 PHP_METHOD(BooleanFieldSearchQuery, field)
@@ -43,7 +43,7 @@ PHP_METHOD(BooleanFieldSearchQuery, field)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_boolean_field_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_boolean_field_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -58,7 +58,7 @@ PHP_METHOD(BooleanFieldSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_boolean_field_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_double(pcbc_boolean_field_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -76,17 +76,17 @@ PHP_METHOD(BooleanFieldSearchQuery, jsonSerialize)
 
     zval *prop, ret;
 
-    prop = zend_read_property(pcbc_boolean_field_search_query_ce, getThis(), ZEND_STRL("value"), 0, &ret);
+    prop = pcbc_read_property(pcbc_boolean_field_search_query_ce, getThis(), ("value"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "bool", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_boolean_field_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_boolean_field_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_boolean_field_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_boolean_field_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/boolean_field_query.c
+++ b/src/couchbase/search/boolean_field_query.c
@@ -25,11 +25,11 @@ PHP_METHOD(BooleanFieldSearchQuery, __construct)
 {
     int rv;
     zend_bool value;
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &value);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &value);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_boolean_field_search_query_ce, getThis(), ZEND_STRL("value"), value TSRMLS_CC);
+    zend_update_property_bool(pcbc_boolean_field_search_query_ce, getThis(), ZEND_STRL("value"), value);
 }
 
 PHP_METHOD(BooleanFieldSearchQuery, field)
@@ -38,12 +38,12 @@ PHP_METHOD(BooleanFieldSearchQuery, field)
     int rv;
     size_t field_len;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field, &field_len);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field, &field_len);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_boolean_field_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_boolean_field_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -53,12 +53,12 @@ PHP_METHOD(BooleanFieldSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_boolean_field_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_double(pcbc_boolean_field_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -123,13 +123,13 @@ PHP_MINIT_FUNCTION(BooleanFieldSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "BooleanFieldSearchQuery", boolean_field_search_query_methods);
-    pcbc_boolean_field_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_boolean_field_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    pcbc_boolean_field_search_query_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_boolean_field_search_query_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_boolean_field_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_boolean_field_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_boolean_field_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_boolean_field_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_boolean_field_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_boolean_field_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/boolean_query.c
+++ b/src/couchbase/search/boolean_query.c
@@ -30,12 +30,12 @@ PHP_METHOD(BooleanSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_double(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -44,12 +44,12 @@ PHP_METHOD(BooleanSearchQuery, must)
 {
     zval *conjunct = NULL;
 
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "O", &conjunct, pcbc_conjunction_search_query_ce) ==
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O", &conjunct, pcbc_conjunction_search_query_ce) ==
         FAILURE) {
         return;
     }
 
-    zend_update_property(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("must"), conjunct TSRMLS_CC);
+    zend_update_property(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("must"), conjunct);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -58,12 +58,12 @@ PHP_METHOD(BooleanSearchQuery, mustNot)
 {
     zval *disjunct = NULL;
 
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "O", &disjunct, pcbc_disjunction_search_query_ce) ==
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O", &disjunct, pcbc_disjunction_search_query_ce) ==
         FAILURE) {
         return;
     }
 
-    zend_update_property(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("mustNot"), disjunct TSRMLS_CC);
+    zend_update_property(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("mustNot"), disjunct);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -72,12 +72,12 @@ PHP_METHOD(BooleanSearchQuery, should)
 {
     zval *disjunct = NULL;
 
-    if (zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "O", &disjunct, pcbc_disjunction_search_query_ce) ==
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "O", &disjunct, pcbc_disjunction_search_query_ce) ==
         FAILURE) {
         return;
     }
 
-    zend_update_property(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("should"), disjunct TSRMLS_CC);
+    zend_update_property(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("should"), disjunct);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -154,14 +154,14 @@ PHP_MINIT_FUNCTION(BooleanSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "BooleanSearchQuery", boolean_search_query_methods);
-    pcbc_boolean_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_boolean_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_boolean_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
+    zend_class_implements(pcbc_boolean_search_query_ce, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_boolean_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_boolean_search_query_ce, ZEND_STRL("must"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_boolean_search_query_ce, ZEND_STRL("must_not"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_boolean_search_query_ce, ZEND_STRL("should"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_boolean_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_boolean_search_query_ce, ZEND_STRL("must"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_boolean_search_query_ce, ZEND_STRL("must_not"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_boolean_search_query_ce, ZEND_STRL("should"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/boolean_query.c
+++ b/src/couchbase/search/boolean_query.c
@@ -35,7 +35,7 @@ PHP_METHOD(BooleanSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_double(pcbc_boolean_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -49,7 +49,7 @@ PHP_METHOD(BooleanSearchQuery, must)
         return;
     }
 
-    zend_update_property(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("must"), conjunct);
+    pcbc_update_property(pcbc_boolean_search_query_ce, getThis(), ("must"), conjunct);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -63,7 +63,7 @@ PHP_METHOD(BooleanSearchQuery, mustNot)
         return;
     }
 
-    zend_update_property(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("mustNot"), disjunct);
+    pcbc_update_property(pcbc_boolean_search_query_ce, getThis(), ("mustNot"), disjunct);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -77,7 +77,7 @@ PHP_METHOD(BooleanSearchQuery, should)
         return;
     }
 
-    zend_update_property(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("should"), disjunct);
+    pcbc_update_property(pcbc_boolean_search_query_ce, getThis(), ("should"), disjunct);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -94,25 +94,25 @@ PHP_METHOD(BooleanSearchQuery, jsonSerialize)
     array_init(return_value);
     zval *prop, ret;
 
-    prop = zend_read_property(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("must"), 0, &ret);
+    prop = pcbc_read_property(pcbc_boolean_search_query_ce, getThis(), ("must"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "must", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("must_not"), 0, &ret);
+    prop = pcbc_read_property(pcbc_boolean_search_query_ce, getThis(), ("must_not"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "must_not", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("should"), 0, &ret);
+    prop = pcbc_read_property(pcbc_boolean_search_query_ce, getThis(), ("should"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "should", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_boolean_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_boolean_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/conjunction_query.c
+++ b/src/couchbase/search/conjunction_query.c
@@ -35,7 +35,7 @@ PHP_METHOD(ConjunctionSearchQuery, __construct)
 
     zval container;
     array_init(&container);
-    zend_update_property(pcbc_conjunction_search_query_ce, getThis(), ZEND_STRL("queries"), &container);
+    pcbc_update_property(pcbc_conjunction_search_query_ce, getThis(), ("queries"), &container);
     Z_DELREF(container);
 
     if (queries && Z_TYPE_P(queries) != IS_NULL) {
@@ -64,7 +64,7 @@ PHP_METHOD(ConjunctionSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_conjunction_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_double(pcbc_conjunction_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -83,7 +83,7 @@ PHP_METHOD(ConjunctionSearchQuery, every)
     if (num_args && args) {
         zval *container, ret;
         int i;
-        container = zend_read_property(pcbc_conjunction_search_query_ce, getThis(), ZEND_STRL("queries"), 0, &ret);
+        container = pcbc_read_property(pcbc_conjunction_search_query_ce, getThis(), ("queries"), 0, &ret);
         for (i = 0; i < num_args; ++i) {
             zval *entry;
             entry = &args[i];
@@ -111,13 +111,13 @@ PHP_METHOD(ConjunctionSearchQuery, jsonSerialize)
     array_init(return_value);
     zval *prop, ret;
 
-    prop = zend_read_property(pcbc_conjunction_search_query_ce, getThis(), ZEND_STRL("queries"), 0, &ret);
+    prop = pcbc_read_property(pcbc_conjunction_search_query_ce, getThis(), ("queries"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "conjuncts", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_conjunction_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_conjunction_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/conjunction_query.c
+++ b/src/couchbase/search/conjunction_query.c
@@ -28,14 +28,14 @@ PHP_METHOD(ConjunctionSearchQuery, __construct)
     zval *queries = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "|a", &queries);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|a", &queries);
     if (rv == FAILURE) {
         return;
     }
 
     zval container;
     array_init(&container);
-    zend_update_property(pcbc_conjunction_search_query_ce, getThis(), ZEND_STRL("queries"), &container TSRMLS_CC);
+    zend_update_property(pcbc_conjunction_search_query_ce, getThis(), ZEND_STRL("queries"), &container);
     Z_DELREF(container);
 
     if (queries && Z_TYPE_P(queries) != IS_NULL) {
@@ -43,7 +43,7 @@ PHP_METHOD(ConjunctionSearchQuery, __construct)
         ZEND_HASH_FOREACH_VAL(HASH_OF(queries), entry)
         {
             if (Z_TYPE_P(entry) != IS_OBJECT ||
-                !instanceof_function(Z_OBJCE_P(entry), pcbc_search_query_ce TSRMLS_CC)) {
+                !instanceof_function(Z_OBJCE_P(entry), pcbc_search_query_ce)) {
                 pcbc_log(LOGARGS(WARN), "Non-query value detected in queries array");
                 zend_type_error("Expected SearchQuery for a FTS conjunction query");
             }
@@ -59,12 +59,12 @@ PHP_METHOD(ConjunctionSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_conjunction_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_double(pcbc_conjunction_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -75,7 +75,7 @@ PHP_METHOD(ConjunctionSearchQuery, every)
     int num_args = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "+", &args, &num_args);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "+", &args, &num_args);
     if (rv == FAILURE) {
         return;
     }
@@ -88,7 +88,7 @@ PHP_METHOD(ConjunctionSearchQuery, every)
             zval *entry;
             entry = &args[i];
             if (Z_TYPE_P(entry) != IS_OBJECT ||
-                !instanceof_function(Z_OBJCE_P(entry), pcbc_search_query_ce TSRMLS_CC)) {
+                !instanceof_function(Z_OBJCE_P(entry), pcbc_search_query_ce)) {
                 pcbc_log(LOGARGS(WARN), "Non-query value detected in queries array");
                 zend_type_error("Expected SearchQuery for a FTS conjunction query");
             }
@@ -154,13 +154,13 @@ PHP_MINIT_FUNCTION(ConjunctionSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "ConjunctionSearchQuery", conjunction_search_query_methods);
-    pcbc_conjunction_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_conjunction_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_conjunction_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_conjunction_search_query_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_conjunction_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_conjunction_search_query_ce, ZEND_STRL("queries"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_conjunction_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_conjunction_search_query_ce, ZEND_STRL("queries"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/date_range_facet.c
+++ b/src/couchbase/search/date_range_facet.c
@@ -37,10 +37,10 @@ PHP_METHOD(DateRangeSearchFacet, __construct)
 
     zval ranges;
     array_init(&ranges);
-    zend_update_property(pcbc_date_range_search_facet_ce, getThis(), ZEND_STRL("ranges"), &ranges);
+    pcbc_update_property(pcbc_date_range_search_facet_ce, getThis(), ("ranges"), &ranges);
     Z_DELREF(ranges);
-    zend_update_property_str(pcbc_date_range_search_facet_ce, getThis(), ZEND_STRL("field"), field);
-    zend_update_property_long(pcbc_date_range_search_facet_ce, getThis(), ZEND_STRL("limit"), limit);
+    pcbc_update_property_str(pcbc_date_range_search_facet_ce, getThis(), ("field"), field);
+    pcbc_update_property_long(pcbc_date_range_search_facet_ce, getThis(), ("limit"), limit);
 }
 
 PHP_METHOD(DateRangeSearchFacet, addRange)
@@ -56,7 +56,7 @@ PHP_METHOD(DateRangeSearchFacet, addRange)
 
     zend_string *date_str = NULL;
     zval *ranges, ret;
-    ranges = zend_read_property(pcbc_date_range_search_facet_ce, getThis(), ZEND_STRL("ranges"), 0, &ret);
+    ranges = pcbc_read_property(pcbc_date_range_search_facet_ce, getThis(), ("ranges"), 0, &ret);
     zval range;
     array_init(&range);
     add_assoc_str(&range, "name", name);
@@ -112,19 +112,19 @@ PHP_METHOD(DateRangeSearchFacet, jsonSerialize)
     array_init(return_value);
     zval *prop, ret;
 
-    prop = zend_read_property(pcbc_date_range_search_facet_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_date_range_search_facet_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_date_range_search_facet_ce, getThis(), ZEND_STRL("limit"), 0, &ret);
+    prop = pcbc_read_property(pcbc_date_range_search_facet_ce, getThis(), ("limit"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "size", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_date_range_search_facet_ce, getThis(), ZEND_STRL("ranges"), 0, &ret);
+    prop = pcbc_read_property(pcbc_date_range_search_facet_ce, getThis(), ("ranges"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "date_ranges", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/date_range_facet.c
+++ b/src/couchbase/search/date_range_facet.c
@@ -30,17 +30,17 @@ PHP_METHOD(DateRangeSearchFacet, __construct)
     zend_long limit;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sl", &field, &limit);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sl", &field, &limit);
     if (rv == FAILURE) {
         return;
     }
 
     zval ranges;
     array_init(&ranges);
-    zend_update_property(pcbc_date_range_search_facet_ce, getThis(), ZEND_STRL("ranges"), &ranges TSRMLS_CC);
+    zend_update_property(pcbc_date_range_search_facet_ce, getThis(), ZEND_STRL("ranges"), &ranges);
     Z_DELREF(ranges);
-    zend_update_property_str(pcbc_date_range_search_facet_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
-    zend_update_property_long(pcbc_date_range_search_facet_ce, getThis(), ZEND_STRL("limit"), limit TSRMLS_CC);
+    zend_update_property_str(pcbc_date_range_search_facet_ce, getThis(), ZEND_STRL("field"), field);
+    zend_update_property_long(pcbc_date_range_search_facet_ce, getThis(), ZEND_STRL("limit"), limit);
 }
 
 PHP_METHOD(DateRangeSearchFacet, addRange)
@@ -49,7 +49,7 @@ PHP_METHOD(DateRangeSearchFacet, addRange)
     zend_string *name = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Szz", &name, &start, &end);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Szz", &name, &start, &end);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -66,7 +66,7 @@ PHP_METHOD(DateRangeSearchFacet, addRange)
             add_assoc_stringl(&range, "start", Z_STRVAL_P(start), Z_STRLEN_P(start));
             break;
         case IS_LONG:
-            date_str = php_format_date(ZEND_STRL(PCBC_DATE_FORMAT_RFC3339), Z_LVAL_P(start), 1 TSRMLS_CC);
+            date_str = php_format_date(ZEND_STRL(PCBC_DATE_FORMAT_RFC3339), Z_LVAL_P(start), 1);
             add_assoc_str(&range, "start", date_str);
             break;
         case IS_NULL:
@@ -83,7 +83,7 @@ PHP_METHOD(DateRangeSearchFacet, addRange)
             add_assoc_stringl(&range, "end", Z_STRVAL_P(end), Z_STRLEN_P(end));
             break;
         case IS_LONG:
-            date_str = php_format_date(ZEND_STRL(PCBC_DATE_FORMAT_RFC3339), Z_LVAL_P(end), 1 TSRMLS_CC);
+            date_str = php_format_date(ZEND_STRL(PCBC_DATE_FORMAT_RFC3339), Z_LVAL_P(end), 1);
             add_assoc_str(&range, "end", date_str);
             break;
         case IS_NULL:
@@ -159,14 +159,14 @@ PHP_MINIT_FUNCTION(DateRangeSearchFacet)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "DateRangeSearchFacet", date_search_facet_methods);
-    pcbc_date_range_search_facet_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_date_range_search_facet_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_date_range_search_facet_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_date_range_search_facet_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_facet_ce);
 
-    zend_declare_property_null(pcbc_date_range_search_facet_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_date_range_search_facet_ce, ZEND_STRL("limit"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_date_range_search_facet_ce, ZEND_STRL("ranges"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_date_range_search_facet_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_date_range_search_facet_ce, ZEND_STRL("limit"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_date_range_search_facet_ce, ZEND_STRL("ranges"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/date_range_query.c
+++ b/src/couchbase/search/date_range_query.c
@@ -34,7 +34,7 @@ PHP_METHOD(DateRangeSearchQuery, field)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_date_range_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -49,7 +49,7 @@ PHP_METHOD(DateRangeSearchQuery, dateTimeParser)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("date_time_parser"),
+    pcbc_update_property_str(pcbc_date_range_search_query_ce, getThis(), ("date_time_parser"),
                              date_time_parser);
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -65,7 +65,7 @@ PHP_METHOD(DateRangeSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_double(pcbc_date_range_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -87,19 +87,19 @@ PHP_METHOD(DateRangeSearchQuery, start)
 
     switch (Z_TYPE_P(start)) {
     case IS_STRING:
-        zend_update_property(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("start"), start);
+        pcbc_update_property(pcbc_date_range_search_query_ce, getThis(), ("start"), start);
         break;
     case IS_LONG: {
         zend_string *date_str = NULL;
         date_str = php_format_date(ZEND_STRL(PCBC_DATE_FORMAT_RFC3339), Z_LVAL_P(start), 1);
-        zend_update_property_str(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("start"), date_str);
+        pcbc_update_property_str(pcbc_date_range_search_query_ce, getThis(), ("start"), date_str);
     } break;
     default:
         zend_type_error("Start date must be either formatted string or integer (Unix timestamp)");
         RETURN_NULL();
     }
     if (!inclusive_null) {
-        zend_update_property_bool(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("inclusive_start"),
+        pcbc_update_property_bool(pcbc_date_range_search_query_ce, getThis(), ("inclusive_start"),
                                   inclusive);
     }
 
@@ -123,19 +123,19 @@ PHP_METHOD(DateRangeSearchQuery, end)
 
     switch (Z_TYPE_P(end)) {
     case IS_STRING:
-        zend_update_property(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("end"), end);
+        pcbc_update_property(pcbc_date_range_search_query_ce, getThis(), ("end"), end);
         break;
     case IS_LONG: {
         zend_string *date_str = NULL;
         date_str = php_format_date(ZEND_STRL(PCBC_DATE_FORMAT_RFC3339), Z_LVAL_P(end), 1);
-        zend_update_property_str(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("end"), date_str);
+        pcbc_update_property_str(pcbc_date_range_search_query_ce, getThis(), ("end"), date_str);
     } break;
     default:
         zend_type_error("End date must be either formatted string or integer (Unix timestamp)");
         RETURN_NULL();
     }
     if (!inclusive_null) {
-        zend_update_property_bool(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("inclusive_end"),
+        pcbc_update_property_bool(pcbc_date_range_search_query_ce, getThis(), ("inclusive_end"),
                                   inclusive);
     }
 
@@ -154,41 +154,41 @@ PHP_METHOD(DateRangeSearchQuery, jsonSerialize)
     array_init(return_value);
     zval *prop, ret;
 
-    prop = zend_read_property(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("start"), 0, &ret);
+    prop = pcbc_read_property(pcbc_date_range_search_query_ce, getThis(), ("start"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "start", prop);
         Z_TRY_ADDREF_P(prop);
-        prop = zend_read_property(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("inclusive_start"), 0, &ret);
+        prop = pcbc_read_property(pcbc_date_range_search_query_ce, getThis(), ("inclusive_start"), 0, &ret);
         if (Z_TYPE_P(prop) != IS_NULL) {
             add_assoc_zval(return_value, "inclusive_start", prop);
             Z_TRY_ADDREF_P(prop);
         }
     }
 
-    prop = zend_read_property(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("end"), 0, &ret);
+    prop = pcbc_read_property(pcbc_date_range_search_query_ce, getThis(), ("end"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "end", prop);
         Z_TRY_ADDREF_P(prop);
-        prop = zend_read_property(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("inclusive_end"), 0, &ret);
+        prop = pcbc_read_property(pcbc_date_range_search_query_ce, getThis(), ("inclusive_end"), 0, &ret);
         if (Z_TYPE_P(prop) != IS_NULL) {
             add_assoc_zval(return_value, "inclusive_end", prop);
             Z_TRY_ADDREF_P(prop);
         }
     }
 
-    prop = zend_read_property(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_date_range_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("date_time_parser"), 0, &ret);
+    prop = pcbc_read_property(pcbc_date_range_search_query_ce, getThis(), ("date_time_parser"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "datetime_parser", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_date_range_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/date_range_query.c
+++ b/src/couchbase/search/date_range_query.c
@@ -30,11 +30,11 @@ PHP_METHOD(DateRangeSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -44,13 +44,13 @@ PHP_METHOD(DateRangeSearchQuery, dateTimeParser)
     zend_string *date_time_parser = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &date_time_parser);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &date_time_parser);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
     zend_update_property_str(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("date_time_parser"),
-                             date_time_parser TSRMLS_CC);
+                             date_time_parser);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -60,12 +60,12 @@ PHP_METHOD(DateRangeSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_double(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -80,19 +80,19 @@ PHP_METHOD(DateRangeSearchQuery, start)
     zend_bool inclusive = 1, inclusive_null = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "z|b!", &start, &inclusive, &inclusive_null);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "z|b!", &start, &inclusive, &inclusive_null);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
     switch (Z_TYPE_P(start)) {
     case IS_STRING:
-        zend_update_property(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("start"), start TSRMLS_CC);
+        zend_update_property(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("start"), start);
         break;
     case IS_LONG: {
         zend_string *date_str = NULL;
-        date_str = php_format_date(ZEND_STRL(PCBC_DATE_FORMAT_RFC3339), Z_LVAL_P(start), 1 TSRMLS_CC);
-        zend_update_property_str(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("start"), date_str TSRMLS_CC);
+        date_str = php_format_date(ZEND_STRL(PCBC_DATE_FORMAT_RFC3339), Z_LVAL_P(start), 1);
+        zend_update_property_str(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("start"), date_str);
     } break;
     default:
         zend_type_error("Start date must be either formatted string or integer (Unix timestamp)");
@@ -100,7 +100,7 @@ PHP_METHOD(DateRangeSearchQuery, start)
     }
     if (!inclusive_null) {
         zend_update_property_bool(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("inclusive_start"),
-                                  inclusive TSRMLS_CC);
+                                  inclusive);
     }
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -116,19 +116,19 @@ PHP_METHOD(DateRangeSearchQuery, end)
     zend_bool inclusive = 1, inclusive_null = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "z|b!", &end, &inclusive, &inclusive_null);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "z|b!", &end, &inclusive, &inclusive_null);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
     switch (Z_TYPE_P(end)) {
     case IS_STRING:
-        zend_update_property(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("end"), end TSRMLS_CC);
+        zend_update_property(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("end"), end);
         break;
     case IS_LONG: {
         zend_string *date_str = NULL;
-        date_str = php_format_date(ZEND_STRL(PCBC_DATE_FORMAT_RFC3339), Z_LVAL_P(end), 1 TSRMLS_CC);
-        zend_update_property_str(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("end"), date_str TSRMLS_CC);
+        date_str = php_format_date(ZEND_STRL(PCBC_DATE_FORMAT_RFC3339), Z_LVAL_P(end), 1);
+        zend_update_property_str(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("end"), date_str);
     } break;
     default:
         zend_type_error("End date must be either formatted string or integer (Unix timestamp)");
@@ -136,7 +136,7 @@ PHP_METHOD(DateRangeSearchQuery, end)
     }
     if (!inclusive_null) {
         zend_update_property_bool(pcbc_date_range_search_query_ce, getThis(), ZEND_STRL("inclusive_end"),
-                                  inclusive TSRMLS_CC);
+                                  inclusive);
     }
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -238,20 +238,20 @@ PHP_MINIT_FUNCTION(DateRangeSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "DateRangeSearchQuery", date_range_search_query_methods);
-    pcbc_date_range_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_date_range_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_date_range_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_date_range_search_query_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_date_range_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_date_range_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_date_range_search_query_ce, ZEND_STRL("start"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_date_range_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_date_range_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_date_range_search_query_ce, ZEND_STRL("start"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_date_range_search_query_ce, ZEND_STRL("inclusive_start"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_date_range_search_query_ce, ZEND_STRL("end"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_date_range_search_query_ce, ZEND_STRL("inclusive_end"), ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_date_range_search_query_ce, ZEND_STRL("end"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_date_range_search_query_ce, ZEND_STRL("inclusive_end"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_date_range_search_query_ce, ZEND_STRL("date_time_parser"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/disjunction_query.c
+++ b/src/couchbase/search/disjunction_query.c
@@ -29,14 +29,14 @@ PHP_METHOD(DisjunctionSearchQuery, __construct)
     zval *queries = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "|a", &queries);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|a", &queries);
     if (rv == FAILURE) {
         return;
     }
 
     zval container;
     array_init(&container);
-    zend_update_property(pcbc_disjunction_search_query_ce, getThis(), ZEND_STRL("queries"), &container TSRMLS_CC);
+    zend_update_property(pcbc_disjunction_search_query_ce, getThis(), ZEND_STRL("queries"), &container);
     Z_DELREF(container);
 
     if (queries && Z_TYPE_P(queries) != IS_NULL) {
@@ -44,7 +44,7 @@ PHP_METHOD(DisjunctionSearchQuery, __construct)
         ZEND_HASH_FOREACH_VAL(HASH_OF(queries), entry)
         {
             if (Z_TYPE_P(entry) != IS_OBJECT ||
-                !instanceof_function(Z_OBJCE_P(entry), pcbc_search_query_ce TSRMLS_CC)) {
+                !instanceof_function(Z_OBJCE_P(entry), pcbc_search_query_ce)) {
                 pcbc_log(LOGARGS(WARN), "Non-query value detected in queries array");
                 zend_type_error("Expected SearchQuery for a FTS disjunction query");
             }
@@ -60,12 +60,12 @@ PHP_METHOD(DisjunctionSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_disjunction_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_double(pcbc_disjunction_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -75,12 +75,12 @@ PHP_METHOD(DisjunctionSearchQuery, min)
     int rv;
     zend_long min;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &min);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &min);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_disjunction_search_query_ce, getThis(), ZEND_STRL("min"), min TSRMLS_CC);
+    zend_update_property_double(pcbc_disjunction_search_query_ce, getThis(), ZEND_STRL("min"), min);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -91,7 +91,7 @@ PHP_METHOD(DisjunctionSearchQuery, either)
     int num_args = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "+", &args, &num_args);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "+", &args, &num_args);
     if (rv == FAILURE) {
         return;
     }
@@ -104,7 +104,7 @@ PHP_METHOD(DisjunctionSearchQuery, either)
             zval *entry;
             entry = &args[i];
             if (Z_TYPE_P(entry) != IS_OBJECT ||
-                !instanceof_function(Z_OBJCE_P(entry), pcbc_search_query_ce TSRMLS_CC)) {
+                !instanceof_function(Z_OBJCE_P(entry), pcbc_search_query_ce)) {
                 pcbc_log(LOGARGS(WARN), "Non-query value detected in queries array");
                 zend_type_error("Expected SearchQuery for a FTS disjunction query");
             }
@@ -181,14 +181,14 @@ PHP_MINIT_FUNCTION(DisjunctionSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "DisjunctionSearchQuery", disjunction_search_query_methods);
-    pcbc_disjunction_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_disjunction_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_disjunction_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_disjunction_search_query_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_disjunction_search_query_ce, ZEND_STRL("queries"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_disjunction_search_query_ce, ZEND_STRL("min"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_disjunction_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_disjunction_search_query_ce, ZEND_STRL("queries"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_disjunction_search_query_ce, ZEND_STRL("min"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_disjunction_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/disjunction_query.c
+++ b/src/couchbase/search/disjunction_query.c
@@ -36,7 +36,7 @@ PHP_METHOD(DisjunctionSearchQuery, __construct)
 
     zval container;
     array_init(&container);
-    zend_update_property(pcbc_disjunction_search_query_ce, getThis(), ZEND_STRL("queries"), &container);
+    pcbc_update_property(pcbc_disjunction_search_query_ce, getThis(), ("queries"), &container);
     Z_DELREF(container);
 
     if (queries && Z_TYPE_P(queries) != IS_NULL) {
@@ -65,7 +65,7 @@ PHP_METHOD(DisjunctionSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_disjunction_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_double(pcbc_disjunction_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -80,7 +80,7 @@ PHP_METHOD(DisjunctionSearchQuery, min)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_disjunction_search_query_ce, getThis(), ZEND_STRL("min"), min);
+    pcbc_update_property_double(pcbc_disjunction_search_query_ce, getThis(), ("min"), min);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -99,7 +99,7 @@ PHP_METHOD(DisjunctionSearchQuery, either)
     if (num_args && args) {
         zval *container, ret;
         int i;
-        container = zend_read_property(pcbc_disjunction_search_query_ce, getThis(), ZEND_STRL("queries"), 0, &ret);
+        container = pcbc_read_property(pcbc_disjunction_search_query_ce, getThis(), ("queries"), 0, &ret);
         for (i = 0; i < num_args; ++i) {
             zval *entry;
             entry = &args[i];
@@ -127,19 +127,19 @@ PHP_METHOD(DisjunctionSearchQuery, jsonSerialize)
     array_init(return_value);
     zval *prop, ret;
 
-    prop = zend_read_property(pcbc_disjunction_search_query_ce, getThis(), ZEND_STRL("queries"), 0, &ret);
+    prop = pcbc_read_property(pcbc_disjunction_search_query_ce, getThis(), ("queries"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "disjuncts", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_disjunction_search_query_ce, getThis(), ZEND_STRL("min"), 0, &ret);
+    prop = pcbc_read_property(pcbc_disjunction_search_query_ce, getThis(), ("min"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "min", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_disjunction_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_disjunction_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/doc_id_query.c
+++ b/src/couchbase/search/doc_id_query.c
@@ -28,11 +28,11 @@ PHP_METHOD(DocIdSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_doc_id_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_doc_id_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -42,12 +42,12 @@ PHP_METHOD(DocIdSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_doc_id_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_double(pcbc_doc_id_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -58,7 +58,7 @@ PHP_METHOD(DocIdSearchQuery, docIds)
     int num_args = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "+", &args, &num_args);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "+", &args, &num_args);
     if (rv == FAILURE) {
         return;
     }
@@ -69,7 +69,7 @@ PHP_METHOD(DocIdSearchQuery, docIds)
         if (Z_TYPE_P(container) == IS_NULL) {
             array_init(&rv1);
             container = &rv1;
-            zend_update_property(pcbc_doc_id_search_query_ce, getThis(), ZEND_STRL("ids"), container TSRMLS_CC);
+            zend_update_property(pcbc_doc_id_search_query_ce, getThis(), ZEND_STRL("ids"), container);
             Z_DELREF_P(container);
         }
         int i;
@@ -149,11 +149,11 @@ PHP_MINIT_FUNCTION(DocIdSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "DocIdSearchQuery", doc_id_search_query_methods);
-    pcbc_doc_id_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_doc_id_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_doc_id_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
-    zend_declare_property_null(pcbc_doc_id_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_doc_id_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_doc_id_search_query_ce, ZEND_STRL("ids"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_class_implements(pcbc_doc_id_search_query_ce, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
+    zend_declare_property_null(pcbc_doc_id_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_doc_id_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_doc_id_search_query_ce, ZEND_STRL("ids"), ZEND_ACC_PRIVATE);
     return SUCCESS;
 }

--- a/src/couchbase/search/doc_id_query.c
+++ b/src/couchbase/search/doc_id_query.c
@@ -32,7 +32,7 @@ PHP_METHOD(DocIdSearchQuery, field)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_doc_id_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_doc_id_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -47,7 +47,7 @@ PHP_METHOD(DocIdSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_doc_id_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_double(pcbc_doc_id_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -65,11 +65,11 @@ PHP_METHOD(DocIdSearchQuery, docIds)
 
     if (num_args && args) {
         zval *container, rv1;
-        container = zend_read_property(pcbc_doc_id_search_query_ce, getThis(), ZEND_STRL("ids"), 0, &rv1);
+        container = pcbc_read_property(pcbc_doc_id_search_query_ce, getThis(), ("ids"), 0, &rv1);
         if (Z_TYPE_P(container) == IS_NULL) {
             array_init(&rv1);
             container = &rv1;
-            zend_update_property(pcbc_doc_id_search_query_ce, getThis(), ZEND_STRL("ids"), container);
+            pcbc_update_property(pcbc_doc_id_search_query_ce, getThis(), ("ids"), container);
             Z_DELREF_P(container);
         }
         int i;
@@ -100,19 +100,19 @@ PHP_METHOD(DocIdSearchQuery, jsonSerialize)
     array_init(return_value);
     zval *prop, ret;
 
-    prop = zend_read_property(pcbc_doc_id_search_query_ce, getThis(), ZEND_STRL("ids"), 0, &ret);
+    prop = pcbc_read_property(pcbc_doc_id_search_query_ce, getThis(), ("ids"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "ids", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_doc_id_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_doc_id_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_doc_id_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_doc_id_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/facet.c
+++ b/src/couchbase/search/facet.c
@@ -24,7 +24,7 @@ PHP_MINIT_FUNCTION(SearchFacet)
 {
     zend_class_entry ce;
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchFacet", search_facet_interface);
-    pcbc_search_facet_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_search_facet_ce = zend_register_internal_interface(&ce);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/geo_bounding_box_query.c
+++ b/src/couchbase/search/geo_bounding_box_query.c
@@ -33,13 +33,13 @@ PHP_METHOD(GeoBoundingBoxSearchQuery, __construct)
     if (rv == FAILURE) {
         return;
     }
-    zend_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("top_left_longitude"),
+    pcbc_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ("top_left_longitude"),
                                 tl_lon);
-    zend_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("top_left_latitude"),
+    pcbc_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ("top_left_latitude"),
                                 tl_lat);
-    zend_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("bottom_right_longitude"),
+    pcbc_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ("bottom_right_longitude"),
                                 br_lon);
-    zend_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("bottom_right_latitude"),
+    pcbc_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ("bottom_right_latitude"),
                                 br_lat);
 }
 
@@ -53,7 +53,7 @@ PHP_METHOD(GeoBoundingBoxSearchQuery, field)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_geo_bounding_box_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -68,7 +68,7 @@ PHP_METHOD(GeoBoundingBoxSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -89,32 +89,32 @@ PHP_METHOD(GeoBoundingBoxSearchQuery, jsonSerialize)
     zval top_left;
     array_init(&top_left);
     prop =
-        zend_read_property(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("top_left_longitude"), 0, &ret);
+        pcbc_read_property(pcbc_geo_bounding_box_search_query_ce, getThis(), ("top_left_longitude"), 0, &ret);
     add_next_index_zval(&top_left, prop);
     prop =
-        zend_read_property(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("top_left_latitude"), 0, &ret);
+        pcbc_read_property(pcbc_geo_bounding_box_search_query_ce, getThis(), ("top_left_latitude"), 0, &ret);
     add_next_index_zval(&top_left, prop);
     add_assoc_zval(return_value, "top_left", &top_left);
     Z_TRY_ADDREF(top_left);
 
     zval bottom_right;
     array_init(&bottom_right);
-    prop = zend_read_property(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("bottom_right_longitude"), 0,
+    prop = pcbc_read_property(pcbc_geo_bounding_box_search_query_ce, getThis(), ("bottom_right_longitude"), 0,
                               &ret);
     add_next_index_zval(&bottom_right, prop);
-    prop = zend_read_property(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("bottom_right_latitude"), 0,
+    prop = pcbc_read_property(pcbc_geo_bounding_box_search_query_ce, getThis(), ("bottom_right_latitude"), 0,
                               &ret);
     add_next_index_zval(&bottom_right, prop);
     add_assoc_zval(return_value, "bottom_right", &bottom_right);
     Z_TRY_ADDREF(bottom_right);
 
-    prop = zend_read_property(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_geo_bounding_box_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_geo_bounding_box_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/geo_bounding_box_query.c
+++ b/src/couchbase/search/geo_bounding_box_query.c
@@ -29,18 +29,18 @@ PHP_METHOD(GeoBoundingBoxSearchQuery, __construct)
     int rv;
     double tl_lon, tl_lat, br_lon, br_lat;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "dddd", &tl_lon, &tl_lat, &br_lon, &br_lat);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "dddd", &tl_lon, &tl_lat, &br_lon, &br_lat);
     if (rv == FAILURE) {
         return;
     }
     zend_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("top_left_longitude"),
-                                tl_lon TSRMLS_CC);
+                                tl_lon);
     zend_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("top_left_latitude"),
-                                tl_lat TSRMLS_CC);
+                                tl_lat);
     zend_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("bottom_right_longitude"),
-                                br_lon TSRMLS_CC);
+                                br_lon);
     zend_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("bottom_right_latitude"),
-                                br_lat TSRMLS_CC);
+                                br_lat);
 }
 
 PHP_METHOD(GeoBoundingBoxSearchQuery, field)
@@ -48,12 +48,12 @@ PHP_METHOD(GeoBoundingBoxSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -63,12 +63,12 @@ PHP_METHOD(GeoBoundingBoxSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_double(pcbc_geo_bounding_box_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -156,20 +156,20 @@ PHP_MINIT_FUNCTION(GeoBoundingBoxSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GeoBoundingBoxSearchQuery", geo_bounding_box_search_query_methods);
-    pcbc_geo_bounding_box_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_geo_bounding_box_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_geo_bounding_box_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_geo_bounding_box_search_query_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_geo_bounding_box_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_geo_bounding_box_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_geo_bounding_box_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_geo_bounding_box_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_geo_bounding_box_search_query_ce, ZEND_STRL("top_left_longitude"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_geo_bounding_box_search_query_ce, ZEND_STRL("top_left_latitude"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_geo_bounding_box_search_query_ce, ZEND_STRL("bottom_right_longitude"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_geo_bounding_box_search_query_ce, ZEND_STRL("bottom_right_latitude"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
     return SUCCESS;
 }

--- a/src/couchbase/search/geo_distance_query.c
+++ b/src/couchbase/search/geo_distance_query.c
@@ -35,10 +35,10 @@ PHP_METHOD(GeoDistanceSearchQuery, __construct)
         return;
     }
 
-    zend_update_property_double(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("longitude"), lon);
-    zend_update_property_double(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("latitude"), lat);
+    pcbc_update_property_double(pcbc_geo_distance_search_query_ce, getThis(), ("longitude"), lon);
+    pcbc_update_property_double(pcbc_geo_distance_search_query_ce, getThis(), ("latitude"), lat);
     if (distance) {
-        zend_update_property_str(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("distance"),
+        pcbc_update_property_str(pcbc_geo_distance_search_query_ce, getThis(), ("distance"),
                                  distance);
     }
 }
@@ -53,7 +53,7 @@ PHP_METHOD(GeoDistanceSearchQuery, field)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_geo_distance_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -68,7 +68,7 @@ PHP_METHOD(GeoDistanceSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_double(pcbc_geo_distance_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -86,25 +86,25 @@ PHP_METHOD(GeoDistanceSearchQuery, jsonSerialize)
 
     zval location;
     array_init(&location);
-    prop = zend_read_property(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("longitude"), 0, &ret);
+    prop = pcbc_read_property(pcbc_geo_distance_search_query_ce, getThis(), ("longitude"), 0, &ret);
     add_next_index_zval(&location, prop);
-    prop = zend_read_property(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("latitude"), 0, &ret);
+    prop = pcbc_read_property(pcbc_geo_distance_search_query_ce, getThis(), ("latitude"), 0, &ret);
     add_next_index_zval(&location, prop);
     add_assoc_zval(return_value, "location", &location);
     Z_TRY_ADDREF(location);
 
-    prop = zend_read_property(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("distance"), 0, &ret);
+    prop = pcbc_read_property(pcbc_geo_distance_search_query_ce, getThis(), ("distance"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "distance", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_geo_distance_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_geo_distance_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/geo_distance_query.c
+++ b/src/couchbase/search/geo_distance_query.c
@@ -30,16 +30,16 @@ PHP_METHOD(GeoDistanceSearchQuery, __construct)
     double lon, lat;
     zend_string *distance = NULL;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "dd|S", &lon, &lat, &distance);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "dd|S", &lon, &lat, &distance);
     if (rv == FAILURE) {
         return;
     }
 
-    zend_update_property_double(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("longitude"), lon TSRMLS_CC);
-    zend_update_property_double(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("latitude"), lat TSRMLS_CC);
+    zend_update_property_double(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("longitude"), lon);
+    zend_update_property_double(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("latitude"), lat);
     if (distance) {
         zend_update_property_str(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("distance"),
-                                 distance TSRMLS_CC);
+                                 distance);
     }
 }
 
@@ -48,12 +48,12 @@ PHP_METHOD(GeoDistanceSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -63,12 +63,12 @@ PHP_METHOD(GeoDistanceSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_double(pcbc_geo_distance_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -143,16 +143,16 @@ PHP_MINIT_FUNCTION(GeoDistanceSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GeoDistanceSearchQuery", geo_distance_search_query_methods);
-    pcbc_geo_distance_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_geo_distance_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_geo_distance_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_geo_distance_search_query_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_geo_distance_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_geo_distance_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_geo_distance_search_query_ce, ZEND_STRL("longitude"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_geo_distance_search_query_ce, ZEND_STRL("latitude"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_geo_distance_search_query_ce, ZEND_STRL("distance"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_geo_distance_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_geo_distance_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_geo_distance_search_query_ce, ZEND_STRL("longitude"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_geo_distance_search_query_ce, ZEND_STRL("latitude"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_geo_distance_search_query_ce, ZEND_STRL("distance"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/geo_polygon_query.c
+++ b/src/couchbase/search/geo_polygon_query.c
@@ -30,7 +30,7 @@ PHP_METHOD(GeoPolygonSearchQuery, __construct)
     if (rv == FAILURE) {
         return;
     }
-    zend_update_property(pcbc_geo_polygon_search_query_ce, getThis(), ZEND_STRL("coordinates"), coordinates);
+    pcbc_update_property(pcbc_geo_polygon_search_query_ce, getThis(), ("coordinates"), coordinates);
 }
 
 PHP_METHOD(GeoPolygonSearchQuery, field)
@@ -43,7 +43,7 @@ PHP_METHOD(GeoPolygonSearchQuery, field)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_geo_polygon_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_geo_polygon_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -58,7 +58,7 @@ PHP_METHOD(GeoPolygonSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_geo_polygon_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_double(pcbc_geo_polygon_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -76,17 +76,17 @@ PHP_METHOD(GeoPolygonSearchQuery, jsonSerialize)
 
     zval *prop, ret;
 
-    prop = zend_read_property(pcbc_geo_polygon_search_query_ce, getThis(), ZEND_STRL("coordinates"), 0, &ret);
+    prop = pcbc_read_property(pcbc_geo_polygon_search_query_ce, getThis(), ("coordinates"), 0, &ret);
     add_assoc_zval(return_value, "polygon_points", prop);
     Z_TRY_ADDREF_P(prop);
 
-    prop = zend_read_property(pcbc_geo_polygon_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_geo_polygon_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_geo_polygon_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_geo_polygon_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);
@@ -128,8 +128,8 @@ PHP_METHOD(Coordinate, __construct)
     if (rv == FAILURE) {
         return;
     }
-    zend_update_property_double(pcbc_coordinate_ce, getThis(), ZEND_STRL("longitude"), longitude);
-    zend_update_property_double(pcbc_coordinate_ce, getThis(), ZEND_STRL("latitude"), latitude);
+    pcbc_update_property_double(pcbc_coordinate_ce, getThis(), ("longitude"), longitude);
+    pcbc_update_property_double(pcbc_coordinate_ce, getThis(), ("latitude"), latitude);
 }
 
 PHP_METHOD(Coordinate, jsonSerialize)
@@ -145,11 +145,11 @@ PHP_METHOD(Coordinate, jsonSerialize)
 
     zval *prop, ret;
 
-    prop = zend_read_property(pcbc_coordinate_ce, getThis(), ZEND_STRL("longitude"), 0, &ret);
+    prop = pcbc_read_property(pcbc_coordinate_ce, getThis(), ("longitude"), 0, &ret);
     add_next_index_zval(return_value, prop);
     Z_TRY_ADDREF_P(prop);
 
-    prop = zend_read_property(pcbc_coordinate_ce, getThis(), ZEND_STRL("latitude"), 0, &ret);
+    prop = pcbc_read_property(pcbc_coordinate_ce, getThis(), ("latitude"), 0, &ret);
     add_next_index_zval(return_value, prop);
     Z_TRY_ADDREF_P(prop);
 }

--- a/src/couchbase/search/geo_polygon_query.c
+++ b/src/couchbase/search/geo_polygon_query.c
@@ -26,11 +26,11 @@ PHP_METHOD(GeoPolygonSearchQuery, __construct)
     int rv;
     zval *coordinates = NULL;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "a", &coordinates);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "a", &coordinates);
     if (rv == FAILURE) {
         return;
     }
-    zend_update_property(pcbc_geo_polygon_search_query_ce, getThis(), ZEND_STRL("coordinates"), coordinates TSRMLS_CC);
+    zend_update_property(pcbc_geo_polygon_search_query_ce, getThis(), ZEND_STRL("coordinates"), coordinates);
 }
 
 PHP_METHOD(GeoPolygonSearchQuery, field)
@@ -38,12 +38,12 @@ PHP_METHOD(GeoPolygonSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_geo_polygon_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_geo_polygon_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -53,12 +53,12 @@ PHP_METHOD(GeoPolygonSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_geo_polygon_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_double(pcbc_geo_polygon_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -124,12 +124,12 @@ PHP_METHOD(Coordinate, __construct)
     double longitude = 0;
     double latitude = 0;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &longitude, &latitude);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "dd", &longitude, &latitude);
     if (rv == FAILURE) {
         return;
     }
-    zend_update_property_double(pcbc_coordinate_ce, getThis(), ZEND_STRL("longitude"), longitude TSRMLS_CC);
-    zend_update_property_double(pcbc_coordinate_ce, getThis(), ZEND_STRL("latitude"), latitude TSRMLS_CC);
+    zend_update_property_double(pcbc_coordinate_ce, getThis(), ZEND_STRL("longitude"), longitude);
+    zend_update_property_double(pcbc_coordinate_ce, getThis(), ZEND_STRL("latitude"), latitude);
 }
 
 PHP_METHOD(Coordinate, jsonSerialize)
@@ -175,19 +175,19 @@ PHP_MINIT_FUNCTION(GeoPolygonSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "GeoPolygonSearchQuery", geo_polygon_search_query_methods);
-    pcbc_geo_polygon_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_geo_polygon_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_geo_polygon_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_geo_polygon_search_query_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_geo_polygon_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_geo_polygon_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_geo_polygon_search_query_ce, ZEND_STRL("coordinates"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_geo_polygon_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_geo_polygon_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_geo_polygon_search_query_ce, ZEND_STRL("coordinates"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "Coordinate", coordinate_methods);
-    pcbc_coordinate_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_coordinate_ce TSRMLS_CC, 1, pcbc_json_serializable_ce);
-    zend_declare_property_null(pcbc_coordinate_ce, ZEND_STRL("longitude"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_coordinate_ce, ZEND_STRL("latitude"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    pcbc_coordinate_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_coordinate_ce, 1, pcbc_json_serializable_ce);
+    zend_declare_property_null(pcbc_coordinate_ce, ZEND_STRL("longitude"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_coordinate_ce, ZEND_STRL("latitude"), ZEND_ACC_PRIVATE);
     return SUCCESS;
 }

--- a/src/couchbase/search/match_all_query.c
+++ b/src/couchbase/search/match_all_query.c
@@ -26,12 +26,12 @@ PHP_METHOD(MatchAllSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_match_all_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_double(pcbc_match_all_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -68,11 +68,11 @@ PHP_MINIT_FUNCTION(MatchAllSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MatchAllSearchQuery", match_all_search_query_methods);
-    pcbc_match_all_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_match_all_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_match_all_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
+    zend_class_implements(pcbc_match_all_search_query_ce, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_match_all_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_match_all_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/match_all_query.c
+++ b/src/couchbase/search/match_all_query.c
@@ -31,7 +31,7 @@ PHP_METHOD(MatchAllSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_match_all_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_double(pcbc_match_all_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -41,7 +41,7 @@ PHP_METHOD(MatchAllSearchQuery, jsonSerialize)
     array_init(return_value);
     zval *prop, ret;
     add_assoc_null(return_value, "match_all");
-    prop = zend_read_property(pcbc_match_all_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_match_all_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/match_none_query.c
+++ b/src/couchbase/search/match_none_query.c
@@ -31,7 +31,7 @@ PHP_METHOD(MatchNoneSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_match_none_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_double(pcbc_match_none_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -41,7 +41,7 @@ PHP_METHOD(MatchNoneSearchQuery, jsonSerialize)
     array_init(return_value);
     zval *prop, ret;
     add_assoc_null(return_value, "match_none");
-    prop = zend_read_property(pcbc_match_none_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_match_none_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/match_none_query.c
+++ b/src/couchbase/search/match_none_query.c
@@ -26,12 +26,12 @@ PHP_METHOD(MatchNoneSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_match_none_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_double(pcbc_match_none_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -68,12 +68,12 @@ PHP_MINIT_FUNCTION(MatchNoneSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MatchNoneSearchQuery", match_none_search_query_methods);
-    pcbc_match_none_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_match_none_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_match_none_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_match_none_search_query_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_match_none_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_match_none_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/match_phrase_query.c
+++ b/src/couchbase/search/match_phrase_query.c
@@ -27,12 +27,12 @@ PHP_METHOD(MatchPhraseSearchQuery, __construct)
     zend_string *value = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &value);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &value);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("value"), value TSRMLS_CC);
+    zend_update_property_str(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("value"), value);
 }
 
 PHP_METHOD(MatchPhraseSearchQuery, analyzer)
@@ -40,12 +40,12 @@ PHP_METHOD(MatchPhraseSearchQuery, analyzer)
     zend_string *analyzer = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &analyzer);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &analyzer);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("analyzer"), analyzer TSRMLS_CC);
+    zend_update_property_str(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("analyzer"), analyzer);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -55,12 +55,12 @@ PHP_METHOD(MatchPhraseSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -70,12 +70,12 @@ PHP_METHOD(MatchPhraseSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_long(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -148,14 +148,14 @@ PHP_MINIT_FUNCTION(MatchPhraseSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MatchPhraseSearchQuery", match_phrase_search_query_methods);
-    pcbc_match_phrase_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_match_phrase_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_match_phrase_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_match_phrase_search_query_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_match_phrase_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_match_phrase_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_match_phrase_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_match_phrase_search_query_ce, ZEND_STRL("analyzer"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_match_phrase_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_match_phrase_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_match_phrase_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_match_phrase_search_query_ce, ZEND_STRL("analyzer"), ZEND_ACC_PRIVATE);
     return SUCCESS;
 }

--- a/src/couchbase/search/match_phrase_query.c
+++ b/src/couchbase/search/match_phrase_query.c
@@ -32,7 +32,7 @@ PHP_METHOD(MatchPhraseSearchQuery, __construct)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("value"), value);
+    pcbc_update_property_str(pcbc_match_phrase_search_query_ce, getThis(), ("value"), value);
 }
 
 PHP_METHOD(MatchPhraseSearchQuery, analyzer)
@@ -45,7 +45,7 @@ PHP_METHOD(MatchPhraseSearchQuery, analyzer)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("analyzer"), analyzer);
+    pcbc_update_property_str(pcbc_match_phrase_search_query_ce, getThis(), ("analyzer"), analyzer);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -60,7 +60,7 @@ PHP_METHOD(MatchPhraseSearchQuery, field)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_match_phrase_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -75,7 +75,7 @@ PHP_METHOD(MatchPhraseSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_long(pcbc_match_phrase_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -91,22 +91,22 @@ PHP_METHOD(MatchPhraseSearchQuery, jsonSerialize)
 
     array_init(return_value);
     zval *prop, ret;
-    prop = zend_read_property(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("value"), 0, &ret);
+    prop = pcbc_read_property(pcbc_match_phrase_search_query_ce, getThis(), ("value"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "match_phrase", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_match_phrase_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("analyzer"), 0, &ret);
+    prop = pcbc_read_property(pcbc_match_phrase_search_query_ce, getThis(), ("analyzer"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "analyzer", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_match_phrase_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_match_phrase_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/match_query.c
+++ b/src/couchbase/search/match_query.c
@@ -32,7 +32,7 @@ PHP_METHOD(MatchSearchQuery, __construct)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_match_search_query_ce, getThis(), ZEND_STRL("value"), value);
+    pcbc_update_property_str(pcbc_match_search_query_ce, getThis(), ("value"), value);
 }
 
 PHP_METHOD(MatchSearchQuery, analyzer)
@@ -45,7 +45,7 @@ PHP_METHOD(MatchSearchQuery, analyzer)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_match_search_query_ce, getThis(), ZEND_STRL("analyzer"), analyzer);
+    pcbc_update_property_str(pcbc_match_search_query_ce, getThis(), ("analyzer"), analyzer);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -60,7 +60,7 @@ PHP_METHOD(MatchSearchQuery, field)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_match_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_match_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -75,7 +75,7 @@ PHP_METHOD(MatchSearchQuery, prefixLength)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_match_search_query_ce, getThis(), ZEND_STRL("prefix_length"),
+    pcbc_update_property_long(pcbc_match_search_query_ce, getThis(), ("prefix_length"),
                               prefix_length);
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -91,7 +91,7 @@ PHP_METHOD(MatchSearchQuery, fuzziness)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_match_search_query_ce, getThis(), ZEND_STRL("fuzziness"), fuzziness);
+    pcbc_update_property_long(pcbc_match_search_query_ce, getThis(), ("fuzziness"), fuzziness);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -106,7 +106,7 @@ PHP_METHOD(MatchSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_match_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_long(pcbc_match_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -122,32 +122,32 @@ PHP_METHOD(MatchSearchQuery, jsonSerialize)
 
     array_init(return_value);
     zval *prop, ret;
-    prop = zend_read_property(pcbc_match_search_query_ce, getThis(), ZEND_STRL("value"), 0, &ret);
+    prop = pcbc_read_property(pcbc_match_search_query_ce, getThis(), ("value"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "match", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_match_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_match_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_match_search_query_ce, getThis(), ZEND_STRL("analyzer"), 0, &ret);
+    prop = pcbc_read_property(pcbc_match_search_query_ce, getThis(), ("analyzer"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "analyzer", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_match_search_query_ce, getThis(), ZEND_STRL("prefix_length"), 0, &ret);
+    prop = pcbc_read_property(pcbc_match_search_query_ce, getThis(), ("prefix_length"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "prefix_length", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_match_search_query_ce, getThis(), ZEND_STRL("fuzziness"), 0, &ret);
+    prop = pcbc_read_property(pcbc_match_search_query_ce, getThis(), ("fuzziness"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "fuzziness", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_match_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_match_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/match_query.c
+++ b/src/couchbase/search/match_query.c
@@ -27,12 +27,12 @@ PHP_METHOD(MatchSearchQuery, __construct)
     zend_string *value = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &value);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &value);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_match_search_query_ce, getThis(), ZEND_STRL("value"), value TSRMLS_CC);
+    zend_update_property_str(pcbc_match_search_query_ce, getThis(), ZEND_STRL("value"), value);
 }
 
 PHP_METHOD(MatchSearchQuery, analyzer)
@@ -40,12 +40,12 @@ PHP_METHOD(MatchSearchQuery, analyzer)
     zend_string *analyzer = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &analyzer);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &analyzer);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_match_search_query_ce, getThis(), ZEND_STRL("analyzer"), analyzer TSRMLS_CC);
+    zend_update_property_str(pcbc_match_search_query_ce, getThis(), ZEND_STRL("analyzer"), analyzer);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -55,12 +55,12 @@ PHP_METHOD(MatchSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_match_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_match_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -70,13 +70,13 @@ PHP_METHOD(MatchSearchQuery, prefixLength)
     zend_long prefix_length = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &prefix_length);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &prefix_length);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
     zend_update_property_long(pcbc_match_search_query_ce, getThis(), ZEND_STRL("prefix_length"),
-                              prefix_length TSRMLS_CC);
+                              prefix_length);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -86,12 +86,12 @@ PHP_METHOD(MatchSearchQuery, fuzziness)
     zend_long fuzziness = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &fuzziness);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &fuzziness);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_match_search_query_ce, getThis(), ZEND_STRL("fuzziness"), fuzziness TSRMLS_CC);
+    zend_update_property_long(pcbc_match_search_query_ce, getThis(), ZEND_STRL("fuzziness"), fuzziness);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -101,12 +101,12 @@ PHP_METHOD(MatchSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_match_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_long(pcbc_match_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -199,15 +199,15 @@ PHP_MINIT_FUNCTION(MatchSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "MatchSearchQuery", match_search_query_methods);
-    pcbc_match_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_match_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_match_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
-    zend_declare_property_null(pcbc_match_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_match_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_match_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_match_search_query_ce, ZEND_STRL("analyzer"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_match_search_query_ce, ZEND_STRL("prefix_length"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_match_search_query_ce, ZEND_STRL("fuzziness"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_class_implements(pcbc_match_search_query_ce, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
+    zend_declare_property_null(pcbc_match_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_match_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_match_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_match_search_query_ce, ZEND_STRL("analyzer"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_match_search_query_ce, ZEND_STRL("prefix_length"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_match_search_query_ce, ZEND_STRL("fuzziness"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/numeric_range_facet.c
+++ b/src/couchbase/search/numeric_range_facet.c
@@ -27,17 +27,17 @@ PHP_METHOD(NumericRangeSearchFacet, __construct)
     zend_long limit;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sl", &field, &limit);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sl", &field, &limit);
     if (rv == FAILURE) {
         return;
     }
 
     zval ranges;
     array_init(&ranges);
-    zend_update_property(pcbc_numeric_range_search_facet_ce, getThis(), ZEND_STRL("ranges"), &ranges TSRMLS_CC);
+    zend_update_property(pcbc_numeric_range_search_facet_ce, getThis(), ZEND_STRL("ranges"), &ranges);
     Z_DELREF(ranges);
-    zend_update_property_str(pcbc_numeric_range_search_facet_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
-    zend_update_property_long(pcbc_numeric_range_search_facet_ce, getThis(), ZEND_STRL("limit"), limit TSRMLS_CC);
+    zend_update_property_str(pcbc_numeric_range_search_facet_ce, getThis(), ZEND_STRL("field"), field);
+    zend_update_property_long(pcbc_numeric_range_search_facet_ce, getThis(), ZEND_STRL("limit"), limit);
 }
 
 PHP_METHOD(NumericRangeSearchFacet, addRange)
@@ -47,7 +47,7 @@ PHP_METHOD(NumericRangeSearchFacet, addRange)
     double min = 0, max = 0;
     zend_bool min_null = 0, max_null = 0;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Sd!d!", &name, &min, &min_null, &max, &max_null);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "Sd!d!", &name, &min, &min_null, &max, &max_null);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -130,14 +130,14 @@ PHP_MINIT_FUNCTION(NumericRangeSearchFacet)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "NumericRangeSearchFacet", numeric_search_facet_methods);
-    pcbc_numeric_range_search_facet_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_numeric_range_search_facet_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_numeric_range_search_facet_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_numeric_range_search_facet_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_facet_ce);
 
-    zend_declare_property_null(pcbc_numeric_range_search_facet_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_numeric_range_search_facet_ce, ZEND_STRL("limit"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_numeric_range_search_facet_ce, ZEND_STRL("ranges"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_numeric_range_search_facet_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_numeric_range_search_facet_ce, ZEND_STRL("limit"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_numeric_range_search_facet_ce, ZEND_STRL("ranges"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/numeric_range_facet.c
+++ b/src/couchbase/search/numeric_range_facet.c
@@ -34,10 +34,10 @@ PHP_METHOD(NumericRangeSearchFacet, __construct)
 
     zval ranges;
     array_init(&ranges);
-    zend_update_property(pcbc_numeric_range_search_facet_ce, getThis(), ZEND_STRL("ranges"), &ranges);
+    pcbc_update_property(pcbc_numeric_range_search_facet_ce, getThis(), ("ranges"), &ranges);
     Z_DELREF(ranges);
-    zend_update_property_str(pcbc_numeric_range_search_facet_ce, getThis(), ZEND_STRL("field"), field);
-    zend_update_property_long(pcbc_numeric_range_search_facet_ce, getThis(), ZEND_STRL("limit"), limit);
+    pcbc_update_property_str(pcbc_numeric_range_search_facet_ce, getThis(), ("field"), field);
+    pcbc_update_property_long(pcbc_numeric_range_search_facet_ce, getThis(), ("limit"), limit);
 }
 
 PHP_METHOD(NumericRangeSearchFacet, addRange)
@@ -53,7 +53,7 @@ PHP_METHOD(NumericRangeSearchFacet, addRange)
     }
 
     zval *ranges, ret;
-    ranges = zend_read_property(pcbc_numeric_range_search_facet_ce, getThis(), ZEND_STRL("ranges"), 0, &ret);
+    ranges = pcbc_read_property(pcbc_numeric_range_search_facet_ce, getThis(), ("ranges"), 0, &ret);
 
     zval range;
     array_init(&range);
@@ -82,19 +82,19 @@ PHP_METHOD(NumericRangeSearchFacet, jsonSerialize)
     array_init(return_value);
     zval *prop, ret;
 
-    prop = zend_read_property(pcbc_numeric_range_search_facet_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_numeric_range_search_facet_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_numeric_range_search_facet_ce, getThis(), ZEND_STRL("limit"), 0, &ret);
+    prop = pcbc_read_property(pcbc_numeric_range_search_facet_ce, getThis(), ("limit"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "size", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_numeric_range_search_facet_ce, getThis(), ZEND_STRL("ranges"), 0, &ret);
+    prop = pcbc_read_property(pcbc_numeric_range_search_facet_ce, getThis(), ("ranges"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "numeric_ranges", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/numeric_range_query.c
+++ b/src/couchbase/search/numeric_range_query.c
@@ -31,7 +31,7 @@ PHP_METHOD(NumericRangeSearchQuery, field)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_numeric_range_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -46,7 +46,7 @@ PHP_METHOD(NumericRangeSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_double(pcbc_numeric_range_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -62,9 +62,9 @@ PHP_METHOD(NumericRangeSearchQuery, min)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("min"), min);
+    pcbc_update_property_double(pcbc_numeric_range_search_query_ce, getThis(), ("min"), min);
     if (!inclusive_null) {
-        zend_update_property_bool(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("inclusive_min"),
+        pcbc_update_property_bool(pcbc_numeric_range_search_query_ce, getThis(), ("inclusive_min"),
                                   inclusive);
     }
 
@@ -82,9 +82,9 @@ PHP_METHOD(NumericRangeSearchQuery, max)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("max"), max);
+    pcbc_update_property_double(pcbc_numeric_range_search_query_ce, getThis(), ("max"), max);
     if (!inclusive_null) {
-        zend_update_property_bool(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("inclusive_max"),
+        pcbc_update_property_bool(pcbc_numeric_range_search_query_ce, getThis(), ("inclusive_max"),
                                   inclusive);
     }
 
@@ -103,35 +103,35 @@ PHP_METHOD(NumericRangeSearchQuery, jsonSerialize)
     array_init(return_value);
     zval *prop, ret;
 
-    prop = zend_read_property(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("min"), 0, &ret);
+    prop = pcbc_read_property(pcbc_numeric_range_search_query_ce, getThis(), ("min"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "min", prop);
         Z_TRY_ADDREF_P(prop);
-        prop = zend_read_property(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("inclusive_min"), 0, &ret);
+        prop = pcbc_read_property(pcbc_numeric_range_search_query_ce, getThis(), ("inclusive_min"), 0, &ret);
         if (Z_TYPE_P(prop) != IS_NULL) {
             add_assoc_zval(return_value, "inclusive_min", prop);
             Z_TRY_ADDREF_P(prop);
         }
     }
 
-    prop = zend_read_property(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("max"), 0, &ret);
+    prop = pcbc_read_property(pcbc_numeric_range_search_query_ce, getThis(), ("max"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "max", prop);
         Z_TRY_ADDREF_P(prop);
-        prop = zend_read_property(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("inclusive_max"), 0, &ret);
+        prop = pcbc_read_property(pcbc_numeric_range_search_query_ce, getThis(), ("inclusive_max"), 0, &ret);
         if (Z_TYPE_P(prop) != IS_NULL) {
             add_assoc_zval(return_value, "inclusive_max", prop);
             Z_TRY_ADDREF_P(prop);
         }
     }
 
-    prop = zend_read_property(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_numeric_range_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_numeric_range_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/numeric_range_query.c
+++ b/src/couchbase/search/numeric_range_query.c
@@ -27,11 +27,11 @@ PHP_METHOD(NumericRangeSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -41,12 +41,12 @@ PHP_METHOD(NumericRangeSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_double(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -57,15 +57,15 @@ PHP_METHOD(NumericRangeSearchQuery, min)
     zend_bool inclusive = 1, inclusive_null = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d|b!", &min, &inclusive, &inclusive_null);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d|b!", &min, &inclusive, &inclusive_null);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("min"), min TSRMLS_CC);
+    zend_update_property_double(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("min"), min);
     if (!inclusive_null) {
         zend_update_property_bool(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("inclusive_min"),
-                                  inclusive TSRMLS_CC);
+                                  inclusive);
     }
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -77,15 +77,15 @@ PHP_METHOD(NumericRangeSearchQuery, max)
     zend_bool inclusive = 1, inclusive_null = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d|b!", &max, &inclusive, &inclusive_null);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d|b!", &max, &inclusive, &inclusive_null);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("max"), max TSRMLS_CC);
+    zend_update_property_double(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("max"), max);
     if (!inclusive_null) {
         zend_update_property_bool(pcbc_numeric_range_search_query_ce, getThis(), ZEND_STRL("inclusive_max"),
-                                  inclusive TSRMLS_CC);
+                                  inclusive);
     }
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -175,19 +175,19 @@ PHP_MINIT_FUNCTION(NumericRangeSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "NumericRangeSearchQuery", numeric_range_search_query_methods);
-    pcbc_numeric_range_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_numeric_range_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_numeric_range_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_numeric_range_search_query_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_numeric_range_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_numeric_range_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_numeric_range_search_query_ce, ZEND_STRL("min"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_numeric_range_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_numeric_range_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_numeric_range_search_query_ce, ZEND_STRL("min"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_numeric_range_search_query_ce, ZEND_STRL("inclusive_min"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_numeric_range_search_query_ce, ZEND_STRL("max"), ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_numeric_range_search_query_ce, ZEND_STRL("max"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(pcbc_numeric_range_search_query_ce, ZEND_STRL("inclusive_max"),
-                               ZEND_ACC_PRIVATE TSRMLS_CC);
+                               ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/phrase_query.c
+++ b/src/couchbase/search/phrase_query.c
@@ -38,7 +38,7 @@ PHP_METHOD(PhraseSearchQuery, __construct)
 
     zval container;
     array_init(&container);
-    zend_update_property(pcbc_phrase_search_query_ce, getThis(), ZEND_STRL("terms"), &container);
+    pcbc_update_property(pcbc_phrase_search_query_ce, getThis(), ("terms"), &container);
     Z_DELREF(container);
 
     if (num_args && args) {
@@ -66,7 +66,7 @@ PHP_METHOD(PhraseSearchQuery, field)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_phrase_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_phrase_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -81,7 +81,7 @@ PHP_METHOD(PhraseSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_phrase_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_long(pcbc_phrase_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -97,19 +97,19 @@ PHP_METHOD(PhraseSearchQuery, jsonSerialize)
 
     array_init(return_value);
     zval *prop, ret;
-    prop = zend_read_property(pcbc_phrase_search_query_ce, getThis(), ZEND_STRL("terms"), 0, &ret);
+    prop = pcbc_read_property(pcbc_phrase_search_query_ce, getThis(), ("terms"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "terms", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_phrase_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_phrase_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_phrase_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_phrase_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/phrase_query.c
+++ b/src/couchbase/search/phrase_query.c
@@ -31,14 +31,14 @@ PHP_METHOD(PhraseSearchQuery, __construct)
     int num_args = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "+", &args, &num_args);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "+", &args, &num_args);
     if (rv == FAILURE) {
         return;
     }
 
     zval container;
     array_init(&container);
-    zend_update_property(pcbc_phrase_search_query_ce, getThis(), ZEND_STRL("terms"), &container TSRMLS_CC);
+    zend_update_property(pcbc_phrase_search_query_ce, getThis(), ZEND_STRL("terms"), &container);
     Z_DELREF(container);
 
     if (num_args && args) {
@@ -61,12 +61,12 @@ PHP_METHOD(PhraseSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_phrase_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_phrase_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -76,12 +76,12 @@ PHP_METHOD(PhraseSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_phrase_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_long(pcbc_phrase_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -146,13 +146,13 @@ PHP_MINIT_FUNCTION(PhraseSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "PhraseSearchQuery", phrase_search_query_methods);
-    pcbc_phrase_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_phrase_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_phrase_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
+    zend_class_implements(pcbc_phrase_search_query_ce, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_phrase_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_phrase_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_phrase_search_query_ce, ZEND_STRL("terms"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_phrase_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_phrase_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_phrase_search_query_ce, ZEND_STRL("terms"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/prefix_query.c
+++ b/src/couchbase/search/prefix_query.c
@@ -31,7 +31,7 @@ PHP_METHOD(PrefixSearchQuery, __construct)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_prefix_search_query_ce, getThis(), ZEND_STRL("value"), prefix);
+    pcbc_update_property_str(pcbc_prefix_search_query_ce, getThis(), ("value"), prefix);
 }
 
 PHP_METHOD(PrefixSearchQuery, field)
@@ -44,7 +44,7 @@ PHP_METHOD(PrefixSearchQuery, field)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_prefix_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_prefix_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -59,7 +59,7 @@ PHP_METHOD(PrefixSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_prefix_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_long(pcbc_prefix_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -75,19 +75,19 @@ PHP_METHOD(PrefixSearchQuery, jsonSerialize)
 
     array_init(return_value);
     zval *prop, ret;
-    prop = zend_read_property(pcbc_prefix_search_query_ce, getThis(), ZEND_STRL("value"), 0, &ret);
+    prop = pcbc_read_property(pcbc_prefix_search_query_ce, getThis(), ("value"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "prefix", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_prefix_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_prefix_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_prefix_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_prefix_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/prefix_query.c
+++ b/src/couchbase/search/prefix_query.c
@@ -26,12 +26,12 @@ PHP_METHOD(PrefixSearchQuery, __construct)
     zend_string *prefix = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &prefix);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &prefix);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_prefix_search_query_ce, getThis(), ZEND_STRL("value"), prefix TSRMLS_CC);
+    zend_update_property_str(pcbc_prefix_search_query_ce, getThis(), ZEND_STRL("value"), prefix);
 }
 
 PHP_METHOD(PrefixSearchQuery, field)
@@ -39,12 +39,12 @@ PHP_METHOD(PrefixSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_prefix_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_prefix_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -54,12 +54,12 @@ PHP_METHOD(PrefixSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_prefix_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_long(pcbc_prefix_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -124,12 +124,12 @@ PHP_MINIT_FUNCTION(PrefixSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "PrefixSearchQuery", prefix_search_query_methods);
-    pcbc_prefix_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_prefix_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_prefix_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
+    zend_class_implements(pcbc_prefix_search_query_ce, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_prefix_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_prefix_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_prefix_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_prefix_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_prefix_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_prefix_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
     return SUCCESS;
 }

--- a/src/couchbase/search/query_string_query.c
+++ b/src/couchbase/search/query_string_query.c
@@ -31,7 +31,7 @@ PHP_METHOD(QueryStringSearchQuery, __construct)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_query_string_search_query_ce, getThis(), ZEND_STRL("value"), query_string);
+    pcbc_update_property_str(pcbc_query_string_search_query_ce, getThis(), ("value"), query_string);
 }
 
 PHP_METHOD(QueryStringSearchQuery, boost)
@@ -44,7 +44,7 @@ PHP_METHOD(QueryStringSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_query_string_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_long(pcbc_query_string_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -60,13 +60,13 @@ PHP_METHOD(QueryStringSearchQuery, jsonSerialize)
 
     array_init(return_value);
     zval *prop, ret;
-    prop = zend_read_property(pcbc_query_string_search_query_ce, getThis(), ZEND_STRL("value"), 0, &ret);
+    prop = pcbc_read_property(pcbc_query_string_search_query_ce, getThis(), ("value"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "query", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_query_string_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_query_string_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/query_string_query.c
+++ b/src/couchbase/search/query_string_query.c
@@ -26,12 +26,12 @@ PHP_METHOD(QueryStringSearchQuery, __construct)
     zend_string *query_string = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &query_string);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &query_string);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_query_string_search_query_ce, getThis(), ZEND_STRL("value"), query_string TSRMLS_CC);
+    zend_update_property_str(pcbc_query_string_search_query_ce, getThis(), ZEND_STRL("value"), query_string);
 }
 
 PHP_METHOD(QueryStringSearchQuery, boost)
@@ -39,12 +39,12 @@ PHP_METHOD(QueryStringSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_query_string_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_long(pcbc_query_string_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -98,13 +98,13 @@ PHP_MINIT_FUNCTION(QueryStringSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "QueryStringSearchQuery", query_string_search_query_methods);
-    pcbc_query_string_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_query_string_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_query_string_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_query_string_search_query_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_query_string_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_query_string_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_query_string_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_query_string_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/regexp_query.c
+++ b/src/couchbase/search/regexp_query.c
@@ -26,12 +26,12 @@ PHP_METHOD(RegexpSearchQuery, __construct)
     zend_string *regexp = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &regexp);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &regexp);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_regexp_search_query_ce, getThis(), ZEND_STRL("value"), regexp TSRMLS_CC);
+    zend_update_property_str(pcbc_regexp_search_query_ce, getThis(), ZEND_STRL("value"), regexp);
 }
 
 PHP_METHOD(RegexpSearchQuery, field)
@@ -39,12 +39,12 @@ PHP_METHOD(RegexpSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_regexp_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_regexp_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -54,12 +54,12 @@ PHP_METHOD(RegexpSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_regexp_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_long(pcbc_regexp_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -124,12 +124,12 @@ PHP_MINIT_FUNCTION(RegexpSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "RegexpSearchQuery", regexp_search_query_methods);
-    pcbc_regexp_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_regexp_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_regexp_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
+    zend_class_implements(pcbc_regexp_search_query_ce, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_regexp_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_regexp_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_regexp_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_regexp_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_regexp_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_regexp_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
     return SUCCESS;
 }

--- a/src/couchbase/search/regexp_query.c
+++ b/src/couchbase/search/regexp_query.c
@@ -31,7 +31,7 @@ PHP_METHOD(RegexpSearchQuery, __construct)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_regexp_search_query_ce, getThis(), ZEND_STRL("value"), regexp);
+    pcbc_update_property_str(pcbc_regexp_search_query_ce, getThis(), ("value"), regexp);
 }
 
 PHP_METHOD(RegexpSearchQuery, field)
@@ -44,7 +44,7 @@ PHP_METHOD(RegexpSearchQuery, field)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_regexp_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_regexp_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -59,7 +59,7 @@ PHP_METHOD(RegexpSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_regexp_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_long(pcbc_regexp_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -75,19 +75,19 @@ PHP_METHOD(RegexpSearchQuery, jsonSerialize)
 
     array_init(return_value);
     zval *prop, ret;
-    prop = zend_read_property(pcbc_regexp_search_query_ce, getThis(), ZEND_STRL("value"), 0, &ret);
+    prop = pcbc_read_property(pcbc_regexp_search_query_ce, getThis(), ("value"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "regexp", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_regexp_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_regexp_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_regexp_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_regexp_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/search_query.c
+++ b/src/couchbase/search/search_query.c
@@ -24,7 +24,7 @@ PHP_MINIT_FUNCTION(SearchQuery)
 {
     zend_class_entry ce;
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchQuery", search_query_interface);
-    pcbc_search_query_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_search_query_ce = zend_register_internal_interface(&ce);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/sort.c
+++ b/src/couchbase/search/sort.c
@@ -28,7 +28,7 @@ PHP_MINIT_FUNCTION(SearchSort)
 {
     zend_class_entry ce;
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchSort", search_sort_interface);
-    pcbc_search_sort_ce = zend_register_internal_interface(&ce TSRMLS_CC);
+    pcbc_search_sort_ce = zend_register_internal_interface(&ce);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/sort_field.c
+++ b/src/couchbase/search/sort_field.c
@@ -26,12 +26,12 @@ PHP_METHOD(SearchSortField, __construct)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("field"), field);
 }
 
 PHP_METHOD(SearchSortField, descending)
@@ -39,12 +39,12 @@ PHP_METHOD(SearchSortField, descending)
     zend_bool descending = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &descending);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &descending);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("desc"), descending TSRMLS_CC);
+    zend_update_property_bool(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("desc"), descending);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -54,12 +54,12 @@ PHP_METHOD(SearchSortField, type)
     zend_string *type = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &type);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &type);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("type"), type TSRMLS_CC);
+    zend_update_property_str(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("type"), type);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -69,12 +69,12 @@ PHP_METHOD(SearchSortField, mode)
     zend_string *mode = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &mode);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &mode);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("mode"), mode TSRMLS_CC);
+    zend_update_property_str(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("mode"), mode);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -84,12 +84,12 @@ PHP_METHOD(SearchSortField, missing)
     zend_string *missing = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &missing);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &missing);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("missing"), missing TSRMLS_CC);
+    zend_update_property_str(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("missing"), missing);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -180,31 +180,31 @@ PHP_MINIT_FUNCTION(SearchSortField)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchSortField", search_sort_field_methods);
-    pcbc_search_sort_field_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_search_sort_field_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_search_sort_field_ce TSRMLS_CC, 2, pcbc_json_serializable_ce, pcbc_search_sort_ce);
-    zend_declare_property_null(pcbc_search_sort_field_ce, ZEND_STRL("desc"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_sort_field_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_sort_field_ce, ZEND_STRL("type"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_sort_field_ce, ZEND_STRL("mode"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_sort_field_ce, ZEND_STRL("missing"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_class_implements(pcbc_search_sort_field_ce, 2, pcbc_json_serializable_ce, pcbc_search_sort_ce);
+    zend_declare_property_null(pcbc_search_sort_field_ce, ZEND_STRL("desc"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_sort_field_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_sort_field_ce, ZEND_STRL("type"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_sort_field_ce, ZEND_STRL("mode"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_sort_field_ce, ZEND_STRL("missing"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchSortType", search_sort_type_interface);
-    pcbc_search_sort_type_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_search_sort_type_ce, ZEND_STRL("AUTO"), ZEND_STRL("auto") TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_search_sort_type_ce, ZEND_STRL("STRING"), ZEND_STRL("string") TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_search_sort_type_ce, ZEND_STRL("NUMBER"), ZEND_STRL("number") TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_search_sort_type_ce, ZEND_STRL("DATE"), ZEND_STRL("date") TSRMLS_CC);
+    pcbc_search_sort_type_ce = zend_register_internal_interface(&ce);
+    zend_declare_class_constant_stringl(pcbc_search_sort_type_ce, ZEND_STRL("AUTO"), ZEND_STRL("auto"));
+    zend_declare_class_constant_stringl(pcbc_search_sort_type_ce, ZEND_STRL("STRING"), ZEND_STRL("string"));
+    zend_declare_class_constant_stringl(pcbc_search_sort_type_ce, ZEND_STRL("NUMBER"), ZEND_STRL("number"));
+    zend_declare_class_constant_stringl(pcbc_search_sort_type_ce, ZEND_STRL("DATE"), ZEND_STRL("date"));
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchSortMode", search_sort_mode_interface);
-    pcbc_search_sort_mode_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_search_sort_mode_ce, ZEND_STRL("DEFAULT"), ZEND_STRL("default") TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_search_sort_mode_ce, ZEND_STRL("MIN"), ZEND_STRL("min") TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_search_sort_mode_ce, ZEND_STRL("MAX"), ZEND_STRL("max") TSRMLS_CC);
+    pcbc_search_sort_mode_ce = zend_register_internal_interface(&ce);
+    zend_declare_class_constant_stringl(pcbc_search_sort_mode_ce, ZEND_STRL("DEFAULT"), ZEND_STRL("default"));
+    zend_declare_class_constant_stringl(pcbc_search_sort_mode_ce, ZEND_STRL("MIN"), ZEND_STRL("min"));
+    zend_declare_class_constant_stringl(pcbc_search_sort_mode_ce, ZEND_STRL("MAX"), ZEND_STRL("max"));
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchSortMissing", search_sort_missing_interface);
-    pcbc_search_sort_missing_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_search_sort_missing_ce, ZEND_STRL("FIRST"), ZEND_STRL("first") TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_search_sort_missing_ce, ZEND_STRL("LAST"), ZEND_STRL("last") TSRMLS_CC);
+    pcbc_search_sort_missing_ce = zend_register_internal_interface(&ce);
+    zend_declare_class_constant_stringl(pcbc_search_sort_missing_ce, ZEND_STRL("FIRST"), ZEND_STRL("first"));
+    zend_declare_class_constant_stringl(pcbc_search_sort_missing_ce, ZEND_STRL("LAST"), ZEND_STRL("last"));
     return SUCCESS;
 }

--- a/src/couchbase/search/sort_field.c
+++ b/src/couchbase/search/sort_field.c
@@ -31,7 +31,7 @@ PHP_METHOD(SearchSortField, __construct)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_search_sort_field_ce, getThis(), ("field"), field);
 }
 
 PHP_METHOD(SearchSortField, descending)
@@ -44,7 +44,7 @@ PHP_METHOD(SearchSortField, descending)
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("desc"), descending);
+    pcbc_update_property_bool(pcbc_search_sort_field_ce, getThis(), ("desc"), descending);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -59,7 +59,7 @@ PHP_METHOD(SearchSortField, type)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("type"), type);
+    pcbc_update_property_str(pcbc_search_sort_field_ce, getThis(), ("type"), type);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -74,7 +74,7 @@ PHP_METHOD(SearchSortField, mode)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("mode"), mode);
+    pcbc_update_property_str(pcbc_search_sort_field_ce, getThis(), ("mode"), mode);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -89,7 +89,7 @@ PHP_METHOD(SearchSortField, missing)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("missing"), missing);
+    pcbc_update_property_str(pcbc_search_sort_field_ce, getThis(), ("missing"), missing);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -106,27 +106,27 @@ PHP_METHOD(SearchSortField, jsonSerialize)
     array_init(return_value);
     add_assoc_string(return_value, "by", "field");
     zval *prop, ret;
-    prop = zend_read_property(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("desc"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_sort_field_ce, getThis(), ("desc"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "desc", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_sort_field_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("type"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_sort_field_ce, getThis(), ("type"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "type", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("mode"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_sort_field_ce, getThis(), ("mode"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "mode", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_search_sort_field_ce, getThis(), ZEND_STRL("missing"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_sort_field_ce, getThis(), ("missing"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "missing", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/sort_geo.c
+++ b/src/couchbase/search/sort_geo.c
@@ -27,14 +27,14 @@ PHP_METHOD(SearchSortGeoDistance, __construct)
     double lon, lat;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sdd", &field, &lon, &lat);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sdd", &field, &lon, &lat);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
-    zend_update_property_double(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("longitude"), lon TSRMLS_CC);
-    zend_update_property_double(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("latitude"), lat TSRMLS_CC);
+    zend_update_property_str(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("field"), field);
+    zend_update_property_double(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("longitude"), lon);
+    zend_update_property_double(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("latitude"), lat);
 }
 
 PHP_METHOD(SearchSortGeoDistance, descending)
@@ -42,12 +42,12 @@ PHP_METHOD(SearchSortGeoDistance, descending)
     zend_bool descending = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &descending);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &descending);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("desc"), descending TSRMLS_CC);
+    zend_update_property_bool(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("desc"), descending);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -57,12 +57,12 @@ PHP_METHOD(SearchSortGeoDistance, unit)
     zend_string *unit = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &unit);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &unit);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("unit"), unit TSRMLS_CC);
+    zend_update_property_str(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("unit"), unit);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -137,14 +137,14 @@ PHP_MINIT_FUNCTION(SearchSortGeoDistance)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchSortGeoDistance", search_sort_geo_distance_methods);
-    pcbc_search_sort_geo_distance_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_search_sort_geo_distance_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_search_sort_geo_distance_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_search_sort_geo_distance_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_sort_ce);
-    zend_declare_property_null(pcbc_search_sort_geo_distance_ce, ZEND_STRL("desc"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_sort_geo_distance_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_sort_geo_distance_ce, ZEND_STRL("longitude"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_sort_geo_distance_ce, ZEND_STRL("latitude"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_sort_geo_distance_ce, ZEND_STRL("unit"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_search_sort_geo_distance_ce, ZEND_STRL("desc"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_sort_geo_distance_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_sort_geo_distance_ce, ZEND_STRL("longitude"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_sort_geo_distance_ce, ZEND_STRL("latitude"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_sort_geo_distance_ce, ZEND_STRL("unit"), ZEND_ACC_PRIVATE);
     return SUCCESS;
 }

--- a/src/couchbase/search/sort_geo.c
+++ b/src/couchbase/search/sort_geo.c
@@ -32,9 +32,9 @@ PHP_METHOD(SearchSortGeoDistance, __construct)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("field"), field);
-    zend_update_property_double(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("longitude"), lon);
-    zend_update_property_double(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("latitude"), lat);
+    pcbc_update_property_str(pcbc_search_sort_geo_distance_ce, getThis(), ("field"), field);
+    pcbc_update_property_double(pcbc_search_sort_geo_distance_ce, getThis(), ("longitude"), lon);
+    pcbc_update_property_double(pcbc_search_sort_geo_distance_ce, getThis(), ("latitude"), lat);
 }
 
 PHP_METHOD(SearchSortGeoDistance, descending)
@@ -47,7 +47,7 @@ PHP_METHOD(SearchSortGeoDistance, descending)
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("desc"), descending);
+    pcbc_update_property_bool(pcbc_search_sort_geo_distance_ce, getThis(), ("desc"), descending);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -62,7 +62,7 @@ PHP_METHOD(SearchSortGeoDistance, unit)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("unit"), unit);
+    pcbc_update_property_str(pcbc_search_sort_geo_distance_ce, getThis(), ("unit"), unit);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -79,12 +79,12 @@ PHP_METHOD(SearchSortGeoDistance, jsonSerialize)
     array_init(return_value);
     add_assoc_string(return_value, "by", "geo_distance");
     zval *prop, ret;
-    prop = zend_read_property(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("desc"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_sort_geo_distance_ce, getThis(), ("desc"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "desc", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_sort_geo_distance_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
@@ -92,13 +92,13 @@ PHP_METHOD(SearchSortGeoDistance, jsonSerialize)
 
     zval location;
     array_init(&location);
-    prop = zend_read_property(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("longitude"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_sort_geo_distance_ce, getThis(), ("longitude"), 0, &ret);
     add_next_index_zval(&location, prop);
-    prop = zend_read_property(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("latitude"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_sort_geo_distance_ce, getThis(), ("latitude"), 0, &ret);
     add_next_index_zval(&location, prop);
     add_assoc_zval(return_value, "location", &location);
 
-    prop = zend_read_property(pcbc_search_sort_geo_distance_ce, getThis(), ZEND_STRL("unit"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_sort_geo_distance_ce, getThis(), ("unit"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "unit", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/sort_id.c
+++ b/src/couchbase/search/sort_id.c
@@ -31,7 +31,7 @@ PHP_METHOD(SearchSortId, descending)
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_search_sort_id_ce, getThis(), ZEND_STRL("desc"), descending);
+    pcbc_update_property_bool(pcbc_search_sort_id_ce, getThis(), ("desc"), descending);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -48,7 +48,7 @@ PHP_METHOD(SearchSortId, jsonSerialize)
     array_init(return_value);
     add_assoc_string(return_value, "by", "id");
     zval *prop, ret;
-    prop = zend_read_property(pcbc_search_sort_id_ce, getThis(), ZEND_STRL("desc"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_sort_id_ce, getThis(), ("desc"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "desc", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/sort_id.c
+++ b/src/couchbase/search/sort_id.c
@@ -26,12 +26,12 @@ PHP_METHOD(SearchSortId, descending)
     zend_bool descending = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &descending);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &descending);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_search_sort_id_ce, getThis(), ZEND_STRL("desc"), descending TSRMLS_CC);
+    zend_update_property_bool(pcbc_search_sort_id_ce, getThis(), ZEND_STRL("desc"), descending);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -75,9 +75,9 @@ PHP_MINIT_FUNCTION(SearchSortId)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchSortId", search_sort_id_methods);
-    pcbc_search_sort_id_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_search_sort_id_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_search_sort_id_ce TSRMLS_CC, 2, pcbc_json_serializable_ce, pcbc_search_sort_ce);
-    zend_declare_property_null(pcbc_search_sort_id_ce, ZEND_STRL("desc"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_class_implements(pcbc_search_sort_id_ce, 2, pcbc_json_serializable_ce, pcbc_search_sort_ce);
+    zend_declare_property_null(pcbc_search_sort_id_ce, ZEND_STRL("desc"), ZEND_ACC_PRIVATE);
     return SUCCESS;
 }

--- a/src/couchbase/search/sort_score.c
+++ b/src/couchbase/search/sort_score.c
@@ -31,7 +31,7 @@ PHP_METHOD(SearchSortScore, descending)
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_search_sort_score_ce, getThis(), ZEND_STRL("desc"), descending);
+    pcbc_update_property_bool(pcbc_search_sort_score_ce, getThis(), ("desc"), descending);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -48,7 +48,7 @@ PHP_METHOD(SearchSortScore, jsonSerialize)
     array_init(return_value);
     add_assoc_string(return_value, "by", "score");
     zval *prop, ret;
-    prop = zend_read_property(pcbc_search_sort_score_ce, getThis(), ZEND_STRL("desc"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_sort_score_ce, getThis(), ("desc"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "desc", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/sort_score.c
+++ b/src/couchbase/search/sort_score.c
@@ -26,12 +26,12 @@ PHP_METHOD(SearchSortScore, descending)
     zend_bool descending = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "b", &descending);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "b", &descending);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_bool(pcbc_search_sort_score_ce, getThis(), ZEND_STRL("desc"), descending TSRMLS_CC);
+    zend_update_property_bool(pcbc_search_sort_score_ce, getThis(), ZEND_STRL("desc"), descending);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -75,9 +75,9 @@ PHP_MINIT_FUNCTION(SearchSortScore)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchSortScore", search_sort_score_methods);
-    pcbc_search_sort_score_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_search_sort_score_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_search_sort_score_ce TSRMLS_CC, 2, pcbc_json_serializable_ce, pcbc_search_sort_ce);
-    zend_declare_property_null(pcbc_search_sort_score_ce, ZEND_STRL("desc"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_class_implements(pcbc_search_sort_score_ce, 2, pcbc_json_serializable_ce, pcbc_search_sort_ce);
+    zend_declare_property_null(pcbc_search_sort_score_ce, ZEND_STRL("desc"), ZEND_ACC_PRIVATE);
     return SUCCESS;
 }

--- a/src/couchbase/search/term_facet.c
+++ b/src/couchbase/search/term_facet.c
@@ -32,8 +32,8 @@ PHP_METHOD(TermSearchFacet, __construct)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_term_search_facet_ce, getThis(), ZEND_STRL("field"), field);
-    zend_update_property_long(pcbc_term_search_facet_ce, getThis(), ZEND_STRL("limit"), limit);
+    pcbc_update_property_str(pcbc_term_search_facet_ce, getThis(), ("field"), field);
+    pcbc_update_property_long(pcbc_term_search_facet_ce, getThis(), ("limit"), limit);
 }
 
 PHP_METHOD(TermSearchFacet, jsonSerialize)
@@ -47,12 +47,12 @@ PHP_METHOD(TermSearchFacet, jsonSerialize)
 
     array_init(return_value);
     zval *prop, ret;
-    prop = zend_read_property(pcbc_term_search_facet_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_term_search_facet_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_term_search_facet_ce, getThis(), ZEND_STRL("limit"), 0, &ret);
+    prop = pcbc_read_property(pcbc_term_search_facet_ce, getThis(), ("limit"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "size", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/term_facet.c
+++ b/src/couchbase/search/term_facet.c
@@ -27,13 +27,13 @@ PHP_METHOD(TermSearchFacet, __construct)
     zend_long limit;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "Sl", &field, &limit);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "Sl", &field, &limit);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_term_search_facet_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
-    zend_update_property_long(pcbc_term_search_facet_ce, getThis(), ZEND_STRL("limit"), limit TSRMLS_CC);
+    zend_update_property_str(pcbc_term_search_facet_ce, getThis(), ZEND_STRL("field"), field);
+    zend_update_property_long(pcbc_term_search_facet_ce, getThis(), ZEND_STRL("limit"), limit);
 }
 
 PHP_METHOD(TermSearchFacet, jsonSerialize)
@@ -80,11 +80,11 @@ PHP_MINIT_FUNCTION(TermSearchFacet)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "TermSearchFacet", term_search_facet_methods);
-    pcbc_term_search_facet_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_term_search_facet_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_term_search_facet_ce TSRMLS_CC, 2, pcbc_json_serializable_ce, pcbc_search_facet_ce);
+    zend_class_implements(pcbc_term_search_facet_ce, 2, pcbc_json_serializable_ce, pcbc_search_facet_ce);
 
-    zend_declare_property_null(pcbc_term_search_facet_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_term_search_facet_ce, ZEND_STRL("limit"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_term_search_facet_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_term_search_facet_ce, ZEND_STRL("limit"), ZEND_ACC_PRIVATE);
     return SUCCESS;
 }

--- a/src/couchbase/search/term_query.c
+++ b/src/couchbase/search/term_query.c
@@ -31,7 +31,7 @@ PHP_METHOD(TermSearchQuery, __construct)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_term_search_query_ce, getThis(), ZEND_STRL("term"), value);
+    pcbc_update_property_str(pcbc_term_search_query_ce, getThis(), ("term"), value);
 }
 
 PHP_METHOD(TermSearchQuery, field)
@@ -44,7 +44,7 @@ PHP_METHOD(TermSearchQuery, field)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_term_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_term_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -59,7 +59,7 @@ PHP_METHOD(TermSearchQuery, prefixLength)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_term_search_query_ce, getThis(), ZEND_STRL("prefix_length"),
+    pcbc_update_property_long(pcbc_term_search_query_ce, getThis(), ("prefix_length"),
                               prefix_length);
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -75,7 +75,7 @@ PHP_METHOD(TermSearchQuery, fuzziness)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_term_search_query_ce, getThis(), ZEND_STRL("fuzziness"), fuzziness);
+    pcbc_update_property_long(pcbc_term_search_query_ce, getThis(), ("fuzziness"), fuzziness);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -90,7 +90,7 @@ PHP_METHOD(TermSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_term_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_long(pcbc_term_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -106,27 +106,27 @@ PHP_METHOD(TermSearchQuery, jsonSerialize)
 
     array_init(return_value);
     zval *prop, ret;
-    prop = zend_read_property(pcbc_term_search_query_ce, getThis(), ZEND_STRL("term"), 0, &ret);
+    prop = pcbc_read_property(pcbc_term_search_query_ce, getThis(), ("term"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "term", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_term_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_term_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_term_search_query_ce, getThis(), ZEND_STRL("prefix_length"), 0, &ret);
+    prop = pcbc_read_property(pcbc_term_search_query_ce, getThis(), ("prefix_length"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "prefix_length", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_term_search_query_ce, getThis(), ZEND_STRL("fuzziness"), 0, &ret);
+    prop = pcbc_read_property(pcbc_term_search_query_ce, getThis(), ("fuzziness"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "fuzziness", prop);
         Z_TRY_ADDREF_P(prop);
     }
-    prop = zend_read_property(pcbc_term_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_term_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/term_query.c
+++ b/src/couchbase/search/term_query.c
@@ -26,12 +26,12 @@ PHP_METHOD(TermSearchQuery, __construct)
     zend_string *value = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &value);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &value);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_term_search_query_ce, getThis(), ZEND_STRL("term"), value TSRMLS_CC);
+    zend_update_property_str(pcbc_term_search_query_ce, getThis(), ZEND_STRL("term"), value);
 }
 
 PHP_METHOD(TermSearchQuery, field)
@@ -39,12 +39,12 @@ PHP_METHOD(TermSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_term_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_term_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -54,13 +54,13 @@ PHP_METHOD(TermSearchQuery, prefixLength)
     zend_long prefix_length = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &prefix_length);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &prefix_length);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
     zend_update_property_long(pcbc_term_search_query_ce, getThis(), ZEND_STRL("prefix_length"),
-                              prefix_length TSRMLS_CC);
+                              prefix_length);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -70,12 +70,12 @@ PHP_METHOD(TermSearchQuery, fuzziness)
     zend_long fuzziness = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &fuzziness);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &fuzziness);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_term_search_query_ce, getThis(), ZEND_STRL("fuzziness"), fuzziness TSRMLS_CC);
+    zend_update_property_long(pcbc_term_search_query_ce, getThis(), ZEND_STRL("fuzziness"), fuzziness);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -85,12 +85,12 @@ PHP_METHOD(TermSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_term_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_long(pcbc_term_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -173,16 +173,16 @@ PHP_MINIT_FUNCTION(TermSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "TermSearchQuery", term_search_query_methods);
-    pcbc_term_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_term_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_term_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
+    zend_class_implements(pcbc_term_search_query_ce, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_term_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_term_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_term_search_query_ce, ZEND_STRL("term"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_term_search_query_ce, ZEND_STRL("analyzer"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_term_search_query_ce, ZEND_STRL("prefix_length"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_term_search_query_ce, ZEND_STRL("fuzziness"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_term_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_term_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_term_search_query_ce, ZEND_STRL("term"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_term_search_query_ce, ZEND_STRL("analyzer"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_term_search_query_ce, ZEND_STRL("prefix_length"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_term_search_query_ce, ZEND_STRL("fuzziness"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/term_range_query.c
+++ b/src/couchbase/search/term_range_query.c
@@ -31,7 +31,7 @@ PHP_METHOD(TermRangeSearchQuery, field)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_term_range_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -46,7 +46,7 @@ PHP_METHOD(TermRangeSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_double(pcbc_term_range_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -62,9 +62,9 @@ PHP_METHOD(TermRangeSearchQuery, min)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("min"), min);
+    pcbc_update_property_str(pcbc_term_range_search_query_ce, getThis(), ("min"), min);
     if (!inclusive_null) {
-        zend_update_property_bool(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("inclusive_min"),
+        pcbc_update_property_bool(pcbc_term_range_search_query_ce, getThis(), ("inclusive_min"),
                                   inclusive);
     }
 
@@ -82,9 +82,9 @@ PHP_METHOD(TermRangeSearchQuery, max)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("max"), max);
+    pcbc_update_property_str(pcbc_term_range_search_query_ce, getThis(), ("max"), max);
     if (!inclusive_null) {
-        zend_update_property_bool(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("inclusive_max"),
+        pcbc_update_property_bool(pcbc_term_range_search_query_ce, getThis(), ("inclusive_max"),
                                   inclusive);
     }
 
@@ -103,35 +103,35 @@ PHP_METHOD(TermRangeSearchQuery, jsonSerialize)
     array_init(return_value);
     zval *prop, ret;
 
-    prop = zend_read_property(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("min"), 0, &ret);
+    prop = pcbc_read_property(pcbc_term_range_search_query_ce, getThis(), ("min"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "min", prop);
         Z_TRY_ADDREF_P(prop);
-        prop = zend_read_property(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("inclusive_min"), 0, &ret);
+        prop = pcbc_read_property(pcbc_term_range_search_query_ce, getThis(), ("inclusive_min"), 0, &ret);
         if (Z_TYPE_P(prop) != IS_NULL) {
             add_assoc_zval(return_value, "inclusive_min", prop);
             Z_TRY_ADDREF_P(prop);
         }
     }
 
-    prop = zend_read_property(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("max"), 0, &ret);
+    prop = pcbc_read_property(pcbc_term_range_search_query_ce, getThis(), ("max"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "max", prop);
         Z_TRY_ADDREF_P(prop);
-        prop = zend_read_property(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("inclusive_max"), 0, &ret);
+        prop = pcbc_read_property(pcbc_term_range_search_query_ce, getThis(), ("inclusive_max"), 0, &ret);
         if (Z_TYPE_P(prop) != IS_NULL) {
             add_assoc_zval(return_value, "inclusive_max", prop);
             Z_TRY_ADDREF_P(prop);
         }
     }
 
-    prop = zend_read_property(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_term_range_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_term_range_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search/term_range_query.c
+++ b/src/couchbase/search/term_range_query.c
@@ -27,11 +27,11 @@ PHP_METHOD(TermRangeSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_str(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -41,12 +41,12 @@ PHP_METHOD(TermRangeSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_double(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_double(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -57,15 +57,15 @@ PHP_METHOD(TermRangeSearchQuery, min)
     zend_bool inclusive = 1, inclusive_null = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|b!", &min, &inclusive, &inclusive_null);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|b!", &min, &inclusive, &inclusive_null);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("min"), min TSRMLS_CC);
+    zend_update_property_str(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("min"), min);
     if (!inclusive_null) {
         zend_update_property_bool(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("inclusive_min"),
-                                  inclusive TSRMLS_CC);
+                                  inclusive);
     }
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -77,15 +77,15 @@ PHP_METHOD(TermRangeSearchQuery, max)
     zend_bool inclusive = 1, inclusive_null = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S|b!", &max, &inclusive, &inclusive_null);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|b!", &max, &inclusive, &inclusive_null);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("max"), max TSRMLS_CC);
+    zend_update_property_str(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("max"), max);
     if (!inclusive_null) {
         zend_update_property_bool(pcbc_term_range_search_query_ce, getThis(), ZEND_STRL("inclusive_max"),
-                                  inclusive TSRMLS_CC);
+                                  inclusive);
     }
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -175,16 +175,16 @@ PHP_MINIT_FUNCTION(TermRangeSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "TermRangeSearchQuery", term_range_search_query_methods);
-    pcbc_term_range_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_term_range_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_term_range_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce,
+    zend_class_implements(pcbc_term_range_search_query_ce, 2, pcbc_json_serializable_ce,
                           pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_term_range_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_term_range_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_term_range_search_query_ce, ZEND_STRL("min"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_term_range_search_query_ce, ZEND_STRL("inclusive_min"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_term_range_search_query_ce, ZEND_STRL("max"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_term_range_search_query_ce, ZEND_STRL("inclusive_max"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_term_range_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_term_range_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_term_range_search_query_ce, ZEND_STRL("min"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_term_range_search_query_ce, ZEND_STRL("inclusive_min"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_term_range_search_query_ce, ZEND_STRL("max"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_term_range_search_query_ce, ZEND_STRL("inclusive_max"), ZEND_ACC_PRIVATE);
     return SUCCESS;
 }

--- a/src/couchbase/search/wildcard_query.c
+++ b/src/couchbase/search/wildcard_query.c
@@ -26,12 +26,12 @@ PHP_METHOD(WildcardSearchQuery, __construct)
     zend_string *wildcard = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &wildcard);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &wildcard);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_wildcard_search_query_ce, getThis(), ZEND_STRL("value"), wildcard TSRMLS_CC);
+    zend_update_property_str(pcbc_wildcard_search_query_ce, getThis(), ZEND_STRL("value"), wildcard);
 }
 
 PHP_METHOD(WildcardSearchQuery, field)
@@ -39,12 +39,12 @@ PHP_METHOD(WildcardSearchQuery, field)
     zend_string *field = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "S", &field);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S", &field);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_wildcard_search_query_ce, getThis(), ZEND_STRL("field"), field TSRMLS_CC);
+    zend_update_property_str(pcbc_wildcard_search_query_ce, getThis(), ZEND_STRL("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -54,12 +54,12 @@ PHP_METHOD(WildcardSearchQuery, boost)
     double boost = 0;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "d", &boost);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "d", &boost);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_wildcard_search_query_ce, getThis(), ZEND_STRL("boost"), boost TSRMLS_CC);
+    zend_update_property_long(pcbc_wildcard_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -124,13 +124,13 @@ PHP_MINIT_FUNCTION(WildcardSearchQuery)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "WildcardSearchQuery", wildcard_search_query_methods);
-    pcbc_wildcard_search_query_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    pcbc_wildcard_search_query_ce = zend_register_internal_class(&ce);
 
-    zend_class_implements(pcbc_wildcard_search_query_ce TSRMLS_CC, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
+    zend_class_implements(pcbc_wildcard_search_query_ce, 2, pcbc_json_serializable_ce, pcbc_search_query_ce);
 
-    zend_declare_property_null(pcbc_wildcard_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_wildcard_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_wildcard_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_wildcard_search_query_ce, ZEND_STRL("boost"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_wildcard_search_query_ce, ZEND_STRL("field"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_wildcard_search_query_ce, ZEND_STRL("value"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/couchbase/search/wildcard_query.c
+++ b/src/couchbase/search/wildcard_query.c
@@ -31,7 +31,7 @@ PHP_METHOD(WildcardSearchQuery, __construct)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_wildcard_search_query_ce, getThis(), ZEND_STRL("value"), wildcard);
+    pcbc_update_property_str(pcbc_wildcard_search_query_ce, getThis(), ("value"), wildcard);
 }
 
 PHP_METHOD(WildcardSearchQuery, field)
@@ -44,7 +44,7 @@ PHP_METHOD(WildcardSearchQuery, field)
         RETURN_NULL();
     }
 
-    zend_update_property_str(pcbc_wildcard_search_query_ce, getThis(), ZEND_STRL("field"), field);
+    pcbc_update_property_str(pcbc_wildcard_search_query_ce, getThis(), ("field"), field);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -59,7 +59,7 @@ PHP_METHOD(WildcardSearchQuery, boost)
         RETURN_NULL();
     }
 
-    zend_update_property_long(pcbc_wildcard_search_query_ce, getThis(), ZEND_STRL("boost"), boost);
+    pcbc_update_property_long(pcbc_wildcard_search_query_ce, getThis(), ("boost"), boost);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -75,19 +75,19 @@ PHP_METHOD(WildcardSearchQuery, jsonSerialize)
 
     array_init(return_value);
     zval *prop, ret;
-    prop = zend_read_property(pcbc_wildcard_search_query_ce, getThis(), ZEND_STRL("value"), 0, &ret);
+    prop = pcbc_read_property(pcbc_wildcard_search_query_ce, getThis(), ("value"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "wildcard", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_wildcard_search_query_ce, getThis(), ZEND_STRL("field"), 0, &ret);
+    prop = pcbc_read_property(pcbc_wildcard_search_query_ce, getThis(), ("field"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "field", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_wildcard_search_query_ce, getThis(), ZEND_STRL("boost"), 0, &ret);
+    prop = pcbc_read_property(pcbc_wildcard_search_query_ce, getThis(), ("boost"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "boost", prop);
         Z_TRY_ADDREF_P(prop);

--- a/src/couchbase/search_options.c
+++ b/src/couchbase/search_options.c
@@ -28,7 +28,7 @@ PHP_METHOD(SearchOptions, timeout)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_search_options_ce, getThis(), ZEND_STRL("timeout"), arg);
+    pcbc_update_property_long(pcbc_search_options_ce, getThis(), ("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -39,7 +39,7 @@ PHP_METHOD(SearchOptions, limit)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_search_options_ce, getThis(), ZEND_STRL("limit"), arg);
+    pcbc_update_property_long(pcbc_search_options_ce, getThis(), ("limit"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -50,7 +50,7 @@ PHP_METHOD(SearchOptions, skip)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_search_options_ce, getThis(), ZEND_STRL("skip"), arg);
+    pcbc_update_property_long(pcbc_search_options_ce, getThis(), ("skip"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -61,7 +61,7 @@ PHP_METHOD(SearchOptions, explain)
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_search_options_ce, getThis(), ZEND_STRL("explain"), arg);
+    pcbc_update_property_bool(pcbc_search_options_ce, getThis(), ("explain"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -75,11 +75,11 @@ PHP_METHOD(SearchOptions, consistentWith)
     }
 
     zval *prop, ret;
-    prop = zend_read_property(pcbc_search_options_ce, getThis(), ZEND_STRL("consistent_with"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_options_ce, getThis(), ("consistent_with"), 0, &ret);
     if (Z_TYPE_P(prop) == IS_NULL) {
         array_init(&ret);
         prop = &ret;
-        zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("consistent_with"), &ret);
+        pcbc_update_property(pcbc_search_options_ce, getThis(), ("consistent_with"), &ret);
         Z_DELREF_P(prop);
     }
 
@@ -118,7 +118,7 @@ PHP_METHOD(SearchOptions, facets)
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("facets"), facets);
+    pcbc_update_property(pcbc_search_options_ce, getThis(), ("facets"), facets);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -142,7 +142,7 @@ PHP_METHOD(SearchOptions, fields)
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("fields"), fields);
+    pcbc_update_property(pcbc_search_options_ce, getThis(), ("fields"), fields);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -167,7 +167,7 @@ PHP_METHOD(SearchOptions, sort)
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("sort"), args);
+    pcbc_update_property(pcbc_search_options_ce, getThis(), ("sort"), args);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -186,9 +186,9 @@ PHP_METHOD(SearchOptions, highlight)
         return;
     }
 
-    zend_update_property_str(pcbc_search_options_ce, getThis(), ZEND_STRL("highlight_style"), style);
+    pcbc_update_property_str(pcbc_search_options_ce, getThis(), ("highlight_style"), style);
     if (fields) {
-        zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("highlight_fields"), fields);
+        pcbc_update_property(pcbc_search_options_ce, getThis(), ("highlight_fields"), fields);
     }
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -207,43 +207,43 @@ PHP_METHOD(SearchOptions, jsonSerialize)
 
     zval *prop, ret;
 
-    prop = zend_read_property(pcbc_search_options_ce, getThis(), ZEND_STRL("explain"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_options_ce, getThis(), ("explain"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "explain", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_search_options_ce, getThis(), ZEND_STRL("limit"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_options_ce, getThis(), ("limit"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "size", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_search_options_ce, getThis(), ZEND_STRL("skip"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_options_ce, getThis(), ("skip"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "from", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_search_options_ce, getThis(), ZEND_STRL("fields"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_options_ce, getThis(), ("fields"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "fields", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_search_options_ce, getThis(), ZEND_STRL("sort"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_options_ce, getThis(), ("sort"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "sort", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_search_options_ce, getThis(), ZEND_STRL("facets"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_options_ce, getThis(), ("facets"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(return_value, "facets", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
-    prop = zend_read_property(pcbc_search_options_ce, getThis(), ZEND_STRL("highlight_style"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_options_ce, getThis(), ("highlight_style"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         zval highlight;
         array_init(&highlight);
@@ -251,7 +251,7 @@ PHP_METHOD(SearchOptions, jsonSerialize)
         Z_TRY_ADDREF_P(prop);
 
         zval ret2;
-        zval *fields = zend_read_property(pcbc_search_options_ce, getThis(), ZEND_STRL("highlight_style"), 0, &ret2);
+        zval *fields = pcbc_read_property(pcbc_search_options_ce, getThis(), ("highlight_style"), 0, &ret2);
         if (Z_TYPE_P(fields) == IS_ARRAY) {
             add_assoc_zval(&highlight, "fields", fields);
         }
@@ -260,14 +260,14 @@ PHP_METHOD(SearchOptions, jsonSerialize)
 
     zval control;
     array_init(&control);
-    prop = zend_read_property(pcbc_search_options_ce, getThis(), ZEND_STRL("timeout"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_options_ce, getThis(), ("timeout"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         add_assoc_zval(&control, "timeout", prop);
         Z_TRY_ADDREF_P(prop);
     }
 
     zval consistency, vectors;
-    prop = zend_read_property(pcbc_search_options_ce, getThis(), ZEND_STRL("consistent_with"), 0, &ret);
+    prop = pcbc_read_property(pcbc_search_options_ce, getThis(), ("consistent_with"), 0, &ret);
     if (Z_TYPE_P(prop) != IS_NULL) {
         array_init(&consistency);
         add_assoc_string(&consistency, "level", "at_plus");

--- a/src/couchbase/search_options.c
+++ b/src/couchbase/search_options.c
@@ -24,44 +24,44 @@ zend_class_entry *pcbc_search_options_ce;
 PHP_METHOD(SearchOptions, timeout)
 {
     zend_long arg;
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_search_options_ce, getThis(), ZEND_STRL("timeout"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_search_options_ce, getThis(), ZEND_STRL("timeout"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(SearchOptions, limit)
 {
     zend_long arg;
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_search_options_ce, getThis(), ZEND_STRL("limit"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_search_options_ce, getThis(), ZEND_STRL("limit"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(SearchOptions, skip)
 {
     zend_long arg;
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "l", &arg);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "l", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_long(pcbc_search_options_ce, getThis(), ZEND_STRL("skip"), arg TSRMLS_CC);
+    zend_update_property_long(pcbc_search_options_ce, getThis(), ZEND_STRL("skip"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
 PHP_METHOD(SearchOptions, explain)
 {
     zend_bool arg;
-    int rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &arg);
+    int rv = zend_parse_parameters(ZEND_NUM_ARGS(), "b", &arg);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
-    zend_update_property_bool(pcbc_search_options_ce, getThis(), ZEND_STRL("explain"), arg TSRMLS_CC);
+    zend_update_property_bool(pcbc_search_options_ce, getThis(), ZEND_STRL("explain"), arg);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -69,7 +69,7 @@ PHP_METHOD(SearchOptions, consistentWith)
 {
     zend_string *index;
     zval *arg;
-    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "SO", &index, &arg, pcbc_mutation_state_ce);
+    int rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "SO", &index, &arg, pcbc_mutation_state_ce);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -79,13 +79,13 @@ PHP_METHOD(SearchOptions, consistentWith)
     if (Z_TYPE_P(prop) == IS_NULL) {
         array_init(&ret);
         prop = &ret;
-        zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("consistent_with"), &ret TSRMLS_CC);
+        zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("consistent_with"), &ret);
         Z_DELREF_P(prop);
     }
 
     zval scan_vectors;
     ZVAL_UNDEF(&scan_vectors);
-    pcbc_mutation_state_export_for_search(arg, &scan_vectors TSRMLS_CC);
+    pcbc_mutation_state_export_for_search(arg, &scan_vectors);
     add_assoc_zval_ex(prop, ZSTR_VAL(index), ZSTR_LEN(index), &scan_vectors);
     Z_ADDREF(scan_vectors);
 
@@ -97,7 +97,7 @@ PHP_METHOD(SearchOptions, facets)
     zval *facets;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "a", &facets);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "a", &facets);
     if (rv == FAILURE) {
         RETURN_NULL();
     }
@@ -107,7 +107,7 @@ PHP_METHOD(SearchOptions, facets)
     ZEND_HASH_FOREACH_STR_KEY_VAL(HASH_OF(facets), string_key, entry)
     {
         if (string_key) {
-            if (!instanceof_function(Z_OBJCE_P(entry), pcbc_search_facet_ce TSRMLS_CC)) {
+            if (!instanceof_function(Z_OBJCE_P(entry), pcbc_search_facet_ce)) {
                 pcbc_log(LOGARGS(WARN), "Non-facet value detected in facets array");
                 zend_type_error("Expected facet object for %s", ZSTR_VAL(string_key));
             }
@@ -118,7 +118,7 @@ PHP_METHOD(SearchOptions, facets)
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("facets"), facets TSRMLS_CC);
+    zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("facets"), facets);
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
@@ -127,7 +127,7 @@ PHP_METHOD(SearchOptions, fields)
     zval *fields = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "a", &fields);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "a", &fields);
     if (rv == FAILURE) {
         return;
     }
@@ -142,7 +142,7 @@ PHP_METHOD(SearchOptions, fields)
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("fields"), fields TSRMLS_CC);
+    zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("fields"), fields);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -152,7 +152,7 @@ PHP_METHOD(SearchOptions, sort)
     zval *args = NULL;
     int rv;
 
-    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS() TSRMLS_CC, "a", &args);
+    rv = zend_parse_parameters_throw(ZEND_NUM_ARGS(), "a", &args);
     if (rv == FAILURE) {
         return;
     }
@@ -161,13 +161,13 @@ PHP_METHOD(SearchOptions, sort)
     ZEND_HASH_FOREACH_VAL(HASH_OF(args), entry)
     {
         if (Z_TYPE_P(entry) != IS_STRING &&
-            (Z_TYPE_P(entry) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(entry), pcbc_search_sort_ce TSRMLS_CC))) {
+            (Z_TYPE_P(entry) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(entry), pcbc_search_sort_ce))) {
             pcbc_log(LOGARGS(WARN), "expected sort entry to be a string or SearchSort");
             zend_type_error("Expected string for a FTS field");
         }
     }
     ZEND_HASH_FOREACH_END();
-    zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("sort"), args TSRMLS_CC);
+    zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("sort"), args);
 
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -181,14 +181,14 @@ PHP_METHOD(SearchOptions, highlight)
     zval *fields = NULL;
     int rv;
 
-    rv = zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S|a", &style, &fields);
+    rv = zend_parse_parameters(ZEND_NUM_ARGS(), "S|a", &style, &fields);
     if (rv == FAILURE) {
         return;
     }
 
-    zend_update_property_str(pcbc_search_options_ce, getThis(), ZEND_STRL("highlight_style"), style TSRMLS_CC);
+    zend_update_property_str(pcbc_search_options_ce, getThis(), ZEND_STRL("highlight_style"), style);
     if (fields) {
-        zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("highlight_fields"), fields TSRMLS_CC);
+        zend_update_property(pcbc_search_options_ce, getThis(), ZEND_STRL("highlight_fields"), fields);
     }
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -358,26 +358,26 @@ PHP_MINIT_FUNCTION(SearchOptions)
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchOptions", search_options_methods);
-    pcbc_search_options_ce = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(pcbc_search_options_ce TSRMLS_CC, 1, pcbc_json_serializable_ce);
+    pcbc_search_options_ce = zend_register_internal_class(&ce);
+    zend_class_implements(pcbc_search_options_ce, 1, pcbc_json_serializable_ce);
 
-    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("limit"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("skip"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("explain"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("consistent_with"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("fields"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("sort"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("facets"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("highlight_style"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("highlight_fields"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("timeout"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("limit"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("skip"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("explain"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("consistent_with"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("fields"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("sort"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("facets"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("highlight_style"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(pcbc_search_options_ce, ZEND_STRL("highlight_fields"), ZEND_ACC_PRIVATE);
 
     INIT_NS_CLASS_ENTRY(ce, "Couchbase", "SearchHighlightMode", pcbc_search_highlight_mode_methods);
-    pcbc_search_highlight_mode_ce = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_search_highlight_mode_ce, ZEND_STRL("HTML"), ZEND_STRL("html") TSRMLS_CC);
-    zend_declare_class_constant_stringl(pcbc_search_highlight_mode_ce, ZEND_STRL("ANSI"), ZEND_STRL("ansi") TSRMLS_CC);
+    pcbc_search_highlight_mode_ce = zend_register_internal_interface(&ce);
+    zend_declare_class_constant_stringl(pcbc_search_highlight_mode_ce, ZEND_STRL("HTML"), ZEND_STRL("html"));
+    zend_declare_class_constant_stringl(pcbc_search_highlight_mode_ce, ZEND_STRL("ANSI"), ZEND_STRL("ansi"));
     zend_declare_class_constant_stringl(pcbc_search_highlight_mode_ce, ZEND_STRL("SIMPLE"),
-                                        ZEND_STRL("simple") TSRMLS_CC);
+                                        ZEND_STRL("simple"));
 
     return SUCCESS;
 }

--- a/transcoding.c
+++ b/transcoding.c
@@ -19,7 +19,7 @@
 #define LOGARGS(lvl) LCB_LOG_##lvl, NULL, "pcbc/transcoding", __FILE__, __LINE__
 
 int pcbc_decode_value(zval *return_value, pcbc_bucket_t *bucket, const char *bytes, int bytes_len, uint32_t flags,
-                      uint8_t datatype TSRMLS_DC)
+                      uint8_t datatype)
 {
     int rv;
     zval params[3];
@@ -32,7 +32,7 @@ int pcbc_decode_value(zval *return_value, pcbc_bucket_t *bucket, const char *byt
     ZVAL_LONG(&params[1], flags);
     ZVAL_LONG(&params[2], datatype);
 
-    rv = call_user_function(CG(function_table), NULL, &bucket->decoder, return_value, 3, params TSRMLS_CC);
+    rv = call_user_function(CG(function_table), NULL, &bucket->decoder, return_value, 3, params);
 
     zval_ptr_dtor(&params[0]);
     zval_ptr_dtor(&params[1]);
@@ -41,7 +41,7 @@ int pcbc_decode_value(zval *return_value, pcbc_bucket_t *bucket, const char *byt
 }
 
 int pcbc_encode_value(pcbc_bucket_t *bucket, zval *value, void **bytes, lcb_size_t *nbytes, lcb_uint32_t *flags,
-                      uint8_t *datatype TSRMLS_DC)
+                      uint8_t *datatype)
 {
     zval retval;
     int rv;
@@ -49,7 +49,7 @@ int pcbc_encode_value(pcbc_bucket_t *bucket, zval *value, void **bytes, lcb_size
     ZVAL_UNDEF(&retval);
     ZVAL_NULL(&retval);
 
-    rv = call_user_function(CG(function_table), NULL, &bucket->encoder, &retval, 1, value TSRMLS_CC);
+    rv = call_user_function(CG(function_table), NULL, &bucket->encoder, &retval, 1, value);
     if (rv != SUCCESS || Z_TYPE_P(&retval) != IS_ARRAY || zend_hash_num_elements(Z_ARRVAL(retval)) != 3) {
         zval_ptr_dtor(&retval);
         return FAILURE;


### PR DESCRIPTION
**First** commit drop TSRMLS macro usage
* These macros are only needed in PHP 5 and have been dropped from PHP 8

**Second** commit drop call_user_function_ex usage, 
* dropped in PHP 8, as no_separation is always 1

**Third** commit drop check for php_url_encode_hash_ex result
* always succeeds and define as void in PHP 8

**Fourth** commit fix read/update property call
* as PHP 8 expect a zend_object instead of a zval
* introduce some pcbc_*_property_* macros

**Fifth** commit fix warnings raise by PHP 8
```
Warning: The magic method Couchbase\Bucket::__get() must have public visibility in Unknown on line 0
Warning: The magic method Couchbase\Bucket::__set() must have public visibility in Unknown on line 0

```
