### PR TITLE
Update jsonSerialize methods to stop deprecations errors in php 8.1

### DIFF
--- a/src/couchbase/managers/search_index_manager.c
+++ b/src/couchbase/managers/search_index_manager.c
@@ -783,7 +783,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_SearchIndex_setSourceParams, 0, 1, Cou
 ZEND_ARG_TYPE_INFO(0, params, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_SearchIndex_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_SearchIndex_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 // clang-format off

--- a/src/couchbase/managers/search_index_manager.c
+++ b/src/couchbase/managers/search_index_manager.c
@@ -783,7 +783,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_SearchIndex_setSourceParams, 0, 1, Cou
 ZEND_ARG_TYPE_INFO(0, params, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(ai_SearchIndex_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_SearchIndex_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 // clang-format off

--- a/src/couchbase/managers/view_index_manager.c
+++ b/src/couchbase/managers/view_index_manager.c
@@ -298,7 +298,11 @@ PHP_METHOD(DesignDocument, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_DesignDocument_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_DesignDocument_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(ai_DesignDocument_name, IS_STRING, 0)

--- a/src/couchbase/managers/view_index_manager.c
+++ b/src/couchbase/managers/view_index_manager.c
@@ -298,7 +298,7 @@ PHP_METHOD(DesignDocument, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_DesignDocument_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_DesignDocument_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(ai_DesignDocument_name, IS_STRING, 0)

--- a/src/couchbase/search/boolean_field_query.c
+++ b/src/couchbase/search/boolean_field_query.c
@@ -93,7 +93,7 @@ PHP_METHOD(BooleanFieldSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_BooleanFieldSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_BooleanFieldSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_BooleanFieldSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/boolean_field_query.c
+++ b/src/couchbase/search/boolean_field_query.c
@@ -93,7 +93,11 @@ PHP_METHOD(BooleanFieldSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_BooleanFieldSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_BooleanFieldSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_BooleanFieldSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/boolean_query.c
+++ b/src/couchbase/search/boolean_query.c
@@ -116,7 +116,11 @@ PHP_METHOD(BooleanSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_BooleanSearchQuery_none, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_BooleanSearchQuery_none, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_BooleanSearchQuery_boost, 0, 1, Couchbase\\BooleanSearchQuery, 0)

--- a/src/couchbase/search/boolean_query.c
+++ b/src/couchbase/search/boolean_query.c
@@ -116,7 +116,7 @@ PHP_METHOD(BooleanSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_BooleanSearchQuery_none, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_BooleanSearchQuery_none, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_BooleanSearchQuery_boost, 0, 1, Couchbase\\BooleanSearchQuery, 0)

--- a/src/couchbase/search/conjunction_query.c
+++ b/src/couchbase/search/conjunction_query.c
@@ -122,7 +122,7 @@ PHP_METHOD(ConjunctionSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_ConjunctionSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_ConjunctionSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_ConjunctionSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/conjunction_query.c
+++ b/src/couchbase/search/conjunction_query.c
@@ -122,7 +122,11 @@ PHP_METHOD(ConjunctionSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_ConjunctionSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_ConjunctionSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_ConjunctionSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/date_range_facet.c
+++ b/src/couchbase/search/date_range_facet.c
@@ -130,7 +130,7 @@ PHP_METHOD(DateRangeSearchFacet, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_DateRangeSearchFacet_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_DateRangeSearchFacet_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_DateRangeSearchFacet_construct, 0, 0, 2)

--- a/src/couchbase/search/date_range_facet.c
+++ b/src/couchbase/search/date_range_facet.c
@@ -130,7 +130,11 @@ PHP_METHOD(DateRangeSearchFacet, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_DateRangeSearchFacet_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_DateRangeSearchFacet_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_DateRangeSearchFacet_construct, 0, 0, 2)

--- a/src/couchbase/search/date_range_query.c
+++ b/src/couchbase/search/date_range_query.c
@@ -192,7 +192,11 @@ PHP_METHOD(DateRangeSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_DateRangeSearchQuery_none, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_DateRangeSearchQuery_none, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_DateRangeSearchQuery_field, 0, 1, Couchbase\\DateRangeSearchQuery, 0)

--- a/src/couchbase/search/date_range_query.c
+++ b/src/couchbase/search/date_range_query.c
@@ -192,7 +192,7 @@ PHP_METHOD(DateRangeSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_DateRangeSearchQuery_none, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_DateRangeSearchQuery_none, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_DateRangeSearchQuery_field, 0, 1, Couchbase\\DateRangeSearchQuery, 0)

--- a/src/couchbase/search/disjunction_query.c
+++ b/src/couchbase/search/disjunction_query.c
@@ -144,7 +144,11 @@ PHP_METHOD(DisjunctionSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_DisjunctionSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_DisjunctionSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_DisjunctionSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/disjunction_query.c
+++ b/src/couchbase/search/disjunction_query.c
@@ -144,7 +144,7 @@ PHP_METHOD(DisjunctionSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_DisjunctionSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_DisjunctionSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_DisjunctionSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/doc_id_query.c
+++ b/src/couchbase/search/doc_id_query.c
@@ -119,7 +119,11 @@ PHP_METHOD(DocIdSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_DocIdSearchQuery_none, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_DocIdSearchQuery_none, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_DocIdSearchQuery_field, 0, 1, Couchbase\\DocIdSearchQuery, 0)

--- a/src/couchbase/search/doc_id_query.c
+++ b/src/couchbase/search/doc_id_query.c
@@ -119,7 +119,7 @@ PHP_METHOD(DocIdSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_DocIdSearchQuery_none, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_DocIdSearchQuery_none, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_DocIdSearchQuery_field, 0, 1, Couchbase\\DocIdSearchQuery, 0)

--- a/src/couchbase/search/geo_bounding_box_query.c
+++ b/src/couchbase/search/geo_bounding_box_query.c
@@ -111,7 +111,7 @@ PHP_METHOD(GeoBoundingBoxSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_GeoBoundingBoxSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_GeoBoundingBoxSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_GeoBoundingBoxSearchQuery_construct, 0, 0, 4)

--- a/src/couchbase/search/geo_bounding_box_query.c
+++ b/src/couchbase/search/geo_bounding_box_query.c
@@ -111,7 +111,11 @@ PHP_METHOD(GeoBoundingBoxSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_GeoBoundingBoxSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_GeoBoundingBoxSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_GeoBoundingBoxSearchQuery_construct, 0, 0, 4)

--- a/src/couchbase/search/geo_distance_query.c
+++ b/src/couchbase/search/geo_distance_query.c
@@ -109,7 +109,7 @@ PHP_METHOD(GeoDistanceSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_GeoDistanceSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_GeoDistanceSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_GeoDistanceSearchQuery_construct, 0, 0, 2)

--- a/src/couchbase/search/geo_distance_query.c
+++ b/src/couchbase/search/geo_distance_query.c
@@ -109,7 +109,11 @@ PHP_METHOD(GeoDistanceSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_GeoDistanceSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_GeoDistanceSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_GeoDistanceSearchQuery_construct, 0, 0, 2)

--- a/src/couchbase/search/geo_polygon_query.c
+++ b/src/couchbase/search/geo_polygon_query.c
@@ -93,7 +93,7 @@ PHP_METHOD(GeoPolygonSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_GeoPolygonSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_GeoPolygonSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_GeoPolygonSearchQuery_construct, 0, 0, 1)
@@ -159,7 +159,7 @@ ZEND_ARG_TYPE_INFO(0, longitude, IS_DOUBLE, 0)
 ZEND_ARG_TYPE_INFO(0, latitude, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(ai_Coordinate_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_Coordinate_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 // clang-format off

--- a/src/couchbase/search/geo_polygon_query.c
+++ b/src/couchbase/search/geo_polygon_query.c
@@ -93,7 +93,11 @@ PHP_METHOD(GeoPolygonSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_GeoPolygonSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_GeoPolygonSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_GeoPolygonSearchQuery_construct, 0, 0, 1)
@@ -159,7 +163,11 @@ ZEND_ARG_TYPE_INFO(0, longitude, IS_DOUBLE, 0)
 ZEND_ARG_TYPE_INFO(0, latitude, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_Coordinate_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_Coordinate_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 // clang-format off

--- a/src/couchbase/search/match_all_query.c
+++ b/src/couchbase/search/match_all_query.c
@@ -48,7 +48,7 @@ PHP_METHOD(MatchAllSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_MatchAllSearchQuery_none, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_MatchAllSearchQuery_none, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_MatchAllSearchQuery_boost, 0, 1, Couchbase\\MatchAllSearchQuery, 0)

--- a/src/couchbase/search/match_all_query.c
+++ b/src/couchbase/search/match_all_query.c
@@ -48,7 +48,11 @@ PHP_METHOD(MatchAllSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_MatchAllSearchQuery_none, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_MatchAllSearchQuery_none, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_MatchAllSearchQuery_boost, 0, 1, Couchbase\\MatchAllSearchQuery, 0)

--- a/src/couchbase/search/match_none_query.c
+++ b/src/couchbase/search/match_none_query.c
@@ -48,7 +48,11 @@ PHP_METHOD(MatchNoneSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_MatchNoneSearchQuery_none, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_MatchNoneSearchQuery_none, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_MatchNoneSearchQuery_boost, 0, 1, Couchbase\\MatchNoneSearchQuery, 0)

--- a/src/couchbase/search/match_none_query.c
+++ b/src/couchbase/search/match_none_query.c
@@ -48,7 +48,7 @@ PHP_METHOD(MatchNoneSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_MatchNoneSearchQuery_none, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_MatchNoneSearchQuery_none, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_MatchNoneSearchQuery_boost, 0, 1, Couchbase\\MatchNoneSearchQuery, 0)

--- a/src/couchbase/search/match_phrase_query.c
+++ b/src/couchbase/search/match_phrase_query.c
@@ -113,7 +113,7 @@ PHP_METHOD(MatchPhraseSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_MatchPhraseSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_MatchPhraseSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_MatchPhraseSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/match_phrase_query.c
+++ b/src/couchbase/search/match_phrase_query.c
@@ -113,7 +113,11 @@ PHP_METHOD(MatchPhraseSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_MatchPhraseSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_MatchPhraseSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_MatchPhraseSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/match_query.c
+++ b/src/couchbase/search/match_query.c
@@ -153,7 +153,11 @@ PHP_METHOD(MatchSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_MatchSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_MatchSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_MatchSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/match_query.c
+++ b/src/couchbase/search/match_query.c
@@ -153,7 +153,7 @@ PHP_METHOD(MatchSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_MatchSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_MatchSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_MatchSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/numeric_range_facet.c
+++ b/src/couchbase/search/numeric_range_facet.c
@@ -100,7 +100,11 @@ PHP_METHOD(NumericRangeSearchFacet, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_NumericRangeSearchFacet_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_NumericRangeSearchFacet_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_NumericRangeSearchFacet_construct, 0, 0, 2)

--- a/src/couchbase/search/numeric_range_facet.c
+++ b/src/couchbase/search/numeric_range_facet.c
@@ -100,7 +100,7 @@ PHP_METHOD(NumericRangeSearchFacet, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_NumericRangeSearchFacet_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_NumericRangeSearchFacet_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_NumericRangeSearchFacet_construct, 0, 0, 2)

--- a/src/couchbase/search/numeric_range_query.c
+++ b/src/couchbase/search/numeric_range_query.c
@@ -136,7 +136,11 @@ PHP_METHOD(NumericRangeSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_NumericRangeSearchQuery_none, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_NumericRangeSearchQuery_none, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_NumericRangeSearchQuery_field, 0, 1, Couchbase\\NumericRangeSearchQuery, 0)

--- a/src/couchbase/search/numeric_range_query.c
+++ b/src/couchbase/search/numeric_range_query.c
@@ -136,7 +136,7 @@ PHP_METHOD(NumericRangeSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_NumericRangeSearchQuery_none, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_NumericRangeSearchQuery_none, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_NumericRangeSearchQuery_field, 0, 1, Couchbase\\NumericRangeSearchQuery, 0)

--- a/src/couchbase/search/phrase_query.c
+++ b/src/couchbase/search/phrase_query.c
@@ -116,7 +116,11 @@ PHP_METHOD(PhraseSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_PhraseSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_PhraseSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_PhraseSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/phrase_query.c
+++ b/src/couchbase/search/phrase_query.c
@@ -116,7 +116,7 @@ PHP_METHOD(PhraseSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_PhraseSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_PhraseSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_PhraseSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/prefix_query.c
+++ b/src/couchbase/search/prefix_query.c
@@ -94,7 +94,7 @@ PHP_METHOD(PrefixSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_PrefixSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_PrefixSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_PrefixSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/prefix_query.c
+++ b/src/couchbase/search/prefix_query.c
@@ -94,7 +94,11 @@ PHP_METHOD(PrefixSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_PrefixSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_PrefixSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_PrefixSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/query_string_query.c
+++ b/src/couchbase/search/query_string_query.c
@@ -73,7 +73,7 @@ PHP_METHOD(QueryStringSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_QueryStringSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_QueryStringSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_QueryStringSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/query_string_query.c
+++ b/src/couchbase/search/query_string_query.c
@@ -73,7 +73,11 @@ PHP_METHOD(QueryStringSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_QueryStringSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_QueryStringSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_QueryStringSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/regexp_query.c
+++ b/src/couchbase/search/regexp_query.c
@@ -94,7 +94,7 @@ PHP_METHOD(RegexpSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_RegexpSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_RegexpSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_RegexpSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/regexp_query.c
+++ b/src/couchbase/search/regexp_query.c
@@ -94,7 +94,11 @@ PHP_METHOD(RegexpSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_RegexpSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_RegexpSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_RegexpSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/sort_field.c
+++ b/src/couchbase/search/sort_field.c
@@ -133,7 +133,11 @@ PHP_METHOD(SearchSortField, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_SearchSortField_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_SearchSortField_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_SearchSortField_construct, 0, 0, 0)

--- a/src/couchbase/search/sort_field.c
+++ b/src/couchbase/search/sort_field.c
@@ -133,7 +133,7 @@ PHP_METHOD(SearchSortField, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_SearchSortField_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_SearchSortField_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_SearchSortField_construct, 0, 0, 0)

--- a/src/couchbase/search/sort_geo.c
+++ b/src/couchbase/search/sort_geo.c
@@ -105,7 +105,11 @@ PHP_METHOD(SearchSortGeoDistance, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_SearchSortGeoDistance_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_SearchSortGeoDistance_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_SearchSortGeoDistance_construct, 0, 0, 3)

--- a/src/couchbase/search/sort_geo.c
+++ b/src/couchbase/search/sort_geo.c
@@ -105,7 +105,7 @@ PHP_METHOD(SearchSortGeoDistance, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_SearchSortGeoDistance_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_SearchSortGeoDistance_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_SearchSortGeoDistance_construct, 0, 0, 3)

--- a/src/couchbase/search/sort_id.c
+++ b/src/couchbase/search/sort_id.c
@@ -55,7 +55,11 @@ PHP_METHOD(SearchSortId, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_SearchSortId_none, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_SearchSortId_none, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_SearchSortId_descending, 0, 1, Couchbase\\SearchSortId, 0)

--- a/src/couchbase/search/sort_id.c
+++ b/src/couchbase/search/sort_id.c
@@ -55,7 +55,7 @@ PHP_METHOD(SearchSortId, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_SearchSortId_none, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_SearchSortId_none, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_SearchSortId_descending, 0, 1, Couchbase\\SearchSortId, 0)

--- a/src/couchbase/search/sort_score.c
+++ b/src/couchbase/search/sort_score.c
@@ -55,7 +55,11 @@ PHP_METHOD(SearchSortScore, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_SearchSortScore_none, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_SearchSortScore_none, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_SearchSortScore_descending, 0, 1, Couchbase\\SearchSortScore, 0)

--- a/src/couchbase/search/sort_score.c
+++ b/src/couchbase/search/sort_score.c
@@ -55,7 +55,7 @@ PHP_METHOD(SearchSortScore, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_SearchSortScore_none, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_SearchSortScore_none, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_SearchSortScore_descending, 0, 1, Couchbase\\SearchSortScore, 0)

--- a/src/couchbase/search/term_facet.c
+++ b/src/couchbase/search/term_facet.c
@@ -59,7 +59,11 @@ PHP_METHOD(TermSearchFacet, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_TermSearchFacet_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_TermSearchFacet_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_TermSearchFacet_construct, 0, 0, 2)

--- a/src/couchbase/search/term_facet.c
+++ b/src/couchbase/search/term_facet.c
@@ -59,7 +59,7 @@ PHP_METHOD(TermSearchFacet, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_TermSearchFacet_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_TermSearchFacet_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_TermSearchFacet_construct, 0, 0, 2)

--- a/src/couchbase/search/term_query.c
+++ b/src/couchbase/search/term_query.c
@@ -132,7 +132,11 @@ PHP_METHOD(TermSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_TermSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_TermSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_TermSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/term_query.c
+++ b/src/couchbase/search/term_query.c
@@ -132,7 +132,7 @@ PHP_METHOD(TermSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_TermSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_TermSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_TermSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/term_range_query.c
+++ b/src/couchbase/search/term_range_query.c
@@ -136,7 +136,11 @@ PHP_METHOD(TermRangeSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_TermRangeSearchQuery_none, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_TermRangeSearchQuery_none, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_TermRangeSearchQuery_field, 0, 1, Couchbase\\TermRangeSearchQuery, 0)

--- a/src/couchbase/search/term_range_query.c
+++ b/src/couchbase/search/term_range_query.c
@@ -136,7 +136,7 @@ PHP_METHOD(TermRangeSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_TermRangeSearchQuery_none, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_TermRangeSearchQuery_none, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_TermRangeSearchQuery_field, 0, 1, Couchbase\\TermRangeSearchQuery, 0)

--- a/src/couchbase/search/wildcard_query.c
+++ b/src/couchbase/search/wildcard_query.c
@@ -94,7 +94,7 @@ PHP_METHOD(WildcardSearchQuery, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_WildcardSearchQuery_jsonSerialize, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_WildcardSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_WildcardSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search/wildcard_query.c
+++ b/src/couchbase/search/wildcard_query.c
@@ -94,7 +94,11 @@ PHP_METHOD(WildcardSearchQuery, jsonSerialize)
     }
 }
 
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_WildcardSearchQuery_jsonSerialize, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_WildcardSearchQuery_jsonSerialize, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_WildcardSearchQuery_construct, 0, 0, 1)

--- a/src/couchbase/search_options.c
+++ b/src/couchbase/search_options.c
@@ -341,6 +341,7 @@ PHP_METHOD(SearchOptions, jsonSerialize)
         Z_TRY_ADDREF_P(prop);
     }
 }
+
 #if PHP_VERSION_ID < 80100
 ZEND_BEGIN_ARG_INFO_EX(ai_SearchOptions_none, 0, 0, 0)
 #else

--- a/src/couchbase/search_options.c
+++ b/src/couchbase/search_options.c
@@ -342,7 +342,7 @@ PHP_METHOD(SearchOptions, jsonSerialize)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(ai_SearchOptions_none, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_SearchOptions_none, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_SearchOptions_timeout, 0, 1, Couchbase\\SearchOptions, 0)

--- a/src/couchbase/search_options.c
+++ b/src/couchbase/search_options.c
@@ -341,8 +341,11 @@ PHP_METHOD(SearchOptions, jsonSerialize)
         Z_TRY_ADDREF_P(prop);
     }
 }
-
+#if PHP_VERSION_ID < 80100
+ZEND_BEGIN_ARG_INFO_EX(ai_SearchOptions_none, 0, 0, 0)
+#else
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_SearchOptions_none, 0, 0, IS_MIXED, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_SearchOptions_timeout, 0, 1, Couchbase\\SearchOptions, 0)


### PR DESCRIPTION
I have changed the ZEND_BEGIN_ARG_INFO_EX call to ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX on any methods that are used by the PHP JsonSerializable interface, to stop deprecation notices in PHP 8.1

Hope this helps.